### PR TITLE
Phase 4: Restructure CLI docs to 3-tool architecture

### DIFF
--- a/.claude/rules/workato-cli.md
+++ b/.claude/rules/workato-cli.md
@@ -7,40 +7,49 @@ paths:
 
 # Workato CLI ツール
 
-## Platform CLI（レシピ管理）
+3つのツールを使い分ける:
 
-2つのバリアントがある。インストール済みの方を使用する:
+## 1. Platform CLI（プロジェクト管理）
 
-| | 本家 | フォーク (rkawaishi) |
-|---|---|---|
-| インストール | `pipx install workato-platform-cli` | `pipx install git+https://github.com/rkawaishi/workato-platform-cli.git` |
-| 追加機能 | — | Jobs, SDK統合, OAuth Profile管理, workspace_id自動解決 |
-| リポジトリ | [workato-devs/workato-platform-cli](https://github.com/workato-devs/workato-platform-cli) | [rkawaishi/workato-platform-cli](https://github.com/rkawaishi/workato-platform-cli) |
+インストール: `pipx install workato-platform-cli`
 
-共通コマンド:
+主なコマンド:
+- Init: `workato init --non-interactive --profile <profile> --project-id <id> --folder-name "projects/<name>"`
 - Pull: `workato projects use "<name>" && workato pull`
 - Push: `workato push`
-- Init: `workato init --non-interactive --profile <profile> --project-id <id> --folder-name "projects/<name>"`
+- Push (再起動付き): `workato push --restart-recipes`
+- Push (削除付き): `workato push --delete`
+- レシピ起動: `workato recipes start --id <id>` / `workato recipes start --all`
 
-フォーク版の追加コマンド:
-- Jobs: `workato jobs list` / `workato jobs get <id>`
-- SDK: `workato sdk new <path>` / `workato sdk push` / `workato sdk exec` / `workato sdk generate schema`
-- OAuth: `workato oauth-profiles list` / `create` / `update` / `delete`
-- Connectors: `workato connectors` 管理
+## 2. API ヘルパー（CLI にない機能の補完）
 
-## Connector SDK CLI（コネクタ開発）
+Platform CLI にないAPI操作を補完するスクリプト。workspace_id ベースでプロファイルを自動解決する。
 
-本家 CLI の場合:
-- インストール: `gem install workato-connector-sdk`
-- 新規作成: `workato new connectors/<name>`
-- テスト: `workato exec connectors/<name>/connector.rb test`
-- Push: `workato push connectors/<name>`
+```bash
+python3 scripts/workato-api.py <command>
+```
 
-フォーク版 CLI の場合（SDK コマンド統合済み）:
-- 新規作成: `workato sdk new connectors/<name>`
-- テスト: `workato sdk exec connectors/<name>/connector.rb test`
-- Push: `workato sdk push connectors/<name>`
-- スキーマ生成: `workato sdk generate schema connectors/<name>`
+| コマンド | 用途 |
+|---|---|
+| `jobs list --recipe-id <id> [--status <s>]` | ジョブ一覧 |
+| `jobs get --recipe-id <id> --job-id <id>` | ジョブ詳細 |
+| `connectors list-platform [--provider <name>]` | Pre-built コネクタ情報 |
+| `connectors list-custom` | カスタムコネクタ一覧 |
+| `recipes list [--folder-id <id>]` | レシピ一覧（JSON） |
+| `profile show` | プロファイル解決結果 |
+
+## 3. Connector SDK CLI（カスタムコネクタ開発）
+
+インストール: `gem install workato-connector-sdk`
+
+**注意:** Platform CLI と同じ `workato` コマンド名を使うため、`bundle exec` でスコープして衝突を避ける。
+
+```bash
+cd connectors/<name>
+bundle exec workato new <PATH>           # 新規作成
+bundle exec workato exec <PATH> test     # テスト
+bundle exec workato push <FOLDER>        # push
+```
 
 ## コネクタの分類
 

--- a/.cursor/rules/workato-cli.mdc
+++ b/.cursor/rules/workato-cli.mdc
@@ -6,40 +6,49 @@ alwaysApply: false
 
 # Workato CLI ツール
 
-## Platform CLI（レシピ管理）
+3つのツールを使い分ける:
 
-2つのバリアントがある。インストール済みの方を使用する:
+## 1. Platform CLI（プロジェクト管理）
 
-| | 本家 | フォーク (rkawaishi) |
-|---|---|---|
-| インストール | `pipx install workato-platform-cli` | `pipx install git+https://github.com/rkawaishi/workato-platform-cli.git` |
-| 追加機能 | — | Jobs, SDK統合, OAuth Profile管理, workspace_id自動解決 |
-| リポジトリ | [workato-devs/workato-platform-cli](https://github.com/workato-devs/workato-platform-cli) | [rkawaishi/workato-platform-cli](https://github.com/rkawaishi/workato-platform-cli) |
+インストール: `pipx install workato-platform-cli`
 
-共通コマンド:
+主なコマンド:
+- Init: `workato init --non-interactive --profile <profile> --project-id <id> --folder-name "projects/<name>"`
 - Pull: `workato projects use "<name>" && workato pull`
 - Push: `workato push`
-- Init: `workato init --non-interactive --profile <profile> --project-id <id> --folder-name "projects/<name>"`
+- Push (再起動付き): `workato push --restart-recipes`
+- Push (削除付き): `workato push --delete`
+- レシピ起動: `workato recipes start --id <id>` / `workato recipes start --all`
 
-フォーク版の追加コマンド:
-- Jobs: `workato jobs list` / `workato jobs get <id>`
-- SDK: `workato sdk new <path>` / `workato sdk push` / `workato sdk exec` / `workato sdk generate schema`
-- OAuth: `workato oauth-profiles list` / `create` / `update` / `delete`
-- Connectors: `workato connectors` 管理
+## 2. API ヘルパー（CLI にない機能の補完）
 
-## Connector SDK CLI（コネクタ開発）
+Platform CLI にないAPI操作を補完するスクリプト。workspace_id ベースでプロファイルを自動解決する。
 
-本家 CLI の場合:
-- インストール: `gem install workato-connector-sdk`
-- 新規作成: `workato new connectors/<name>`
-- テスト: `workato exec connectors/<name>/connector.rb test`
-- Push: `workato push connectors/<name>`
+```bash
+python3 scripts/workato-api.py <command>
+```
 
-フォーク版 CLI の場合（SDK コマンド統合済み）:
-- 新規作成: `workato sdk new connectors/<name>`
-- テスト: `workato sdk exec connectors/<name>/connector.rb test`
-- Push: `workato sdk push connectors/<name>`
-- スキーマ生成: `workato sdk generate schema connectors/<name>`
+| コマンド | 用途 |
+|---|---|
+| `jobs list --recipe-id <id> [--status <s>]` | ジョブ一覧 |
+| `jobs get --recipe-id <id> --job-id <id>` | ジョブ詳細 |
+| `connectors list-platform [--provider <name>]` | Pre-built コネクタ情報 |
+| `connectors list-custom` | カスタムコネクタ一覧 |
+| `recipes list [--folder-id <id>]` | レシピ一覧（JSON） |
+| `profile show` | プロファイル解決結果 |
+
+## 3. Connector SDK CLI（カスタムコネクタ開発）
+
+インストール: `gem install workato-connector-sdk`
+
+**注意:** Platform CLI と同じ `workato` コマンド名を使うため、`bundle exec` でスコープして衝突を避ける。
+
+```bash
+cd connectors/<name>
+bundle exec workato new <PATH>           # 新規作成
+bundle exec workato exec <PATH> test     # テスト
+bundle exec workato push <FOLDER>        # push
+```
 
 ## コネクタの分類
 

--- a/docs/patterns/deployment-guide.md
+++ b/docs/patterns/deployment-guide.md
@@ -83,8 +83,8 @@ pull 後に `/learn-recipe` でフィールド情報を抽出・蓄積する。
 CLI でテスト結果を確認する場合:
 ```bash
 workato recipes start --id <recipe-id>
-workato jobs list --recipe-id <recipe-id> --status failed
-workato jobs get --recipe-id <recipe-id> --job-id <job-id>
+python3 scripts/workato-api.py jobs list --recipe-id <recipe-id> --status failed
+python3 scripts/workato-api.py jobs get --recipe-id <recipe-id> --job-id <job-id>
 ```
 
 ## Workflow App のデプロイフロー

--- a/guides/quickstart-claude-code.md
+++ b/guides/quickstart-claude-code.md
@@ -21,12 +21,12 @@ cd workato-dev-kit
 ## 3. Workato Platform CLI をインストール
 
 ```bash
-pipx install git+https://github.com/rkawaishi/workato-platform-cli.git
+pipx install workato-platform-cli
 ```
 
 > `pipx` がない場合: `brew install pipx && pipx ensurepath`
 
-> **Note**: 公式 CLI (`workato-platform-cli`) も利用可能ですが、本ツールキットでは [rkawaishi/workato-platform-cli](https://github.com/rkawaishi/workato-platform-cli)（フォーク版）を推奨します。ジョブ管理、アセット一覧、レシピ起動など、開発に必要なコマンドが追加されています。
+> **Note**: 公式 CLI でプロジェクトの pull/push を行います。ジョブ管理やコネクタ情報取得など CLI にない機能は、付属の API ヘルパー (`python3 scripts/workato-api.py`) で補完します。詳細は `.claude/rules/workato-cli.md` を参照。
 
 ## 4. CLI の初期認証
 

--- a/guides/quickstart-cursor.md
+++ b/guides/quickstart-cursor.md
@@ -21,12 +21,12 @@ cd workato-dev-kit
 ## 3. Workato Platform CLI をインストール
 
 ```bash
-pipx install git+https://github.com/rkawaishi/workato-platform-cli.git
+pipx install workato-platform-cli
 ```
 
 > `pipx` がない場合: `brew install pipx && pipx ensurepath`
 
-> **Note**: 公式 CLI (`workato-platform-cli`) も利用可能ですが、本ツールキットでは [rkawaishi/workato-platform-cli](https://github.com/rkawaishi/workato-platform-cli)（フォーク版）を推奨します。ジョブ管理、アセット一覧、レシピ起動など、開発に必要なコマンドが追加されています。
+> **Note**: 公式 CLI でプロジェクトの pull/push を行います。ジョブ管理やコネクタ情報取得など CLI にない機能は、付属の API ヘルパー (`python3 scripts/workato-api.py`) で補完します。詳細は `.claude/rules/workato-cli.md` を参照。
 
 ## 4. CLI の初期認証
 


### PR DESCRIPTION
## Summary
- `.claude/rules/workato-cli.md` を3ツール体系に再構成:
  1. Platform CLI (`workato`) — プロジェクト管理
  2. API ヘルパー (`python3 scripts/workato-api.py`) — CLI 補完
  3. Connector SDK (`bundle exec workato`) — コネクタ開発
- `docs/patterns/deployment-guide.md` の jobs コマンドを API ヘルパーに置換
- `guides/quickstart-claude-code.md` / `quickstart-cursor.md` のフォーク推奨を本家 CLI + API ヘルパーに変更

## Test plan
- [ ] `.claude/rules/workato-cli.md` にフォーク版の記述が残っていないこと
- [ ] quickstart ガイドが本家 CLI のインストールを案内していること
- [ ] `.cursor/rules/workato-cli.mdc` が同期されていること

Refs #36 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change recommended CLI commands and installation guidance; low risk aside from potential user confusion if instructions don’t match installed tooling.
> 
> **Overview**
> Updates the CLI documentation to a **3-tool architecture**: use the official `workato-platform-cli` for project pull/push, `python3 scripts/workato-api.py` for missing API operations (jobs/connectors/recipes/profile), and `bundle exec workato` for Connector SDK workflows.
> 
> Adjusts user-facing guides to match this split by switching job-inspection commands in `deployment-guide.md` to the API helper and updating both quickstart guides to install the official CLI (removing the fork recommendation) while pointing readers to the new CLI rule doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b4a2be8e9c4da3025790f6433367432ac9b7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->