### PR TITLE
sdk push 完了時に connectors/docs を自動更新する

### DIFF
--- a/.claude/hooks/sync-docs-after-sdk-push.sh
+++ b/.claude/hooks/sync-docs-after-sdk-push.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# PostToolUse hook: after sdk push, remind Claude to sync connector docs
+# PostToolUse hook: after sdk push, remind AI to sync connector docs
+#
+# Compatible with both Claude Code and Cursor:
+#   Claude Code: tool_name="Bash", tool_response={exitCode,stdout,stderr}
+#   Cursor:      tool_name="Shell", tool_output="{\"exitCode\":0,...}" (JSON string)
 #
 # When `sdk push` completes successfully, this hook detects the connector path
-# from the command and outputs a message for Claude to update connectors/docs/.
+# from the command and outputs a message to update connectors/docs/.
 
 INPUT=$(cat)
 
@@ -12,42 +16,51 @@ case "$INPUT" in
   *) exit 0 ;;
 esac
 
-# Extract the command string
-COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+# Parse tool input and check exit code (handles both Claude Code and Cursor formats)
+RESULT=$(echo "$INPUT" | python3 -c "
+import sys, json, re
 
-# Verify it's actually an sdk push command
-case "$COMMAND" in
-  *"workato-api.py sdk push"*) ;;
-  *) exit 0 ;;
-esac
+data = json.load(sys.stdin)
+command = data.get('tool_input', {}).get('command', '')
 
-# Check exit code (success = 0)
-EXIT_CODE=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_response',{}).get('exitCode',1))" 2>/dev/null)
-if [ "$EXIT_CODE" != "0" ]; then
-  exit 0
-fi
+# Verify it's an sdk push command
+if 'workato-api.py sdk push' not in command:
+    sys.exit(0)
+
+# Get exit code: Claude Code uses tool_response (dict), Cursor uses tool_output (JSON string)
+exit_code = 1
+resp = data.get('tool_response')
+if isinstance(resp, dict):
+    exit_code = resp.get('exitCode', 1)
+else:
+    raw = data.get('tool_output', '')
+    if isinstance(raw, str) and raw:
+        try:
+            exit_code = json.loads(raw).get('exitCode', 1)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+if exit_code != 0:
+    sys.exit(0)
 
 # Extract connector path from --connector argument
