### PR TITLE
Auto-detect new vs update in sdk push (#62)

### DIFF
--- a/.claude/skills/create-connector/SKILL.md
+++ b/.claude/skills/create-connector/SKILL.md
@@ -80,10 +80,25 @@ api_key: YOUR_API_KEY
 
 ```ruby
 source 'https://rubygems.org'
+
 gem 'workato-connector-sdk'
-gem 'rspec'
-gem 'vcr'
-gem 'webmock'
+
+# Ruby 3.4+ で default gems から外れた stdlib。
+# `LoadError: cannot load such file -- csv` 等を避けるため明示する。
+# 詳細: docs/connector-sdk/overview.md「Ruby 4.0 では default gems が外れている」
+gem 'csv'
+gem 'base64'
+gem 'bigdecimal'
+gem 'logger'
+gem 'drb'
+gem 'ostruct'
+gem 'mutex_m'
+
+group :test do
+  gem 'rspec'
+  gem 'vcr'
+  gem 'webmock'
+end
 ```
 
 ## .gitignore テンプレート
@@ -103,17 +118,26 @@ settings.yaml.enc
 - コネクタの構成サマリー（認証方式、アクション数、トリガー数）
 - 次のステップ:
   1. `settings.yaml` に認証情報を設定（ローカルテスト用）
-  2. テスト（Ruby gem CLI）:
+  2. テスト（Ruby gem CLI, 任意）:
      ```bash
      cd connectors/<name>
      bundle install                              # 初回のみ
-     bundle exec workato exec connector.rb test  # テスト
+     bundle exec workato exec connector.rb test  # テスト（settings.yaml に実認証情報が必要）
      ```
      > **Note**: `bundle exec workato` を使うのは、Platform CLI と `workato` コマンド名が競合するため
   3. Workato へアップロード（API ヘルパー — Ruby 不要、Platform CLI のプロファイルで認証）:
      ```bash
-     # 新規作成
-     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --title "<Title>"
-     # 既存コネクタの更新
-     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --connector-id <id>
+     # 初回も更新も同じコマンドで OK。
+     # 初回は新規作成し、返ってきた connector_id を
+     # connectors/docs/<name>.md の YAML フロントマターに保存する。
+     # 2 回目以降は frontmatter の connector_id を読んで自動で更新 push する。
+     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb
      ```
+     - 明示的に新規作成したい場合は `--title "<Title>"` を付ける（frontmatter に ID が無い場合のみ）
+     - 明示的に特定 ID を更新したい場合は `--connector-id <id>` を付ける（frontmatter より優先）
+  4. docs の本体（トリガー/アクション/フィールド）を埋める:
+     ```
+     /sync-connectors --custom <name>
+     ```
+     初回 push 後、`connectors/docs/<name>.md` はフロントマター + スタブだけの状態になる。
+     `/sync-connectors` が `connector.rb` をパースして本文を埋める（フロントマターは保持される）。

--- a/.claude/skills/sync-connectors/SKILL.md
+++ b/.claude/skills/sync-connectors/SKILL.md
@@ -99,7 +99,14 @@ ls connectors/*/connector.rb 2>/dev/null
 
 3. `connectors/docs/<name>.md` を作成または更新:
 
+   **フロントマター保持のルール**: ファイル先頭に `---` で囲まれた YAML フロントマター（`connector_id:` など）がある場合は **必ずそのまま保持** する。
+   `sdk push` が書き込んだ情報（connector_id 等）を書き換えたり消したりしないこと。
+
 ```markdown
+---
+connector_id: <id>   # sdk push が自動管理
+---
+
 # <Title> コネクタ
 
 Provider: `<name>`
@@ -173,6 +180,7 @@ Provider: `<name>`
 - **更新**: 既存ファイルがある場合:
   - API から取得したトリガー/アクションと比較
   - 新しいものがあれば追加
+  - **フロントマター（`---` で囲まれた YAML ブロック）は必ず保持** する。`connector_id` などは `sdk push` が自動管理しているため、絶対に書き換えない
   - `## フィールド詳細` 以降のセクション（/learn-recipe で蓄積した情報）は保持
   - deprecated フラグが立ったものに注記を追加
 - **provider 名の確定**: API の `name` フィールドが正式な provider 名

--- a/.cursor/skills/create-connector/SKILL.md
+++ b/.cursor/skills/create-connector/SKILL.md
@@ -80,10 +80,25 @@ api_key: YOUR_API_KEY
 
 ```ruby
 source 'https://rubygems.org'
+
 gem 'workato-connector-sdk'
-gem 'rspec'
-gem 'vcr'
-gem 'webmock'
+
+# Ruby 3.4+ で default gems から外れた stdlib。
+# `LoadError: cannot load such file -- csv` 等を避けるため明示する。
+# 詳細: docs/connector-sdk/overview.md「Ruby 4.0 では default gems が外れている」
+gem 'csv'
+gem 'base64'
+gem 'bigdecimal'
+gem 'logger'
+gem 'drb'
+gem 'ostruct'
+gem 'mutex_m'
+
+group :test do
+  gem 'rspec'
+  gem 'vcr'
+  gem 'webmock'
+end
 ```
 
 ## .gitignore テンプレート
@@ -103,17 +118,26 @@ settings.yaml.enc
 - コネクタの構成サマリー（認証方式、アクション数、トリガー数）
 - 次のステップ:
   1. `settings.yaml` に認証情報を設定（ローカルテスト用）
-  2. テスト（Ruby gem CLI）:
+  2. テスト（Ruby gem CLI, 任意）:
      ```bash
      cd connectors/<name>
      bundle install                              # 初回のみ
-     bundle exec workato exec connector.rb test  # テスト
+     bundle exec workato exec connector.rb test  # テスト（settings.yaml に実認証情報が必要）
      ```
      > **Note**: `bundle exec workato` を使うのは、Platform CLI と `workato` コマンド名が競合するため
   3. Workato へアップロード（API ヘルパー — Ruby 不要、Platform CLI のプロファイルで認証）:
      ```bash
-     # 新規作成
-     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --title "<Title>"
-     # 既存コネクタの更新
-     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --connector-id <id>
+     # 初回も更新も同じコマンドで OK。
+     # 初回は新規作成し、返ってきた connector_id を
+     # connectors/docs/<name>.md の YAML フロントマターに保存する。
+     # 2 回目以降は frontmatter の connector_id を読んで自動で更新 push する。
+     python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb
      ```
+     - 明示的に新規作成したい場合は `--title "<Title>"` を付ける（frontmatter に ID が無い場合のみ）
+     - 明示的に特定 ID を更新したい場合は `--connector-id <id>` を付ける（frontmatter より優先）
+  4. docs の本体（トリガー/アクション/フィールド）を埋める:
+     ```
+     /sync-connectors --custom <name>
+     ```
+     初回 push 後、`connectors/docs/<name>.md` はフロントマター + スタブだけの状態になる。
+     `/sync-connectors` が `connector.rb` をパースして本文を埋める（フロントマターは保持される）。

--- a/.cursor/skills/sync-connectors/SKILL.md
+++ b/.cursor/skills/sync-connectors/SKILL.md
@@ -99,7 +99,12 @@ ls connectors/*/connector.rb 2>/dev/null
 
 3. `connectors/docs/<name>.md` を作成または更新:
 
+   **フロントマター保持のルール**: ファイル先頭に `---` で囲まれた YAML フロントマター（`connector_id:` など）がある場合は **必ずそのまま保持** する。
+   `sdk push` が書き込んだ情報（connector_id 等）を書き換えたり消したりしないこと。
+
 ```markdown
+connector_id: <id>   # sdk push が自動管理
+
 # <Title> コネクタ
 
 Provider: `<name>`
@@ -173,6 +178,7 @@ Provider: `<name>`
 - **更新**: 既存ファイルがある場合:
   - API から取得したトリガー/アクションと比較
   - 新しいものがあれば追加
+  - **フロントマター（`---` で囲まれた YAML ブロック）は必ず保持** する。`connector_id` などは `sdk push` が自動管理しているため、絶対に書き換えない
   - `## フィールド詳細` 以降のセクション（/learn-recipe で蓄積した情報）は保持
   - deprecated フラグが立ったものに注記を追加
 - **provider 名の確定**: API の `name` フィールドが正式な provider 名

--- a/.cursor/skills/sync-connectors/SKILL.md
+++ b/.cursor/skills/sync-connectors/SKILL.md
@@ -103,7 +103,9 @@ ls connectors/*/connector.rb 2>/dev/null
    `sdk push` が書き込んだ情報（connector_id 等）を書き換えたり消したりしないこと。
 
 ```markdown
+---
 connector_id: <id>   # sdk push が自動管理
+---
 
 # <Title> コネクタ
 

--- a/scripts/sync-cursor-rules.sh
+++ b/scripts/sync-cursor-rules.sh
@@ -21,9 +21,14 @@ CURSOR_SKILLS="$REPO_ROOT/.cursor/skills"
 mkdir -p "$CURSOR_RULES" "$CURSOR_SKILLS"
 
 # --- ルール: description をファイルの最初の # 見出しから自動生成 ---
+#
+# frontmatter の終端検出は、行頭 "---" を2回数える方式。
+# ただしコードフェンス (```) 内の "---" は YAML frontmatter の例として
+# 本文に書くケースがあるため、フェンス状態を追跡して区切り扱いしない。
 get_description() {
   awk '
-    /^---$/ { fm++; next }
+    /^```/ { fence = !fence; next }
+    !fence && /^---$/ { fm++; next }
     fm >= 2 && /^# / {
       sub(/^# */, "")
       print
