### PR TITLE
Run workato recipes validate in pre-push hook (#65)

### DIFF
--- a/.claude/hooks/validate-before-push.sh
+++ b/.claude/hooks/validate-before-push.sh
@@ -49,6 +49,7 @@ if [ -z "$PROJECT_DIR" ] || [ ! -d "$PROJECT_DIR" ]; then
 fi
 
 ERRORS=()
+ERROR_DETAILS=()
 WARNINGS=()
 
 # 1. Validate JSON syntax (blocking)
@@ -94,6 +95,56 @@ with open(os.environ['VALIDATE_FILE']) as f:
   fi
 done < <(find "$PROJECT_DIR" -type f -name "*.lcap_page.json" -print0 2>/dev/null)
 
+# 4. Run `workato recipes validate` per recipe (blocking, ~2s/file, with noise filter)
+if command -v workato >/dev/null 2>&1; then
+  RECIPE_FILES=()
+  while IFS= read -r -d '' file; do
+    # Skip files that already failed syntax check
+    base=$(basename "$file")
+    skip=0
+    for err in "${ERRORS[@]}"; do
+      case "$err" in *"$base"*) skip=1; break;; esac
+    done
+    [ $skip -eq 0 ] && RECIPE_FILES+=("$file")
+  done < <(find "$PROJECT_DIR" -type f -name "*.recipe.json" -print0 2>/dev/null)
+
+  if [ ${#RECIPE_FILES[@]} -gt 0 ]; then
+    echo "" >&2
+    echo "Running 'workato recipes validate' on ${#RECIPE_FILES[@]} recipe(s) (~2s each)..." >&2
+
+    NOISE_COUNT=0
+    for file in "${RECIPE_FILES[@]}"; do
+      base=$(basename "$file")
+      rel=$(VALIDATE_FILE="$file" VALIDATE_ROOT="$PROJECT_DIR" python3 -c "import os; print(os.path.relpath(os.environ['VALIDATE_FILE'], os.environ['VALIDATE_ROOT']))" 2>/dev/null)
+      [ -z "$rel" ] && rel="$file"
+
+      raw=$(cd "$PROJECT_DIR" && workato recipes validate --path "$rel" < /dev/null 2>&1)
+      clean=$(printf '%s' "$raw" | tr '\r' '\n' | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | grep -v "^[[:space:]]*$" | grep -v "^[[:space:]]*⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏" | grep -Ev "Validating recipe:.*\([0-9.]+s\)")
+
+      if ! printf '%s' "$clean" | grep -q "Validation failed"; then
+        continue
+      fi
+
+      # Noise filter: workspace-level pre-check fails when any custom connector
+      # in the workspace has `latest_released_version = null` (not yet released).
+      # This short-circuits recipe-level validation regardless of the recipe's own
+      # contents, so we can't extract real format errors. Aggregate into a single
+      # warning rather than spamming one per recipe.
+      if printf '%s' "$clean" | grep -q "CustomConnector" && printf '%s' "$clean" | grep -q "latest_released_version"; then
+        NOISE_COUNT=$((NOISE_COUNT + 1))
+        continue
+      fi
+
+      ERRORS+=("CLI validation failed: $base")
+      ERROR_DETAILS+=("$clean")
+    done
+
+    if [ $NOISE_COUNT -gt 0 ]; then
+      WARNINGS+=("CLI validate skipped for $NOISE_COUNT recipe(s): workspace has unreleased custom connector(s). Release with 'workato sdk push' to enable deeper validation.")
+    fi
+  fi
+fi
+
 # Show warnings (non-blocking)
 if [ ${#WARNINGS[@]} -gt 0 ]; then
   echo "" >&2
@@ -107,8 +158,11 @@ fi
 if [ ${#ERRORS[@]} -gt 0 ]; then
   echo "" >&2
   echo "=== Pre-push validation FAILED ===" >&2
-  for err in "${ERRORS[@]}"; do
-    echo "  ❌ $err" >&2
+  for i in "${!ERRORS[@]}"; do
+    echo "  ❌ ${ERRORS[$i]}" >&2
+    if [ -n "${ERROR_DETAILS[$i]:-}" ]; then
+      printf '%s\n' "${ERROR_DETAILS[$i]}" | sed 's/^/      /' >&2
+    fi
   done
   echo "" >&2
   echo "Fix errors above before pushing." >&2

--- a/.claude/hooks/validate-before-push.sh
+++ b/.claude/hooks/validate-before-push.sh
@@ -99,11 +99,13 @@ done < <(find "$PROJECT_DIR" -type f -name "*.lcap_page.json" -print0 2>/dev/nul
 if command -v workato >/dev/null 2>&1; then
   RECIPE_FILES=()
   while IFS= read -r -d '' file; do
-    # Skip files that already failed syntax check
+    # Skip files that already failed syntax check (exact match on the known
+    # error message produced by step 1 to avoid basename substring collisions
+    # like "broken.recipe.json" vs "really-broken.recipe.json").
     base=$(basename "$file")
     skip=0
     for err in "${ERRORS[@]}"; do
-      case "$err" in *"$base"*) skip=1; break;; esac
+      [ "$err" = "JSON syntax error: $base" ] && skip=1 && break
     done
     [ $skip -eq 0 ] && RECIPE_FILES+=("$file")
   done < <(find "$PROJECT_DIR" -type f -name "*.recipe.json" -print0 2>/dev/null)
@@ -121,22 +123,31 @@ if command -v workato >/dev/null 2>&1; then
       raw=$(cd "$PROJECT_DIR" && workato recipes validate --path "$rel" < /dev/null 2>&1)
       clean=$(printf '%s' "$raw" | tr '\r' '\n' | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | grep -v "^[[:space:]]*$" | grep -v "^[[:space:]]*⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏" | grep -Ev "Validating recipe:.*\([0-9.]+s\)")
 
-      if ! printf '%s' "$clean" | grep -q "Validation failed"; then
+      # Explicit success marker — anything else needs classification below.
+      if printf '%s' "$clean" | grep -qE "Validation passed|✅"; then
         continue
       fi
 
-      # Noise filter: workspace-level pre-check fails when any custom connector
-      # in the workspace has `latest_released_version = null` (not yet released).
-      # This short-circuits recipe-level validation regardless of the recipe's own
-      # contents, so we can't extract real format errors. Aggregate into a single
-      # warning rather than spamming one per recipe.
-      if printf '%s' "$clean" | grep -q "CustomConnector" && printf '%s' "$clean" | grep -q "latest_released_version"; then
-        NOISE_COUNT=$((NOISE_COUNT + 1))
+      if printf '%s' "$clean" | grep -q "Validation failed"; then
+        # Noise filter: workspace-level pre-check fails when any custom connector
+        # in the workspace has `latest_released_version = null` (not yet released).
+        # This short-circuits recipe-level validation regardless of the recipe's own
+        # contents, so we can't extract real format errors. Aggregate into a single
+        # warning rather than spamming one per recipe.
+        if printf '%s' "$clean" | grep -q "CustomConnector" && printf '%s' "$clean" | grep -q "latest_released_version"; then
+          NOISE_COUNT=$((NOISE_COUNT + 1))
+          continue
+        fi
+        ERRORS+=("CLI validation failed: $base")
+        ERROR_DETAILS+=("$clean")
         continue
       fi
 
-      ERRORS+=("CLI validation failed: $base")
-      ERROR_DETAILS+=("$clean")
+      # Unexpected output — neither pass nor fail marker. Likely auth/network
+      # failure, CLI version change, or empty output. Surface as a warning so
+      # the user can investigate instead of silently treating as success.
+      snippet=$(printf '%s' "$clean" | tr '\n' ' ' | tail -c 200)
+      WARNINGS+=("CLI validate inconclusive for $base (no pass/fail marker). Tail: ${snippet:-<empty>}")
     done
 
     if [ $NOISE_COUNT -gt 0 ]; then

--- a/.claude/skills/wpush/SKILL.md
+++ b/.claude/skills/wpush/SKILL.md
@@ -64,6 +64,14 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
   push しても選択肢の値が保存されません。UI で設定するか、JSON で dataSource を定義してください。
 ```
 
+#### 1d. Workato CLI recipes validate（ブロッキング）
+
+`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+- **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
+- **失敗時**: エラー詳細を表示して push を中断（exit 2）
+- **ワークスペース制約（警告扱い）**: workspace に未リリースのカスタムコネクタがあると CLI 側の pre-check が先に失敗し、レシピ本体の検証まで到達できない。この場合は「CLI validate skipped for N recipe(s): ... Release with 'workato sdk push' to enable deeper validation.」という警告が出るのみで push は通す。deeper validation を有効にするには `workato sdk push` で連携対象のカスタムコネクタを release する
+
 ### 2. 新規コネクションの検出
 
 push 前にプロジェクト内の `.connection.json` ファイルを確認し、Workato リモートにまだ存在しない新規コネクションがあるか検出する。

--- a/.cursor/skills/wpush/SKILL.md
+++ b/.cursor/skills/wpush/SKILL.md
@@ -64,6 +64,14 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
   push しても選択肢の値が保存されません。UI で設定するか、JSON で dataSource を定義してください。
 ```
 
+#### 1d. Workato CLI recipes validate（ブロッキング）
+
+`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+- **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
+- **失敗時**: エラー詳細を表示して push を中断（exit 2）
+- **ワークスペース制約（警告扱い）**: workspace に未リリースのカスタムコネクタがあると CLI 側の pre-check が先に失敗し、レシピ本体の検証まで到達できない。この場合は「CLI validate skipped for N recipe(s): ... Release with 'workato sdk push' to enable deeper validation.」という警告が出るのみで push は通す。deeper validation を有効にするには `workato sdk push` で連携対象のカスタムコネクタを release する
+
 ### 2. 新規コネクションの検出
 
 push 前にプロジェクト内の `.connection.json` ファイルを確認し、Workato リモートにまだ存在しない新規コネクションがあるか検出する。


### PR DESCRIPTION
## Summary

- `.claude/hooks/validate-before-push.sh` が `workato push` を検知したときに `workato recipes validate --path <file>` を全 `*.recipe.json` に対して実行
- CLI の workspace-level pre-check が未リリースのカスタムコネクタに反応して全レシピ検証を短絡させる挙動をノイズとして判定し、push ごとに N レシピ分の重複警告を出すのではなく 1 本に集約
- ノイズ検出時は警告のみで push は継続（開発中のカスタムコネクタが release されるまで関係ないレシピの push を塞がない設計）
- 非ノイズの validation failed は詳細ログ付きで push をブロック (exit 2)
- `/wpush` SKILL.md に 1d 項目として追記、Cursor 側にも同期

Closes #65

## Implementation notes

- `workato recipes validate` は 1 ファイル ~2 秒、直列。大規模プロジェクトの push 前に待ち時間が生まれる点は割り切り
- `workato recipes validate` は失敗時も exit 0 を返すバグがあるため stdout を `"Validation failed"` でマッチさせて判定
- CLI のスピナー出力は `tr '\r' '\n'` で分割 + ANSI escape を sed で除去
- ワークスペースに未リリースのカスタムコネクタがある限り CLI pre-check が短絡するため、本当の意味での「フォーマット不備早期検出」は connector を release してからになる点をドキュメントに明記

## Test plan

- [x] `[App] IT Onboarding` で実行 → 未リリースコネクタ由来のノイズが 1 本の warning に集約されることを確認
- [x] JSON syntax 壊れファイルで実行 → 従来どおり exit 2 でブロック
- [x] `workato push` を含まないコマンドで実行 → 即 exit 0（fast-exit 維持）
- [ ] bugbot レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a blocking pre-push step that shells out to the Workato CLI for every recipe, increasing push latency and introducing dependency on CLI output parsing/availability.
> 
> **Overview**
> **Pre-push validation is strengthened for Workato recipes.** When a `workato push` is detected, the hook now runs `workato recipes validate` for each `*.recipe.json`, filters spinner/ANSI noise, and blocks the push with detailed CLI output when validation fails.
> 
> **Workspace-level false failures are de-noised.** If validation fails due to unreleased custom connectors (the `latest_released_version = null` pre-check), failures are aggregated into a single warning so unrelated recipe pushes can proceed; docs in both `/wpush` skill guides are updated to describe this behavior and expected runtime (~2s/recipe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982cb3c184406f29e8b24b3304a2ffabc2d348b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->