-CONNECTOR_PATH=$(echo "$COMMAND" | python3 -c "
-import sys, re
-cmd = sys.stdin.read()
-m = re.search(r'--connector\s+[\"\\x27](.*?)[\"\\x27]', cmd) or re.search(r'--connector\s+(\S+)', cmd)
-print(m.group(1) if m else '')
-")
+m = re.search(r'--connector\s+[\"\\x27](.*?)[\"\\x27]', command) or re.search(r'--connector\s+(\S+)', command)
+if not m:
+    sys.exit(0)
 
-if [ -z "$CONNECTOR_PATH" ]; then
+from pathlib import Path
+p = Path(m.group(1))
+name = p.parent.name if p.name == 'connector.rb' else p.stem
+print(name)
+" 2>/dev/null)
+
+if [ -z "$RESULT" ]; then
   exit 0
 fi
 
-# Derive connector name from path (parent directory of connector.rb)
-CONNECTOR_NAME=$(echo "$CONNECTOR_PATH" | python3 -c "
-from pathlib import Path
-import sys
-p = Path(sys.stdin.read().strip())
-print(p.parent.name if p.name == 'connector.rb' else p.stem)
-")
+CONNECTOR_NAME="$RESULT"
 
-# Output feedback for Claude (stdout is shown to Claude as hook feedback)
+# Output feedback (stdout is shown to the AI as hook feedback)
 echo "sdk push completed. Please update connector docs: read connectors/${CONNECTOR_NAME}/connector.rb and generate/update connectors/docs/${CONNECTOR_NAME}.md following the custom connector doc format defined in the /sync-connectors skill."
 
 exit 0

--- a/.claude/hooks/sync-docs-after-sdk-push.sh
+++ b/.claude/hooks/sync-docs-after-sdk-push.sh
@@ -44,7 +44,8 @@ if exit_code != 0:
     sys.exit(0)
 
 # Extract connector path from --connector argument
-m = re.search(r'--connector\s+[\"\\x27](.*?)[\"\\x27]', command) or re.search(r'--connector\s+(\S+)', command)
+q = chr(39)  # single quote (avoids bash escaping issues)
+m = re.search(r'--connector\s+[\"' + q + r'](.*?)[\"' + q + r']', command) or re.search(r'--connector\s+(\S+)', command)
 if not m:
     sys.exit(0)
 

--- a/.claude/hooks/sync-docs-after-sdk-push.sh
+++ b/.claude/hooks/sync-docs-after-sdk-push.sh
@@ -43,9 +43,9 @@ else:
 if exit_code != 0:
     sys.exit(0)
 
-# Extract connector path from --connector argument
+# Extract connector path from --connector argument (supports both --connector path and --connector=path)
 q = chr(39)  # single quote (avoids bash escaping issues)
-m = re.search(r'--connector\s+[\"' + q + r'](.*?)[\"' + q + r']', command) or re.search(r'--connector\s+(\S+)', command)
+m = re.search(r'--connector[\s=]+[\"' + q + r'](.*?)[\"' + q + r']', command) or re.search(r'--connector[\s=]+(\S+)', command)
 if not m:
     sys.exit(0)
 

--- a/.claude/hooks/sync-docs-after-sdk-push.sh
+++ b/.claude/hooks/sync-docs-after-sdk-push.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PostToolUse hook: after sdk push, remind Claude to sync connector docs
+#
+# When `sdk push` completes successfully, this hook detects the connector path
+# from the command and outputs a message for Claude to update connectors/docs/.
+
+INPUT=$(cat)
+
+# Fast exit: skip if not an sdk push command
+case "$INPUT" in
+  *"sdk push"*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the command string
+COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+# Verify it's actually an sdk push command
+case "$COMMAND" in
+  *"workato-api.py sdk push"*) ;;
+  *) exit 0 ;;
+esac
+
+# Check exit code (success = 0)
+EXIT_CODE=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_response',{}).get('exitCode',1))" 2>/dev/null)
+if [ "$EXIT_CODE" != "0" ]; then
+  exit 0
+fi
+
+# Extract connector path from --connector argument
+CONNECTOR_PATH=$(echo "$COMMAND" | python3 -c "
+import sys, re
+cmd = sys.stdin.read()
+m = re.search(r'--connector\s+[\"\\x27](.*?)[\"\\x27]', cmd) or re.search(r'--connector\s+(\S+)', cmd)
+print(m.group(1) if m else '')
+")
+
+if [ -z "$CONNECTOR_PATH" ]; then
+  exit 0
+fi
+
+# Derive connector name from path (parent directory of connector.rb)
+CONNECTOR_NAME=$(echo "$CONNECTOR_PATH" | python3 -c "
+from pathlib import Path
+import sys
+p = Path(sys.stdin.read().strip())
+print(p.parent.name if p.name == 'connector.rb' else p.stem)
+")
+
+# Output feedback for Claude (stdout is shown to Claude as hook feedback)
+echo "sdk push completed. Please update connector docs: read connectors/${CONNECTOR_NAME}/connector.rb and generate/update connectors/docs/${CONNECTOR_NAME}.md following the custom connector doc format defined in the /sync-connectors skill."
+
+exit 0

--- a/.claude/rules/workato-connector-sdk.md
+++ b/.claude/rules/workato-connector-sdk.md
@@ -80,6 +80,15 @@ connectors/<name>/
 `/sync-connectors --custom` で `connector.rb` をパースして自動生成。
 Pre-built コネクタ（`docs/connectors/`）と同じ形式。
 
+## sdk push 後の docs 自動更新
+
+`python3 scripts/workato-api.py sdk push` の完了後は、push したコネクタの `connectors/docs/<name>.md` を更新すること。
+
+手順:
+1. `connectors/<name>/connector.rb` を読む
+2. `/sync-connectors` スキルのカスタムコネクタ doc フォーマットに従い `connectors/docs/<name>.md` を生成/更新
+3. 既存の `## フィールド詳細` セクションに `/learn-recipe` で蓄積したデータがあれば保持する
+
 ## 注意事項
 
 - 使用可能な Ruby メソッドは許可リストに限定

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sync-docs-after-sdk-push.sh"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,6 +3,7 @@
   "hooks": {
     "postToolUse": [
       {
+        "matcher": "Shell",
         "command": ".claude/hooks/sync-docs-after-sdk-push.sh",
         "type": "command"
       }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "command": ".claude/hooks/sync-docs-after-sdk-push.sh",
+        "type": "command"
+      }
+    ]
+  }
+}

