### PR TITLE
Clarify sdk push method in CLI rules

### DIFF
--- a/.claude/rules/workato-cli.md
+++ b/.claude/rules/workato-cli.md
@@ -36,9 +36,10 @@ python3 scripts/workato-api.py <command>
 | `connectors list-platform [--provider <name>]` | Pre-built コネクタ情報 |
 | `connectors list-custom` | カスタムコネクタ一覧 |
 | `recipes list [--folder-id <id>]` | レシピ一覧（JSON） |
+| `sdk push --connector <path> [--connector-id <id>]` | カスタムコネクタ push（**推奨**） |
 | `profile show` | プロファイル解決結果 |
 
-## 3. Connector SDK CLI（カスタムコネクタ開発）
+## 3. Connector SDK CLI（カスタムコネクタ開発・ローカルテスト）
 
 インストール: `gem install workato-connector-sdk`
 
@@ -47,9 +48,21 @@ python3 scripts/workato-api.py <command>
 ```bash
 cd connectors/<name>
 bundle exec workato new <PATH>           # 新規作成
-bundle exec workato exec <PATH> test     # テスト
-bundle exec workato push <FOLDER>        # push
+bundle exec workato exec <PATH> test     # ローカルテスト
 ```
+
+### カスタムコネクタの push
+
+**API ヘルパーを使う（推奨）。** Ruby 不要、Platform CLI のプロファイルで認証。
+
+```bash
+# 新規作成
+python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --title "<Title>"
+# 既存コネクタの更新
+python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --connector-id <id>
+```
+
+> `bundle exec workato push` や `workato sdk push` も使えるが、API ヘルパーの方がプロファイル自動解決・リリース自動化の点で推奨。
 
 ## コネクタの分類
 

--- a/.cursor/rules/workato-cli.mdc
+++ b/.cursor/rules/workato-cli.mdc
@@ -35,9 +35,10 @@ python3 scripts/workato-api.py <command>
 | `connectors list-platform [--provider <name>]` | Pre-built コネクタ情報 |
 | `connectors list-custom` | カスタムコネクタ一覧 |
 | `recipes list [--folder-id <id>]` | レシピ一覧（JSON） |
+| `sdk push --connector <path> [--connector-id <id>]` | カスタムコネクタ push（**推奨**） |
 | `profile show` | プロファイル解決結果 |
 
-## 3. Connector SDK CLI（カスタムコネクタ開発）
+## 3. Connector SDK CLI（カスタムコネクタ開発・ローカルテスト）
 
 インストール: `gem install workato-connector-sdk`
 
@@ -46,9 +47,21 @@ python3 scripts/workato-api.py <command>
 ```bash
 cd connectors/<name>
 bundle exec workato new <PATH>           # 新規作成
-bundle exec workato exec <PATH> test     # テスト
-bundle exec workato push <FOLDER>        # push
+bundle exec workato exec <PATH> test     # ローカルテスト
 ```
+
+### カスタムコネクタの push
+
+**API ヘルパーを使う（推奨）。** Ruby 不要、Platform CLI のプロファイルで認証。
+
+```bash
+# 新規作成
+python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --title "<Title>"
+# 既存コネクタの更新
+python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --connector-id <id>
+```
+
+> `bundle exec workato push` や `workato sdk push` も使えるが、API ヘルパーの方がプロファイル自動解決・リリース自動化の点で推奨。
 
 ## コネクタの分類
 


### PR DESCRIPTION
## Summary
- API ヘルパーのコマンド表に `sdk push` を追加（以前は記載なし）
- Connector SDK CLI セクションを整理し、API ヘルパーの `sdk push` を推奨と明記
- `bundle exec workato push` はローカルテスト用として位置付け

AI がカスタムコネクタ push 時にヘルパースクリプトを選択しないケースへの対策。

## Test plan
- [ ] `/create-connector` スキルからコネクタ作成 → push 時に API ヘルパーが案内されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust recommended workflow and commands; no runtime or production code is modified.
> 
> **Overview**
> Updates the Workato CLI rules docs to **explicitly recommend** pushing custom connectors via the API helper by adding `sdk push` to the command table and documenting create/update examples.
> 
> Reframes the Connector SDK CLI section toward *local testing* (`bundle exec workato exec ... test`) and adds guidance noting alternative push commands exist but the API helper is preferred for profile auto-resolution and release automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a54726cbd13cca315841536ac94f6773d8327d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->