### PR TITLE
Add PC loan request Workflow App (approval → Jira)

### DIFF
--- a/projects/[App] PC Loan Request/pc_loan_jira.connection.json
+++ b/projects/[App] PC Loan Request/pc_loan_jira.connection.json
@@ -1,0 +1,5 @@
+{
+  "name": "PC Loan | Jira",
+  "provider": "jira",
+  "root_folder": false
+}

--- a/projects/[App] PC Loan Request/pc_loan_request.lcap_app.json
+++ b/projects/[App] PC Loan Request/pc_loan_request.lcap_app.json
@@ -1,0 +1,66 @@
+{
+  "name": "PC Loan Request",
+  "creation_page": {
+    "zip_name": "submit_pc_loan_request.lcap_page.json",
+    "name": "Submit PC loan request",
+    "folder": ""
+  },
+  "workato_db_table": {
+    "zip_name": "pc_loan_requests.workato_db_table.json",
+    "name": "PC Loan Requests",
+    "folder": ""
+  },
+  "workflow_stages": [
+    {
+      "name": "New",
+      "color": 0
+    },
+    {
+      "name": "Manager review",
+      "color": 1,
+      "task_page": {
+        "zip_name": "review_pc_loan_request.lcap_page.json",
+        "name": "Review PC loan request",
+        "folder": ""
+      },
+      "details_page": {
+        "zip_name": "request_details.lcap_page.json",
+        "name": "Request details",
+        "folder": ""
+      }
+    },
+    {
+      "name": "Done",
+      "color": 2,
+      "details_page": {
+        "zip_name": "approved_page.lcap_page.json",
+        "name": "Approved page",
+        "folder": ""
+      }
+    },
+    {
+      "name": "Canceled",
+      "color": 3,
+      "details_page": {
+        "zip_name": "rejected_page.lcap_page.json",
+        "name": "Rejected page",
+        "folder": ""
+      }
+    }
+  ],
+  "tabs": [
+    {
+      "name": "New request",
+      "kind": "new_request",
+      "visibility": "all"
+    }
+  ],
+  "displayed_columns": [
+    { "id": "CURRENT_STAGE", "visibility": "all" },
+    { "id": "ASSIGNED_TO", "visibility": "all" },
+    { "id": "CREATED_BY", "visibility": "all" },
+    { "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000001", "visibility": "all" },
+    { "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000002", "visibility": "all" },
+    { "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000003", "visibility": "all" }
+  ]
+}