--- a/.cursor/rules/workato-connector-sdk.mdc
+++ b/.cursor/rules/workato-connector-sdk.mdc
@@ -80,6 +80,15 @@ connectors/<name>/
 `/sync-connectors --custom` で `connector.rb` をパースして自動生成。
 Pre-built コネクタ（`docs/connectors/`）と同じ形式。
 
+## sdk push 後の docs 自動更新
+
+`python3 scripts/workato-api.py sdk push` の完了後は、push したコネクタの `connectors/docs/<name>.md` を更新すること。
+
+手順:
+1. `connectors/<name>/connector.rb` を読む
+2. `/sync-connectors` スキルのカスタムコネクタ doc フォーマットに従い `connectors/docs/<name>.md` を生成/更新
+3. 既存の `## フィールド詳細` セクションに `/learn-recipe` で蓄積したデータがあれば保持する
+
 ## 注意事項
 
 - 使用可能な Ruby メソッドは許可リストに限定


### PR DESCRIPTION
## Summary

Closes #47

- `sdk push` の成功を PostToolUse hook で検知し、AI に `connectors/docs/<name>.md` の更新を指示する
- Claude Code と Cursor の両方に対応（stdin JSON 形式の差異を吸収）
- ルールベースのフォールバックも追加（hook が動作しない場合の保険）

## 変更内容

| ファイル | 内容 |
|---|---|
| `.claude/hooks/sync-docs-after-sdk-push.sh` | PostToolUse hook スクリプト（新規） |
| `.claude/settings.json` | Claude Code に PostToolUse hook を登録 |
| `.cursor/hooks.json` | Cursor に postToolUse hook を登録（新規） |
| `.claude/rules/workato-connector-sdk.md` | 「sdk push 後の docs 自動更新」ルール追記 |
| `.cursor/rules/workato-connector-sdk.mdc` | 同上（Cursor 同期） |

## 動作フロー

```
sdk push 実行 → 成功 (exitCode=0) → hook がフィードバック出力
→ AI が connector.rb を読み、/sync-connectors スキルのフォーマットで
  connectors/docs/<name>.md を生成/更新
```

## 設計判断

- **hook + AI パース方式を採用**: Python で Ruby DSL パーサーを書く案（案1）を検討したが、正規表現ベースのパーサーは脆く、`/sync-connectors` スキルが既に Claude の言語理解で connector.rb をパースできるためフック方式（案2）を採用
- **両エディタ対応**: Claude Code (`tool_response` object, `Bash`) と Cursor (`tool_output` JSON string, `Shell`) の差異を hook スクリプト内で吸収

## Test plan

- [x] Claude Code 形式の stdin で正しくコネクタ名を抽出できる
- [x] Cursor 形式の stdin で正しくコネクタ名を抽出できる
- [x] 失敗時 (exitCode≠0) はスキップされる
- [x] 無関係なコマンドはスキップされる
- [x] クォート付きパスも正しく処理される
- [ ] 実際の `sdk push` 後に connector docs が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds editor/AI workflow hooks and documentation; no production/runtime code paths are affected beyond running a small local parsing script after shell commands.
> 
> **Overview**
> Adds a new PostToolUse hook script (`.claude/hooks/sync-docs-after-sdk-push.sh`) that parses the tool event JSON, detects a successful `python3 scripts/workato-api.py sdk push --connector ...`, derives the connector name, and prints a reminder to generate/update `connectors/docs/<name>.md` via `/sync-connectors`.
> 
> Registers the hook in `.claude/settings.json` (Claude Code) and introduces `.cursor/hooks.json` (Cursor), and updates the connector SDK rules (`.claude/rules/workato-connector-sdk.md`, `.cursor/rules/workato-connector-sdk.mdc`) to document the required docs-update step after `sdk push`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c7279c132ce12fed2f9f0e1eefdfb3d80068ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->