### PR TITLE
Phase 3: Resolve CLI command conflict, update /create-connector

### DIFF
--- a/.claude/skills/create-connector/SKILL.md
+++ b/.claude/skills/create-connector/SKILL.md
@@ -101,11 +101,13 @@ settings.yaml.enc
 生成完了後、以下を表示:
 - 生成したファイル一覧
 - コネクタの構成サマリー（認証方式、アクション数、トリガー数）
-- 次のステップ（本家 CLI の場合）:
+- 次のステップ:
   1. `settings.yaml` に認証情報を設定
-  2. `workato exec connectors/<name>/connector.rb test` でテスト
-  3. `workato push connectors/<name>` でアップロード
-- 次のステップ（フォーク版 CLI の場合）:
-  1. `settings.yaml` に認証情報を設定
-  2. `workato sdk exec connectors/<name>/connector.rb test` でテスト
-  3. `workato sdk push connectors/<name>` でアップロード
+  2. SDK CLI でテスト・アップロード:
+     ```bash
+     cd connectors/<name>
+     bundle install                              # 初回のみ
+     bundle exec workato exec connector.rb test  # テスト
+     bundle exec workato push .                  # push
+     ```
+  > **Note**: `bundle exec workato` を使うのは、Platform CLI (`pipx install workato-platform-cli`) と `workato` コマンド名が競合するため

--- a/.cursor/skills/create-connector/SKILL.md
+++ b/.cursor/skills/create-connector/SKILL.md
@@ -101,11 +101,13 @@ settings.yaml.enc
 生成完了後、以下を表示:
 - 生成したファイル一覧
 - コネクタの構成サマリー（認証方式、アクション数、トリガー数）
-- 次のステップ（本家 CLI の場合）:
+- 次のステップ:
   1. `settings.yaml` に認証情報を設定
-  2. `workato exec connectors/<name>/connector.rb test` でテスト
-  3. `workato push connectors/<name>` でアップロード
-- 次のステップ（フォーク版 CLI の場合）:
-  1. `settings.yaml` に認証情報を設定
-  2. `workato sdk exec connectors/<name>/connector.rb test` でテスト
-  3. `workato sdk push connectors/<name>` でアップロード
+  2. SDK CLI でテスト・アップロード:
+     ```bash
+     cd connectors/<name>
+     bundle install                              # 初回のみ
+     bundle exec workato exec connector.rb test  # テスト
+     bundle exec workato push .                  # push
+     ```
+  > **Note**: `bundle exec workato` を使うのは、Platform CLI (`pipx install workato-platform-cli`) と `workato` コマンド名が競合するため

--- a/docs/connector-sdk/overview.md
+++ b/docs/connector-sdk/overview.md
@@ -21,32 +21,17 @@ Workato が標準で提供していないアプリケーションに接続する
 
 ## SDK CLI コマンド
 
-### 本家 CLI (`gem install workato-connector-sdk`)
+### SDK CLI (`gem install workato-connector-sdk`)
+
+> **Note**: Platform CLI (`pipx install workato-platform-cli`) も `workato` コマンドを登録するため、`push` 等のサブコマンドが競合する。SDK CLI は必ず `bundle exec workato` 形式で実行すること。
 
 | コマンド | 説明 |
 |---|---|
-| `workato new <PATH>` | 新規コネクタプロジェクト作成 |
-| `workato exec <PATH>` | コネクタの lambda ブロックを実行・テスト |
-| `workato push <FOLDER>` | コネクタコードを Workato にアップロード |
-| `workato edit <PATH>` | 暗号化ファイルを編集 |
-| `workato generate <SUBCOMMAND>` | テンプレートからコード生成 |
-
-### フォーク版 CLI (`rkawaishi/workato-platform-cli`)
-
-SDK コマンドが Platform CLI に統合されており、Ruby gem 不要:
-
-| コマンド | 説明 |
-|---|---|
-| `workato sdk new <PATH>` | 新規コネクタプロジェクト作成 |
-| `workato sdk exec <PATH>` | コネクタの lambda ブロックを実行・テスト |
-| `workato sdk push <FOLDER>` | コネクタコードを Workato にアップロード |
-| `workato sdk generate schema <PATH>` | コネクタからスキーマ生成 |
-| `workato sdk oauth2 <PATH>` | OAuth2 フロー実行 |
-
-フォーク版にはさらに以下の追加機能がある:
-- `workato jobs list` / `workato jobs get` — ジョブ一覧・詳細
-- `workato oauth-profiles` — Custom OAuth Profile の CRUD
-- `workspace_id` による自動プロファイル解決（`.workatoenv` の Git 共有対応）
+| `bundle exec workato new <PATH>` | 新規コネクタプロジェクト作成 |
+| `bundle exec workato exec <PATH>` | コネクタの lambda ブロックを実行・テスト |
+| `bundle exec workato push <FOLDER>` | コネクタコードを Workato にアップロード |
+| `bundle exec workato edit <PATH>` | 暗号化ファイルを編集 |
+| `bundle exec workato generate <SUBCOMMAND>` | テンプレートからコード生成 |
 
 ## プロジェクト構造
 


### PR DESCRIPTION
## Summary
- Platform CLI と Connector SDK gem の `workato` コマンド名衝突を解決
- Connector SDK は `bundle exec workato` でスコープする方針に統一
- `/create-connector` スキルからフォーク版 SDK セクションを削除
- `docs/connector-sdk/overview.md` からフォーク版セクションを削除、`bundle exec` 形式に更新

## Test plan
- [ ] `/create-connector` の出力が `bundle exec workato` 形式になっていること
- [ ] `docs/connector-sdk/overview.md` にフォーク版の記述が残っていないこと
- [ ] `.cursor/` が同期されていること

Refs #36 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change recommended CLI invocation to avoid `workato` command name conflicts; no runtime code or connector logic is modified.
> 
> **Overview**
> Updates the `/create-connector` skill output (both `.claude` and `.cursor` copies) to standardize the post-generation instructions on **`bundle exec workato`** for testing and pushing connectors.
> 
> Refreshes `docs/connector-sdk/overview.md` to remove the forked-CLI guidance and document the command-conflict note, presenting all SDK CLI commands in `bundle exec workato ...` form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75c0ccd96720fea40f4fb3e42562f1f7ee952c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->