--- a/projects/[App] PC Loan Request/pc_loan_request_approval_and_jira_ticket.recipe.json
+++ b/projects/[App] PC Loan Request/pc_loan_request_approval_and_jira_ticket.recipe.json
@@ -1,0 +1,258 @@
+{
+  "name": "PC loan request: manager approval and Jira ticket creation",
+  "description": "PC 貸与リクエストが送信されたら、マネージャーに承認タスクをアサインする。\n承認された場合は Jira にチケットを起票し、ワークフローを Done に変更する。\n却下された場合は Canceled に変更する。\n\n**Trigger**: Workflow App で PC 貸与リクエスト送信\n**Actions**:\n1. マネージャーに承認タスクをアサイン\n2. 承認: Jira にチケット起票 → Done\n3. 却下: Canceled",
+  "version": 1,
+  "private": true,
+  "concurrency": 1,
+  "code": {
+    "number": 0,
+    "provider": "workato_workflow_task",
+    "name": "new_requests_realtime",
+    "as": "new_requests_realtime",
+    "keyword": "trigger",
+    "input": {
+      "app_id": {
+        "zip_name": "pc_loan_request.lcap_app.json",
+        "name": "PC Loan Request",
+        "folder": ""
+      }
+    },
+    "extended_output_schema": [
+      {
+        "label": "Request",
+        "name": "request",
+        "properties": [
+          {
+            "control_type": "text",
+            "label": "Record ID",
+            "type": "string",
+            "name": "11fbe9a6_a16d_4d7e_86ea_afe42ec03005"
+          },
+          {
+            "control_type": "text",
+            "label": "PC type",
+            "type": "string",
+            "name": "b1a2c3d4_e5f6_4a7b_8c9d_100000000001"
+          },
+          {
+            "control_type": "text",
+            "label": "Reason",
+            "type": "string",
+            "name": "b1a2c3d4_e5f6_4a7b_8c9d_100000000002"
+          },
+          {
+            "control_type": "text",
+            "label": "Preferred delivery date",
+            "type": "string",
+            "name": "b1a2c3d4_e5f6_4a7b_8c9d_100000000003"
+          },
+          {
+            "properties": [
+              {
+                "control_type": "text",
+                "label": "User ID",
+                "type": "string",
+                "name": "id"
+              },
+              {
+                "control_type": "text",
+                "label": "User name",
+                "type": "string",
+                "name": "name"
+              },
+              {
+                "control_type": "email",
+                "label": "Email",
+                "type": "string",
+                "name": "email"
+              }
+            ],
+            "label": "Creator",
+            "type": "object",
+            "name": "creator"
+          }
+        ],
+        "type": "object"
+      }
+    ],
+    "block": [
+      {
+        "number": 1,
+        "provider": "workato_workflow_task",
+        "name": "human_review_on_existing_record",
+        "as": "human_review_on_existing_record",
+        "keyword": "action",
+        "toggleCfg": {
+          "send_email_notification": true,
+          "reassignable": true,
+          "workflow_stage_id": true,
+          "due_in_days": true
+        },
+        "input": {
+          "app_id": {
+            "zip_name": "pc_loan_request.lcap_app.json",
+            "name": "PC Loan Request",
+            "folder": ""
+          },
+          "record_id": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"11fbe9a6_a16d_4d7e_86ea_afe42ec03005\"]}')}",
+          "workflow_stage_id": {
+            "name": "Manager review"
+          },
+          "due_in_days": "7",
+          "send_email_notification": "true",
+          "reassignable": "true"
+        },
+        "extended_output_schema": [
+          {
+            "label": "Task",
+            "name": "task",
+            "properties": [
+              {
+                "control_type": "text",
+                "label": "Is approved",
+                "type": "boolean",
+                "name": "is_approved"
+              }
+            ],
+            "type": "object"
+          },
+          {
+            "label": "Record",
+            "name": "record",
+            "properties": [
+              {
+                "control_type": "text",
+                "label": "Record ID",
+                "type": "string",
+                "name": "11fbe9a6_a16d_4d7e_86ea_afe42ec03005"
+              }
+            ],
+            "type": "object"
+          }
+        ],
+        "comment": "マネージャーに承認タスクをアサイン。7日以内に承認/却下を待つ。",
+        "uuid": "a1b2c3d4-0001-4a7b-8c9d-000000000001"
+      },
+      {
+        "number": 2,
+        "as": "if_approved",
+        "keyword": "if",
+        "input": {
+          "type": "compound",
+          "operand": "and",
+          "conditions": [
+            {
+              "operand": "is_true",
+              "lhs": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"human_review_on_existing_record\",\"path\":[\"task\",\"is_approved\"]}')}",
+              "rhs": "",
+              "uuid": "condition-a1b2c3d4-0002-4a7b-8c9d-000000000001"
+            }
+          ]
+        },
+        "block": [
+          {
+            "number": 3,
+            "provider": "jira",
+            "name": "create_issue",
+            "as": "create_issue",
+            "keyword": "action",
+            "input": {
+              "summary": "PC 貸与依頼: #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"b1a2c3d4_e5f6_4a7b_8c9d_100000000001\"]}')} - #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"creator\",\"name\"]}')}",
+              "description": "## PC 貸与依頼\n\n**申請者**: #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"creator\",\"name\"]}')} (#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"creator\",\"email\"]}')})\n**PC タイプ**: #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"b1a2c3d4_e5f6_4a7b_8c9d_100000000001\"]}')} \n**理由**: #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"b1a2c3d4_e5f6_4a7b_8c9d_100000000002\"]}')} \n**希望納期**: #{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"new_requests_realtime\",\"path\":[\"request\",\"b1a2c3d4_e5f6_4a7b_8c9d_100000000003\"]}')}"
+            },
+            "comment": "承認済み: Jira に PC 貸与チケットを起票。プロジェクトやイシュータイプは Workato UI で設定する。",
+            "uuid": "a1b2c3d4-0003-4a7b-8c9d-000000000001"
+          },
+          {
+            "number": 4,
+            "provider": "workato_workflow_task",
+            "name": "update_request",
+            "as": "update_request",
+            "keyword": "action",
+            "input": {
+              "app_id": {
+                "zip_name": "pc_loan_request.lcap_app.json",
+                "name": "PC Loan Request",
+                "folder": ""
+              },
+              "record_id": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"human_review_on_existing_record\",\"path\":[\"record\",\"11fbe9a6_a16d_4d7e_86ea_afe42ec03005\"]}')}",
+              "parameters": {
+                "b1a2c3d4-e5f6-4a7b-8c9d-100000000005": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"jira\",\"line\":\"create_issue\",\"path\":[\"key\"]}')}"
+              }
+            },
+            "comment": "Jira チケットキーをリクエストレコードに保存",
+            "uuid": "a1b2c3d4-0004-4a7b-8c9d-000000000001"
+          },
+          {
+            "number": 5,
+            "provider": "workato_workflow_task",
+            "name": "change_workflow_stage",
+            "as": "change_stage_done",
+            "keyword": "action",
+            "input": {
+              "project_id": {
+                "zip_name": "pc_loan_request.lcap_app.json",
+                "name": "PC Loan Request",
+                "folder": ""
+              },
+              "record_id": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"human_review_on_existing_record\",\"path\":[\"record\",\"11fbe9a6_a16d_4d7e_86ea_afe42ec03005\"]}')}",
+              "workflow_stage_id": {
+                "name": "Done"
+              }
+            },
+            "comment": "ワークフローを Done に変更",
+            "uuid": "a1b2c3d4-0005-4a7b-8c9d-000000000001"
+          }
+        ],
+        "uuid": "a1b2c3d4-0006-4a7b-8c9d-000000000001"
+      },
+      {
+        "number": 6,
+        "keyword": "elsif",
+        "block": [
+          {
+            "number": 7,
+            "provider": "workato_workflow_task",
+            "name": "change_workflow_stage",
+            "as": "change_stage_canceled",
+            "keyword": "action",
+            "input": {
+              "project_id": {
+                "zip_name": "pc_loan_request.lcap_app.json",
+                "name": "PC Loan Request",
+                "folder": ""
+              },
+              "record_id": "#{_dp('{\"pill_type\":\"output\",\"provider\":\"workato_workflow_task\",\"line\":\"human_review_on_existing_record\",\"path\":[\"record\",\"11fbe9a6_a16d_4d7e_86ea_afe42ec03005\"]}')}",
+              "workflow_stage_id": {
+                "name": "Canceled"
+              }
+            },
+            "comment": "却下: ワークフローを Canceled に変更",
+            "uuid": "a1b2c3d4-0007-4a7b-8c9d-000000000001"
+          }
+        ],
+        "uuid": "a1b2c3d4-0008-4a7b-8c9d-000000000001"
+      }
+    ],
+    "comment": "PC 貸与リクエスト送信時に起動",
+    "uuid": "a1b2c3d4-0009-4a7b-8c9d-000000000001",
+    "format_version": 2
+  },
+  "config": [
+    {
+      "keyword": "application",
+      "provider": "workato_workflow_task",
+      "account_id": null
+    },
+    {
+      "keyword": "application",
+      "provider": "jira",
+      "account_id": {
+        "zip_name": "pc_loan_jira.connection.json",
+        "name": "PC Loan | Jira",
+        "folder": ""
+      },
+      "skip_validation": false
+    }
+  ]
+}

