### PR TITLE
Exclude .custom_adapter files from project push

### DIFF
--- a/.workato-ignore
+++ b/.workato-ignore
@@ -67,4 +67,9 @@ Thumbs.db
 # Custom connectors (SDK projects, separate from Platform CLI)
 connectors/
 
+# Custom connector source pulled into projects.
+# Managed via SDK push — including in project push can revert SDK changes.
+*.custom_adapter.rb
+*.custom_adapter.json
+
 # Add your own patterns below


### PR DESCRIPTION
## Summary
- `workato pull` はカスタムコネクタ参照レシピがあると `.custom_adapter.rb` / `.custom_adapter.json` をプロジェクト内に含める
- この古いファイルが `workato push` に含まれると、SDK push で更新したコネクタが巻き戻される
- `.workato-ignore` に `*.custom_adapter.rb` / `*.custom_adapter.json` を追加して push 対象から除外

## 再現手順
1. SDK push でカスタムコネクタ v1 作成
2. レシピ作成 → `workato push` → `workato pull`（`.custom_adapter.rb` v1 がローカルに）
3. SDK push でコネクタ v2（フィールド追加）
4. `workato push` → **v1 コードで v3 が作成・リリースされ v2 の変更が消失**

## 対策後の動作
- `.custom_adapter.rb` は pull 時にローカルに残る（参照用）
- push パッケージには含まれないため、SDK 側のコネクタ変更は保護される

## Test plan
- [x] SDK push 後に workato push → コネクタバージョンが巻き戻されないことを確認
- [x] workato pull で `.custom_adapter.rb` がローカルに残ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates ignore patterns for Workato CLI pushes; no runtime code or data-handling behavior changes.
> 
> **Overview**
> Prevents Workato project pushes from including pulled custom connector source by adding `*.custom_adapter.rb` and `*.custom_adapter.json` to `.workato-ignore`.
> 
> This avoids unintentionally reverting SDK-managed connector updates when running `workato push` after a `workato pull`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a18e813d0def5bff701ce923d526b0e5adf4d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->