### PR TITLE
Fix sdk push: correct API field names and separate release call

### DIFF
--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -314,7 +314,7 @@ class WorkatoAPI:
 
         # Release unless explicitly skipped
         if not no_release:
-            cid = connector_id or (data.get("id") if isinstance(data, dict) else None)
+            cid = connector_id if connector_id is not None else (data.get("id") if isinstance(data, dict) else None)
             if cid is not None:
                 self._request(
                     f"/api/custom_connectors/{cid}/release",

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -287,14 +287,16 @@ class WorkatoAPI:
         notes: str | None = None,
         no_release: bool = False,
     ) -> dict:
-        """Push connector source code to Workato."""
-        payload: dict = {"source_code": source_code}
+        """Push connector source code to Workato.
+
+        The create/update call uploads the code. A separate release call
+        publishes the latest uploaded version.
+        """
+        payload: dict = {"code": source_code}
         if description:
             payload["description"] = description
         if notes:
-            payload["notes"] = notes
-        if no_release:
-            payload["release"] = False
+            payload["note"] = notes
 
         if connector_id is not None:
             result = self._request(
@@ -308,7 +310,18 @@ class WorkatoAPI:
                 method="POST", body=payload,
             )
 
-        return result.get("data", result) if isinstance(result, dict) else result
+        data = result.get("data", result) if isinstance(result, dict) else result
+
+        # Release unless explicitly skipped
+        if not no_release:
+            cid = connector_id or (data.get("id") if isinstance(data, dict) else None)
+            if cid is not None:
+                self._request(
+                    f"/api/custom_connectors/{cid}/release",
+                    method="POST",
+                )
+
+        return data
 
     # -- OAuth Profiles --
 


### PR DESCRIPTION
## Summary
- `source_code` → `code`: API が期待するフィールド名に修正（ソースコードが反映されなかった原因）
- `notes` → `note`: API 仕様に合わせて単数形に修正
- リリース処理をペイロードのフラグから別エンドポイント `POST /api/custom_connectors/{id}/release` に変更

Platform CLI の OpenAPI 生成モデル (`CustomConnectorCreateRequest`) と照合して修正。

## Test plan
- [ ] `sdk push --connector <path>` で新規コネクタ作成 → コードが反映されること
- [ ] `sdk push --connector <path> --connector-id <id>` で既存コネクタ更新 → コードが反映されること
- [ ] `sdk push --no-release` でリリースAPIが呼ばれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters how custom connectors are uploaded and released, which can change deployment behavior (e.g., auto-publishing) and impact automation that relies on the previous request payload/flow.
> 
> **Overview**
> Fixes `sdk push` to match Workato’s custom connector API by sending source as `code` (not `source_code`) and release notes as `note` (not `notes`).
> 
> Changes publishing semantics so create/update only uploads, and a separate `POST /api/custom_connectors/{id}/release` call is made unless `--no-release` is set; response handling now returns the uploaded connector data after the optional release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45772a102e1989ac57fb4c6b64ab281617c91fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->