--- a/projects/[App] PC Loan Request/pc_loan_requests.workato_db_table.json
+++ b/projects/[App] PC Loan Request/pc_loan_requests.workato_db_table.json
@@ -1,0 +1,73 @@
+{
+  "name": "PC Loan Requests",
+  "schema": [
+    {
+      "id": "11fbe9a6-a16d-4d7e-86ea-afe42ec03005",
+      "title": "Record ID",
+      "type": "short-text",
+      "read_only": true,
+      "hidden": true
+    },
+    {
+      "id": "a5612739-5401-4ae7-bd07-782c1a6fb2d1",
+      "title": "Created time",
+      "type": "date-time",
+      "read_only": true,
+      "hidden": true
+    },
+    {
+      "id": "61aae604-a95e-4519-9091-bb0bf754a67f",
+      "title": "Last modified time",
+      "type": "date-time",
+      "read_only": true,
+      "hidden": true
+    },
+    {
+      "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000001",
+      "title": "PC type",
+      "type": "short-text",
+      "read_only": false,
+      "hidden": false,
+      "required": true,
+      "hint": "Windows / Mac / Linux",
+      "metadata": {}
+    },
+    {
+      "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000002",
+      "title": "Reason",
+      "type": "long-text",
+      "read_only": false,
+      "hidden": false,
+      "required": true,
+      "metadata": {}
+    },
+    {
+      "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000003",
+      "title": "Preferred delivery date",
+      "type": "date",
+      "read_only": false,
+      "hidden": false,
+      "required": false,
+      "metadata": {}
+    },
+    {
+      "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000004",
+      "title": "Review comments",
+      "type": "long-text",
+      "read_only": false,
+      "hidden": false,
+      "required": false,
+      "metadata": {}
+    },
+    {
+      "id": "b1a2c3d4-e5f6-4a7b-8c9d-100000000005",
+      "title": "Jira ticket key",
+      "type": "short-text",
+      "read_only": false,
+      "hidden": false,
+      "required": false,
+      "metadata": {}
+    }
+  ],
+  "project_name": "[App] PC Loan Request"
+}