@@ -48,6 +53,7 @@ for claude_file in "$CLAUDE_RULES"/*.md; do
   fi
 
   # Claude フロントマターから paths を抽出してカンマ区切りに変換
+  # (frontmatter block 内には code fence は出ないので fence 追跡不要)
   globs=$(awk '
     /^---$/ { fm++; next }
     fm == 1 && /^  - "/ {
@@ -59,8 +65,10 @@ for claude_file in "$CLAUDE_RULES"/*.md; do
   ' "$claude_file")
 
   # フロントマター以降の本文を抽出
+  # コードフェンス内の "---" は frontmatter 区切りではないので無視
   body=$(awk '
-    /^---$/ { fm++; next }
+    fm >= 2 && /^```/ { fence = !fence; print; next }
+    !fence && /^---$/ { fm++; next }
     fm >= 2 { print }
   ' "$claude_file")
 
@@ -93,6 +101,7 @@ for skill_dir in "$CLAUDE_SKILLS"/*/; do
   mkdir -p "$cursor_skill_dir"
 
   # フロントマターのフィールドを抽出
+  # (frontmatter block 内には code fence は出ないので fence 追跡不要)
   desc=$(awk '
     /^---$/ { fm++; next }
     fm == 1 && /^description:/ {
@@ -111,8 +120,10 @@ for skill_dir in "$CLAUDE_SKILLS"/*/; do
 
   # フロントマター以降の本文を抽出し、ファイル参照パスを変換
   # Note: /skill-name は Cursor でも同じなので変換不要
+  # コードフェンス内の "---" は frontmatter 区切りではないので無視
   body=$(awk '
-    /^---$/ { fm++; next }
+    fm >= 2 && /^```/ { fence = !fence; print; next }
+    !fence && /^---$/ { fm++; next }
     fm >= 2 { print }
   ' "$skill_file" | sed \
     -e 's|@docs/|docs/|g' \

--- a/scripts/tests/test_sdk_push_frontmatter.py
+++ b/scripts/tests/test_sdk_push_frontmatter.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Regression tests for the connector-docs frontmatter helpers in
+`scripts/workato-api.py` that back `sdk push` auto-detect/persist.
+
+Run with:
+    python3 scripts/tests/test_sdk_push_frontmatter.py
+
+Intentionally stdlib-only and importlib-based so CI doesn't need a test
+runner or the script on sys.path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+def _tmp_connector_rb(tmp: Path, name: str = "foo") -> Path:
+    """Create `<tmp>/connectors/<name>/connector.rb` and return its path."""
+    rb = tmp / "connectors" / name / "connector.rb"
+    rb.parent.mkdir(parents=True)
+    rb.write_text("{ title: 'Foo' }\n")
+    return rb
+
+
+def test_read_frontmatter_missing_file():
+    with tempfile.TemporaryDirectory() as d:
+        fm, body = wa._read_frontmatter(Path(d) / "nope.md")
+        assert fm == {} and body == ""
+
+
+def test_read_frontmatter_no_fm():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "f.md"
+        p.write_text("# Hello\n\nbody\n")
+        fm, body = wa._read_frontmatter(p)
+        assert fm == {}
+        assert "# Hello" in body
+
+
+def test_read_frontmatter_parses_flat_kv():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "f.md"
+        p.write_text("---\nconnector_id: 42\ntitle: Foo\n---\n\n# Hello\n")
+        fm, body = wa._read_frontmatter(p)
+        assert fm == {"connector_id": "42", "title": "Foo"}
+        assert "# Hello" in body
+
+
+def test_write_frontmatter_creates_stub_when_missing():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "docs" / "my_conn.md"
+        wa._write_frontmatter(p, {"connector_id": "99"}, connector_name="my_conn")
+        text = p.read_text()
+        assert text.startswith("---\nconnector_id: 99\n---\n")
+        assert "my_conn コネクタ" in text
+
+
+def test_write_frontmatter_preserves_body_on_update():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "f.md"
+        p.write_text("---\nconnector_id: 1\n---\n\n# Body\nStuff\n")
+        fm, _ = wa._read_frontmatter(p)
+        fm["connector_id"] = "2"
+        wa._write_frontmatter(p, fm)
+        text = p.read_text()
+        assert "connector_id: 2" in text
+        assert "# Body" in text
+        assert "Stuff" in text
+
+
+def test_write_frontmatter_does_not_duplicate_when_body_empty():
+    # Regression: a file containing only frontmatter (no body) previously
+    # re-read raw text as the body, producing two `---` blocks.
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "f.md"
+        p.write_text("---\nconnector_id: 123\n---\n")
+        fm, _ = wa._read_frontmatter(p)
+        fm["connector_id"] = "456"
+        wa._write_frontmatter(p, fm)
+        text = p.read_text()
+        assert text.count("---\n") == 2, f"expected 2 `---` lines, got:\n{text}"
+        assert "connector_id: 456" in text
+        assert "connector_id: 123" not in text
+
+
+def test_connector_docs_path_layout():
+    with tempfile.TemporaryDirectory() as d:
+        rb = _tmp_connector_rb(Path(d), "my_conn")
+        expected = (Path(d) / "connectors" / "docs" / "my_conn.md").resolve()
+        assert wa._connector_docs_path(rb) == expected
+
+
+def test_resolve_connector_id_no_docs_returns_none():
+    with tempfile.TemporaryDirectory() as d:
+        rb = _tmp_connector_rb(Path(d))
+        rid, dp = wa._resolve_connector_id(rb, None)
+        assert rid is None
+        assert dp == (Path(d) / "connectors" / "docs" / "foo.md").resolve()
+
+
+def test_resolve_connector_id_reads_frontmatter():
+    with tempfile.TemporaryDirectory() as d:
+        rb = _tmp_connector_rb(Path(d))
+        docs = Path(d) / "connectors" / "docs"
+        docs.mkdir()
+        (docs / "foo.md").write_text("---\nconnector_id: 123\n---\n# Foo\n")
+        rid, _ = wa._resolve_connector_id(rb, None)
+        assert rid == 123
+
+
+def test_resolve_connector_id_explicit_wins():
+    with tempfile.TemporaryDirectory() as d:
+        rb = _tmp_connector_rb(Path(d))
+        docs = Path(d) / "connectors" / "docs"
+        docs.mkdir()
+        (docs / "foo.md").write_text("---\nconnector_id: 123\n---\n")
+        rid, _ = wa._resolve_connector_id(rb, 999)
+        assert rid == 999
+
+
+def test_resolve_connector_id_non_integer_warns_and_degrades():
+    with tempfile.TemporaryDirectory() as d:
+        rb = _tmp_connector_rb(Path(d))
+        docs = Path(d) / "connectors" / "docs"
+        docs.mkdir()
+        (docs / "foo.md").write_text("---\nconnector_id: abc\n---\n")
+        saved = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rid, _ = wa._resolve_connector_id(rb, None)
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = saved
+        assert rid is None
+        assert "not an integer" in err
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -653,15 +653,9 @@ def _read_frontmatter(md_path: Path) -> tuple[dict, str]:
         return {}, text
     end = text.find("\n---\n", 4)
     if end == -1:
-        # Trailing form: `---` at the very end of file
-        end_trailing = text.find("\n---", 4)
-        if end_trailing == -1 or end_trailing != len(text) - 4:
-            return {}, text
-        fm_text = text[4:end_trailing]
-        body = ""
-    else:
-        fm_text = text[4:end]
-        body = text[end + len("\n---\n"):]
+        return {}, text
+    fm_text = text[4:end]
+    body = text[end + len("\n---\n"):]
 
     fm: dict = {}
     for line in fm_text.splitlines():
@@ -685,8 +679,6 @@ def _write_frontmatter(md_path: Path, fm: dict, connector_name: str | None = Non
 
     if md_path.exists():
         _existing_fm, body = _read_frontmatter(md_path)
-        if not body:
-            body = md_path.read_text()
     else:
         name = connector_name or md_path.stem
         body = (

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -16,6 +16,8 @@ Usage:
   python3 scripts/workato-api.py connectors list-custom
   python3 scripts/workato-api.py recipes list [--folder-id <id>]
   python3 scripts/workato-api.py sdk push --connector <path> [--title <t>]
+    (auto-detects new vs. update by reading connector_id from
+     connectors/docs/<name>.md frontmatter; saves ID back after initial create)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
   python3 scripts/workato-api.py profile show
@@ -620,6 +622,112 @@ def _resolve_key_path(key_arg: str | None, enc_file: Path) -> Path:
     return enc_file.parent / "master.key"
 
 
+# ---------------------------------------------------------------------------
+# Connector docs frontmatter (for connector_id persistence)
+#
+# `connectors/docs/<name>.md` holds a YAML-ish frontmatter block that records
+# the Workato connector ID after a successful push. Subsequent pushes read
+# it back so the user does not need to remember `--connector-id`.
+# Only flat `key: value` pairs are supported (no nested structures).
+# ---------------------------------------------------------------------------
+
+
+def _connector_docs_path(connector_rb_path: Path) -> Path:
+    """Return `connectors/docs/<name>.md` derived from the connector.rb path.
+
+    `<name>` is the basename of the connector.rb's parent directory, and the
+    docs dir is a sibling of that parent (i.e. `connectors/docs/`).
+    """
+    connector_dir = connector_rb_path.resolve().parent
+    name = connector_dir.name
+    docs_dir = connector_dir.parent / "docs"
+    return docs_dir / f"{name}.md"
+
+
+def _read_frontmatter(md_path: Path) -> tuple[dict, str]:
+    """Parse top-of-file YAML-ish frontmatter. Returns (fm_dict, body)."""
+    if not md_path.exists():
+        return {}, ""
+    text = md_path.read_text()
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        # Trailing form: `---` at the very end of file
+        end_trailing = text.find("\n---", 4)
+        if end_trailing == -1 or end_trailing != len(text) - 4:
+            return {}, text
+        fm_text = text[4:end_trailing]
+        body = ""
+    else:
+        fm_text = text[4:end]
+        body = text[end + len("\n---\n"):]
+
+    fm: dict = {}
+    for line in fm_text.splitlines():
+        line = line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        fm[k.strip()] = v.strip()
+    return fm, body
+
+
+def _write_frontmatter(md_path: Path, fm: dict, connector_name: str | None = None):
+    """Write/update frontmatter at top of `md_path`.
+
+    Creates a minimal stub body if the file doesn't exist yet so the
+    frontmatter has somewhere to live.
+    """
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if md_path.exists():
+        _existing_fm, body = _read_frontmatter(md_path)
+        if not body:
+            body = md_path.read_text()
+    else:
+        name = connector_name or md_path.stem
+        body = (
+            f"# {name} コネクタ\n\n"
+            f"Provider: `{name}`\n"
+            f"Source: Custom (Connector SDK)\n\n"
+            f"> `/sync-connectors --custom {name}` を実行して "
+            f"トリガー/アクション/フィールド情報を反映してください。\n"
+        )
+
+    fm_lines = "\n".join(f"{k}: {v}" for k, v in fm.items())
+    md_path.write_text(f"---\n{fm_lines}\n---\n\n{body.lstrip()}")
+
+
+def _resolve_connector_id(
+    connector_rb_path: Path, explicit_id: int | None
+) -> tuple[int | None, Path]:
+    """Decide which connector ID to use for this push.
+
+    Returns `(id_or_None, docs_path)`. Explicit `--connector-id` wins;
+    otherwise the frontmatter of `connectors/docs/<name>.md` is consulted.
+    """
+    docs_path = _connector_docs_path(connector_rb_path)
+    if explicit_id is not None:
+        return explicit_id, docs_path
+
+    fm, _ = _read_frontmatter(docs_path)
+    raw = fm.get("connector_id")
+    if not raw:
+        return None, docs_path
+    try:
+        return int(raw), docs_path
+    except ValueError:
+        print(
+            f"Warning: connector_id in {docs_path} is not an integer ('{raw}'); "
+            "treating as new connector.",
+            file=sys.stderr,
+        )
+        return None, docs_path
+
+
 def cmd_sdk_push(api: WorkatoAPI, args: argparse.Namespace):
     connector_path = Path(args.connector)
     if not connector_path.exists():
@@ -634,19 +742,69 @@ def cmd_sdk_push(api: WorkatoAPI, args: argparse.Namespace):
         match = re.search(r"title:\s*['\"](.+?)['\"]", source_code)
         title = match.group(1) if match else connector_path.parent.name
 
+    resolved_id, docs_path = _resolve_connector_id(connector_path, args.connector_id)
+    is_update = resolved_id is not None
+
+    try:
+        display_docs = docs_path.relative_to(Path.cwd())
+    except ValueError:
+        display_docs = docs_path
+
+    if is_update:
+        if args.connector_id is not None:
+            print(f"Updating connector id={resolved_id} (--connector-id)", file=sys.stderr)
+        else:
+            print(
+                f"Updating connector id={resolved_id} "
+                f"(from {display_docs} frontmatter)",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"Creating new connector '{title}' "
+            f"(no connector_id found in {display_docs})",
+            file=sys.stderr,
+        )
+
     result = api.sdk_push(
         source_code=source_code,
         title=title,
-        connector_id=args.connector_id,
+        connector_id=resolved_id,
         description=args.description,
         notes=args.notes,
         no_release=args.no_release,
     )
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
-    action = "Updated" if args.connector_id else "Created"
-    cid = result.get("id", "?")
-    print(f"\n{action} connector: {result.get('title', title)} (id={cid})", file=sys.stderr)
+    returned_id = result.get("id") if isinstance(result, dict) else None
+    final_id = resolved_id if resolved_id is not None else returned_id
+
+    action = "Updated" if is_update else "Created"
+    print(
+        f"\n{action} connector: {result.get('title', title)} (id={final_id or '?'})",
+        file=sys.stderr,
+    )
+
+    # Persist connector_id to docs frontmatter on first successful push
+    # (or if the docs file did not yet record the ID for some reason).
+    if final_id is not None and not args.skip_save_id:
+        fm, _ = _read_frontmatter(docs_path)
+        existing = fm.get("connector_id")
+        if existing != str(final_id):
+            fm["connector_id"] = str(final_id)
+            _write_frontmatter(docs_path, fm, connector_name=connector_path.parent.name)
+            if existing is None:
+                print(
+                    f"Saved connector_id={final_id} to "
+                    f"{docs_path} (next push will update in place)",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"Updated connector_id in {docs_path} "
+                    f"({existing} -> {final_id})",
+                    file=sys.stderr,
+                )
 
 
 def cmd_sdk_decrypt(_api: WorkatoAPI, args: argparse.Namespace):
@@ -815,6 +973,11 @@ def main():
     sdk_push_p.add_argument("--notes", default=None, help="Release notes")
     sdk_push_p.add_argument(
         "--no-release", action="store_true", help="Upload without releasing"
+    )
+    sdk_push_p.add_argument(
+        "--skip-save-id", action="store_true",
+        help="Don't persist the returned connector_id to "
+             "connectors/docs/<name>.md frontmatter",
     )
 
     sdk_decrypt_p = sdk_sub.add_parser(


### PR DESCRIPTION
## Summary

Address the high-value parts of #62: remove the manual `--title` / `--connector-id` juggling when pushing custom connectors, and update the scaffold Gemfile so new connectors run on Ruby 3.4+ out of the box. The issue's auto-test and git-add proposals are intentionally left out — test requires real auth in `settings.yaml` so it'd fail on first run, and auto git-add risks catching `master.key` / `settings.yaml`.

## What changed

- **`scripts/workato-api.py sdk push`** — reads/writes `connector_id` in the YAML frontmatter of `connectors/docs/<name>.md`, so the same command now works for both initial create and subsequent updates
  - Explicit `--connector-id` still wins; `--skip-save-id` opts out of persistence
  - Non-integer frontmatter → warning + treat as new
  - Docs file doesn't exist yet → emit a minimal stub that points at `/sync-connectors`
- **`/create-connector` Gemfile template** — add `csv`, `base64`, `bigdecimal`, `logger`, `drb`, `ostruct`, `mutex_m` (Ruby 3.4+ removed these from bundled gems, cross-ref `docs/connector-sdk/overview.md`)
- **`/create-connector` "next steps"** — rewrite the push section to reflect the one-command flow and point to `/sync-connectors --custom <name>` for populating the docs body
- **`/sync-connectors`** — require any `---` frontmatter block to be preserved on regeneration, so we never clobber the persisted `connector_id`
- `.cursor/` mirrors synced via `scripts/sync-cursor-rules.sh`

## Test plan

- [x] Smoke-tested `_read_frontmatter` / `_write_frontmatter` / `_resolve_connector_id` (no frontmatter, with frontmatter, round-trip update, explicit ID override, invalid ID warning, stub creation)
- [x] `python3 scripts/workato-api.py sdk push --help` still parses and shows `--skip-save-id`
- [ ] End-to-end against a real workspace — push a fresh connector, confirm `connectors/docs/<name>.md` gets `connector_id: <N>`, re-push and confirm it updates in place. (Requires live Workato credentials; recommend manual verification before merge.)

Closes #62 for the scoped-down items. Worth a follow-up issue if we decide to also automate the `settings.yaml` setup / API-key retrieval flow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `sdk push` behavior to infer update vs create and to write `connector_id` into `connectors/docs` files, which can affect existing connector deployment workflows if docs/frontmatter are malformed or paths differ.
> 
> **Overview**
> **`scripts/workato-api.py sdk push` now auto-detects create vs update** by reading `connector_id` from `connectors/docs/<name>.md` YAML frontmatter, and persists the returned ID back to that file (with `--connector-id` overriding and `--skip-save-id` to opt out). It also creates a minimal stub docs file when missing and warns/falls back to “create new” on non-integer frontmatter.
> 
> Documentation/scaffolding is updated to match this one-command flow: the `/create-connector` Gemfile template now explicitly includes stdlib gems needed for Ruby 3.4+ and the next-steps guidance points to `/sync-connectors --custom` while requiring doc regeneration to **preserve frontmatter**. `scripts/sync-cursor-rules.sh` is hardened to ignore `---` inside code fences when parsing frontmatter, and a stdlib-only regression test script is added for the new frontmatter helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdd2fd1d04808f7943bfb2d221f05c64c782f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->