### PR TITLE
Phase 1: Replace fork CLI commands in /wpush skill

### DIFF
--- a/.claude/skills/wpush/SKILL.md
+++ b/.claude/skills/wpush/SKILL.md
@@ -180,8 +180,8 @@ Workflow App の UI 確認チェックリスト:
 ### 5. レシピ起動（--start / --test 指定時）
 
 ```bash
-# プロジェクト内のレシピ一覧を取得
-workato recipes list --output-mode json
+# プロジェクト内のレシピ一覧を取得（folder_id は .workatoenv から取得）
+python3 scripts/workato-api.py recipes list --folder-id <folder_id>
 
 # 個別レシピを起動
 workato recipes start --id <recipe-id>
@@ -194,17 +194,17 @@ workato recipes start --all
 
 ```bash
 # レシピのジョブ一覧を取得（失敗のみ）
-workato jobs list --recipe-id <recipe-id> --status failed
+python3 scripts/workato-api.py jobs list --recipe-id <recipe-id> --status failed
 
 # ジョブの詳細（エラー内容）を取得
-workato jobs get --recipe-id <recipe-id> --job-id <job-id>
+python3 scripts/workato-api.py jobs get --recipe-id <recipe-id> --job-id <job-id>
 ```
 
 ### 7. エラー修正サイクル
 
 ジョブが失敗した場合:
 
-1. `workato jobs get` でエラー内容を確認
+1. `python3 scripts/workato-api.py jobs get` でエラー内容を確認
 2. エラー原因を分析:
    - **datapill 参照エラー**: path の指定ミス → レシピ JSON を修正
    - **コネクション未設定**: UI でコネクション認証を設定するよう案内

--- a/.cursor/skills/wpush/SKILL.md
+++ b/.cursor/skills/wpush/SKILL.md
@@ -180,8 +180,8 @@ Workflow App の UI 確認チェックリスト:
 ### 5. レシピ起動（--start / --test 指定時）
 
 ```bash
-# プロジェクト内のレシピ一覧を取得
-workato recipes list --output-mode json
+# プロジェクト内のレシピ一覧を取得（folder_id は .workatoenv から取得）
+python3 scripts/workato-api.py recipes list --folder-id <folder_id>
 
 # 個別レシピを起動
 workato recipes start --id <recipe-id>
@@ -194,17 +194,17 @@ workato recipes start --all
 
 ```bash
 # レシピのジョブ一覧を取得（失敗のみ）
-workato jobs list --recipe-id <recipe-id> --status failed
+python3 scripts/workato-api.py jobs list --recipe-id <recipe-id> --status failed
 
 # ジョブの詳細（エラー内容）を取得
-workato jobs get --recipe-id <recipe-id> --job-id <job-id>
+python3 scripts/workato-api.py jobs get --recipe-id <recipe-id> --job-id <job-id>
 ```
 
 ### 7. エラー修正サイクル
 
 ジョブが失敗した場合:
 
-1. `workato jobs get` でエラー内容を確認
+1. `python3 scripts/workato-api.py jobs get` でエラー内容を確認
 2. エラー原因を分析:
    - **datapill 参照エラー**: path の指定ミス → レシピ JSON を修正
    - **コネクション未設定**: UI でコネクション認証を設定するよう案内


### PR DESCRIPTION
## Summary
- `/wpush` スキルのフォーク版 CLI コマンドを API ヘルパーに置換
- `workato recipes list --output-mode json` → `python3 scripts/workato-api.py recipes list`
- `workato jobs list/get` → `python3 scripts/workato-api.py jobs list/get`
- `workato recipes start` 等の本家対応済みコマンドはそのまま

## Test plan
- [ ] `/wpush --test` でジョブ確認フローが API ヘルパー経由で動作すること
- [ ] `.cursor/skills/wpush/SKILL.md` が同期されていること

Refs #36 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates example commands for listing recipes and inspecting jobs; no runtime code paths are modified.
> 
> **Overview**
> **Updates `/wpush` operational docs** to replace fork-specific `workato` CLI commands with the repo’s `python3 scripts/workato-api.py` helper when listing recipes and checking job status/details (including the error-triage step).
> 
> Keeps recipe start commands on the official `workato recipes start` CLI, and applies the same doc change in both `.claude/skills/wpush/SKILL.md` and `.cursor/skills/wpush/SKILL.md` to keep them in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647f475235bfaa178647b783b8ec9dfcd7a7acf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->