### PR DESCRIPTION
## Summary
PC 貸与依頼の Workflow App レシピを `/create-recipe` スキルで生成。

### フロー
```
[0] trigger: リクエスト送信
  [1] マネージャー承認待ち (7日期限)
  [2] if 承認:
    [3] Jira チケット起票 (PC type, Reason, 申請者情報)
    [4] Jira チケットキーをレコードに保存
    [5] → Done
  [6] else:
    [7] → Canceled
```

### 生成ファイル
- `pc_loan_request.lcap_app.json` — Workflow App 定義 (4ステージ)
- `pc_loan_requests.workato_db_table.json` — Data Table (PC type, Reason, Delivery date, Review comments, Jira ticket key)
- `pc_loan_request_approval_and_jira_ticket.recipe.json` — メインレシピ
- `pc_loan_jira.connection.json` — Jira コネクション

### UI で要設定
- Jira コネクションの認証
- Jira の Project / Issue type 選択
- マネージャーのアサイン先設定
- Workflow App のページ定義 (lcap_page) は UI で作成

## Test plan
- [ ] `workato push` でインポート成功
- [ ] Workato UI でレシピ構造が正しく表示される
- [ ] Jira コネクション設定後にチケット起票が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Workflow App automation that creates Jira issues and updates workflow stages based on manager approval, so misconfiguration could create incorrect/spam tickets or move requests to the wrong stage.
> 
> **Overview**
> Introduces a new **PC Loan Request** Workflow App backed by a `PC Loan Requests` data table to capture request details (PC type, reason, preferred delivery date) plus review comments and a stored Jira ticket key.
> 
> Adds a recipe that triggers on new requests, assigns a 7-day manager approval task, and on approval creates a Jira issue, persists the returned issue key to the request record, and transitions the workflow to `Done` (otherwise transitions to `Canceled`). Includes a Jira connection stub (`pc_loan_jira.connection.json`) referenced by the recipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e2f53e56ebf0b387a67afa32634b60ad9545b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->