### PR TITLE
Fix sdk push to return post-release state

### DIFF
--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -370,10 +370,13 @@ class WorkatoAPI:
         if not no_release:
             cid = connector_id if connector_id is not None else (data.get("id") if isinstance(data, dict) else None)
             if cid is not None:
-                self._request(
+                rel = self._request(
                     f"/api/custom_connectors/{cid}/release",
                     method="POST",
                 )
+                rel_data = rel.get("data", rel) if isinstance(rel, dict) else rel
+                if isinstance(rel_data, dict):
+                    data = rel_data
 
         return data
 


### PR DESCRIPTION
## Summary
- リリース API のレスポンスを返すように修正。以前は update レスポンス（リリース前）を返していたため、`latest_released_version` が古いバージョンを示していた
- #53 のフォローアップ

## Test plan
- [x] push + release で `latest_released_version` が push したバージョンと一致することを確認
- [x] `--no-release` で `latest_released_version` が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the CLI helper’s return value after a release call; low risk aside from potential downstream expectations of the previous response shape.
> 
> **Overview**
> `sdk_push` in `scripts/workato-api.py` now returns the response from the connector `release` API call (when `--no-release` is not set), instead of returning the pre-release create/update payload. This ensures fields like `latest_released_version` reflect the newly released version after a push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42b36a5de2cd4d551f9334bd65bd8157f94f16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->