### PR TITLE
Phase 2: Replace fork CLI commands in /sync-connectors skill

### DIFF
--- a/.claude/skills/sync-connectors/SKILL.md
+++ b/.claude/skills/sync-connectors/SKILL.md
@@ -27,10 +27,10 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
 
 ```bash
 # 特定コネクタのトリガー/アクション一覧（JSON）
-workato connectors list --platform --provider <name> --output-mode json
+python3 scripts/workato-api.py connectors list-platform --provider <name>
 
 # カスタムコネクタ一覧
-workato connectors list --custom --output-mode json
+python3 scripts/workato-api.py connectors list-custom
 ```
 
 API から取得できる情報:
@@ -140,7 +140,7 @@ Source: Custom (Connector SDK)
 
 1. CLI でコネクタ情報を取得:
 ```bash
-workato connectors list --platform --provider <name> --output-mode json 2>/dev/null
+python3 scripts/workato-api.py connectors list-platform --provider <name>
 ```
 
 2. JSON をパースし、triggers/actions を抽出
@@ -182,7 +182,7 @@ Provider: `<name>`
 #### Pre-built コネクタ
 ```bash
 # 全 Pre-built コネクタを取得
-workato connectors list --platform --output-mode json 2>/dev/null
+python3 scripts/workato-api.py connectors list-platform
 ```
 全コネクタの JSON を取得し、各コネクタの `docs/connectors/<name>.md` を生成・更新する。
 

--- a/.cursor/skills/sync-connectors/SKILL.md
+++ b/.cursor/skills/sync-connectors/SKILL.md
@@ -27,10 +27,10 @@ description: コネクタ情報を収集しドキュメントを更新する。P
 
 ```bash
 # 特定コネクタのトリガー/アクション一覧（JSON）
-workato connectors list --platform --provider <name> --output-mode json
+python3 scripts/workato-api.py connectors list-platform --provider <name>
 
 # カスタムコネクタ一覧
-workato connectors list --custom --output-mode json
+python3 scripts/workato-api.py connectors list-custom
 ```
 
 API から取得できる情報:
@@ -140,7 +140,7 @@ Source: Custom (Connector SDK)
 
 1. CLI でコネクタ情報を取得:
 ```bash
-workato connectors list --platform --provider <name> --output-mode json 2>/dev/null
+python3 scripts/workato-api.py connectors list-platform --provider <name>
 ```
 
 2. JSON をパースし、triggers/actions を抽出
@@ -182,7 +182,7 @@ Provider: `<name>`
 #### Pre-built コネクタ
 ```bash
 # 全 Pre-built コネクタを取得
-workato connectors list --platform --output-mode json 2>/dev/null
+python3 scripts/workato-api.py connectors list-platform
 ```
 全コネクタの JSON を取得し、各コネクタの `docs/connectors/<name>.md` を生成・更新する。
 


### PR DESCRIPTION
## Summary
- `/sync-connectors` スキルのフォーク版 CLI コマンドを API ヘルパーに置換
- `workato connectors list --platform` → `python3 scripts/workato-api.py connectors list-platform`
- `workato connectors list --custom` → `python3 scripts/workato-api.py connectors list-custom`
- 4箇所の CLI コマンドを一括置換

## Test plan
- [ ] `/sync-connectors salesforce` で API ヘルパー経由でコネクタ情報が取得できること
- [ ] `.cursor/skills/sync-connectors/SKILL.md` が同期されていること

Refs #36 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example commands for fetching connector metadata; no runtime code paths are modified.
> 
> **Overview**
> Updates the `/sync-connectors` skill docs to replace the forked `workato connectors list ...` CLI examples with the API helper equivalents (`python3 scripts/workato-api.py connectors list-platform` and `connectors list-custom`) for both single-provider and `--all` flows.
> 
> Keeps `.claude` and `.cursor` versions of `SKILL.md` in sync with the new command usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86a0810033dbdd63407b0e9dd8f06474fc365de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->