### PR TITLE
Add /auto-learn skill for autonomous connector field collection (Issue #27)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -125,5 +125,5 @@ Workato には「API Client」という名前の似て非なる 4 系統（Devel
 | `/learn-recipe` | レシピからフィールド情報を学習しドキュメントに反映 |
 | `/learn-pattern` | レシピから構築パターンを抽出しカタログに蓄積 |
 | `/sync-connectors` | コネクタ情報を収集・更新（Pre-built: API、カスタム: connector.rb パース） |
-| `/auto-learn` | Workato UI を Claude in Chrome で操作してオペレーションのフィールド詳細を能動収集（`/sync-connectors` と `/learn-recipe` の隙間を埋める） |
+| `/auto-learn` | 1 コネクタの全 op を Claude in Chrome で自律収集（対話なし、不確実なものは skip + log）。完全性より網羅性を優先 |
 | `/design` | プロジェクト設計書の作成・更新・参照 |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -125,4 +125,5 @@ Workato には「API Client」という名前の似て非なる 4 系統（Devel
 | `/learn-recipe` | レシピからフィールド情報を学習しドキュメントに反映 |
 | `/learn-pattern` | レシピから構築パターンを抽出しカタログに蓄積 |
 | `/sync-connectors` | コネクタ情報を収集・更新（Pre-built: API、カスタム: connector.rb パース） |
+| `/auto-learn` | Workato UI を Claude in Chrome で操作してオペレーションのフィールド詳細を能動収集（`/sync-connectors` と `/learn-recipe` の隙間を埋める） |
 | `/design` | プロジェクト設計書の作成・更新・参照 |

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -100,11 +100,11 @@ for op in queue:
 1. switchStepToOp(op)
    - kind=trigger → Step 1 を上書き（App タブ → コネクタ → Trigger picker → 当該 op）
    - kind=action  → Step 3 を上書き（App タブ → コネクタ → Action picker → 当該 op）
-   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open'
+   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open' を返して**早期終了**（後続の step 2-6 はスキップ）
 
 2. waitForSetupTab()
    - 完了判定: button.tabs__label.tabs__label_active のテキスト === 'Setup'
-   - timeout 8 秒で諦める
+   - timeout 8 秒。タイムアウトしたら result.status='failed_to_open' で**早期終了**
 
 3. result.input = captureInputFields()
    - "Show optional fields" ボタンがあれば開いてモーダルから {label, type, visibleByDefault} 取得 → Cancel
@@ -129,7 +129,10 @@ for op in queue:
        result.errors.push("dynamic_probe_failed: " + e.message)
      }
 
-6. result.status = 'ok'（errors の有無に関わらず、Phase 4 で記録）
+6. ステータス確定:
+   - ここまで result.status が未設定（=step 1〜2 で早期終了していない）なら、result.status = 'ok' を設定
+   - errors 配列の有無は status に影響させない（部分学習は status='ok' + errors=[...] で表す）
+   - ⚠ step 1 / 2 で 'failed_to_open' を設定して早期 return したケースは、ここに到達しないため status は上書きされない
 ```
 
 ### Phase 4: docs に追記
@@ -157,10 +160,20 @@ for op in queue:
 - 観測例: ... （PII を残さない範囲で）
 ```
 
-ステータス別の追記:
-- `status='ok'` & errors=[] → 完全に追記
-- `status='ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えて追記
-- `status='failed_to_open'` / `status='error'` → セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: <reason> — <date>`）
+ステータスは以下の 4 値のいずれか:
+
+| status | 意味 |
+|---|---|
+| `ok` | processOperation が最後まで通った（`errors` が non-empty なら部分学習）|
+| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return した |
+| `error` | step 3〜5 のいずれかで例外発生（`errors` に詳細）|
+| `unexpected_error` | processOperation そのものが投げた例外を上位 catch で受けた（後述） |
+
+追記ルーティング（`'ok'` 以外はすべて学習失敗ログ扱い）:
+
+- `status === 'ok'` & errors=[] → セクション本体に完全に追記
+- `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
+- `status !== 'ok'`（=`failed_to_open` / `error` / `unexpected_error` / その他将来追加される非 ok ステータス全般）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
 ### Phase 5: レポート出力
 
@@ -234,7 +247,8 @@ for (const op of queue) {
     const result = await processOperation(op);
     results.push(result);
   } catch (e) {
-    // 想定外の例外も次の op に進む
+    // processOperation 内 try/catch を通り抜けた想定外例外も次の op に進める
+    // status='unexpected_error' は Phase 4 ルーティング表で 'ok 以外' = 学習失敗ログ扱い
     results.push({ name: op.name, kind: op.kind, status: 'unexpected_error', errors: [e.message] });
     continue;
   }

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -1,253 +1,261 @@
 ---
-description: Workato UI を Claude in Chrome で操作し、コネクタの input/output フィールド詳細を収集して docs/connectors/<provider>.md に追記する。/sync-connectors（一覧）と /learn-recipe（既存レシピから学習）の隙間を埋め、新規レシピを書かずに能動的にフィールドナレッジを蓄積する。
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
 ---
 
 # /auto-learn
 
-Workato UI のレシピ編集画面を Claude in Chrome で操作し、対象オペレーションのフィールド詳細（type / hint / required / picklist / 動的フィールド）を収集して `docs/connectors/<provider>.md` に追記するスキル。
+Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
 
-`/sync-connectors` がトリガー/アクションの **一覧** を取り、`/learn-recipe` が既存レシピから **学習** するのに対し、`/auto-learn` は「**ドキュメントに無いオペレーションを能動的に学びにいく**」ポジションを担う。
+## 設計原則（重要）
+
+このスキルは「**自律性優先・網羅性重視**」で設計する。完全な型・nest 構造の正確性より、**多くのコネクタにある程度のフィールド情報を行き渡らせる**ことを目的とする。細かな修正はマニュアルレシピや `/learn-recipe` で後追いする。
+
+1. **対話禁止**: 1 回の呼び出しで対象コネクタの全 op を試す。途中でユーザーに質問しない。判断材料が無い場合は **defaults → skip + log**。
+2. **フェイルソフト**: 各 op を try / catch で囲み、失敗しても次に進む。1 op の失敗で run 全体を止めない。
+3. **記録駆動**: 取れたものは追記、取れなかったものは「学習失敗 / 部分学習」で残す。最後にレポートを出す。
+4. **UI のみ**: 内部 API への新規 fetch / XHR は禁止（リバースエンジニアリング厳禁）。UI 操作で発生したレスポンスの**受動観察**のみ可。詳細は `@docs/patterns/auto-learn-ui-operations.md` 参照。
 
 ## 使い方
 
-- `/auto-learn <provider>` — 指定コネクタの全オペレーションを学習
-- `/auto-learn <provider> <operation>` — 単一のトリガー/アクションのみ学習
-- `/auto-learn <provider> --triggers` — トリガーのみ学習
-- `/auto-learn <provider> --actions` — アクションのみ学習
-- `/auto-learn <provider> --resume` — 前回中断したコネクタの未学習分から再開
-
-## 動作モデル（重要）
-
-**Workato 内部 API を直接叩いてリバースエンジニアリングするやり方は禁止**（`@.claude/rules/`、および [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) の方針参照）。
-
-このスキルは:
-- ✅ Claude in Chrome で **Workato UI を実際に操作**して画面遷移する
-- ✅ レンダリング後の **DOM を読み取って**フィールド情報を取得する
-- ✅ `docs.workato.com` を WebFetch で参照する（補助的な型・hint 情報の補完）
-- ❌ `/integrations/meta`、`/connections/<id>/extended_schema.json` 等の内部エンドポイントを fetch / XHR で**直接呼ばない**
-- ❌ パラメータ総当たりや CSRF 偽装による探索を**しない**
-
-UI 操作の結果として Workato 自身が発火させたリクエストのレスポンスを **観測専用 interceptor** で受動的に読むのは可。ただしレスポンスから取れる構造化情報を活用するときも、**新規リクエストの構築・送信は禁止**。
-
-## 前提条件
-
-実行前にユーザーは以下を準備:
-
-1. **Chrome 環境**:
-   - Chrome で Workato にログイン済み
-   - Claude in Chrome 拡張が接続済み
-
-2. **検証用ワークスペース / プロジェクト**:
-   - 専用プロジェクト（推奨: `auto-learn-sandbox` など、本番に混ざらない名前）
-   - 対象コネクタの認証済みコネクションが存在
-   - 動的スキーマ系（Google Sheets、Salesforce、Database 等）を学ぶ場合: 学習用の**シンプルな**サンプルデータ（極小スプレッドシート、1 行のテーブル等）— PII を含まないもの
-
-3. **検証用レシピ**:
-   - 各オペレーションを開ける状態のスケルトンレシピ
-   - 推奨: ユーザーがあらかじめスケルトン JSON を `workato push` 経由で作成 → スキルは push せず操作のみ
-   - 1 レシピに複数オペレーションを並べてもよい（学習対象を Step 番号で指定する）
-
-## 実行手順
-
-### Phase 0: 前提確認
-
-1. `docs/connectors/<provider>.md` を Read。学習対象オペレーションのリストを取得（Triggers / Actions テーブル）
-   - `__adhoc_http_action` などの内部用途は除外
-   - `## フィールド詳細` 配下に既にエントリがあるオペレーションは、`--force` 指定がない限りスキップ
-2. ユーザーに以下を確認（対話）:
-   - 検証用ワークスペースの URL（例: `https://app.trial.workato.com/?fid=23794`）
-   - 学習に使うレシピ ID と、各オペレーションが何ステップ目にあるか
-   - 動的スキーマ確認用のサンプルデータ（必要なら）
-3. Claude in Chrome のタブを `tabs_context_mcp` で確保
-
-### Phase 1: コネクタ単位のループ
-
-対象オペレーションごとに Phase 2〜4 を実行。途中失敗時は `--resume` 用に進捗を保存。
-
-### Phase 2: ステップを開く
-
-1. `mcp__Claude_in_Chrome__navigate` で `https://app.<region>.workato.com/recipes/<id>/edit` に遷移
-2. `mcp__Claude_in_Chrome__javascript_tool` で対象ステップを click:
-   ```javascript
-   document.querySelectorAll('w-recipe-step .recipe-step__header')[stepIndex].click();
-   ```
-3. パネル展開を待機（`recipe-step-config` クラスが `w-panel-content` に出るまで）
-4. 現在のタブが `Setup` であることを確認:
-   ```javascript
-   document.querySelector('button.tabs__label.tabs__label_active')?.textContent.trim() === 'Setup'
-   ```
-   - 違うときは事前準備不足。ユーザーに「Connection 認証 / コネクタ未選択」をエスカレーション
-
-### Phase 3: 静的フィールドの収集
-
-DOM 操作の詳細セレクタは [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) 参照。要点:
-
-#### 3-a. Show optional fields モーダル経由でフィールド一覧 + 型を取得
-
-```javascript
-// "Show optional fields" ボタンをクリック → モーダル出現
-const optBtn = Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Show optional fields');
-optBtn?.click();
-// ※ ボタンが存在しない場合（オプションフィールドが無いコネクタ）は 3-b に直接進む
+```
+/auto-learn <provider>
 ```
 
-```javascript
-// モーダルから全フィールドリスト + 型を抽出
-const items = Array.from(document.querySelectorAll('label.multi-select-list__item')).map(label => ({
-  label: label.querySelector('.multi-select-list__item-title')?.textContent.trim(),
-  type: (label.querySelector('.multi-select-list__item-icon')?.getAttribute('data-icon-id') || '').replace(/^field-type\//,''),
-  visibleByDefault: label.querySelector('input[type="checkbox"]')?.checked,
-}));
+オプション:
+- `--recipe-id <id>` — 検証用レシピ ID（既定: 規約レシピ名から推定 / 直前タブの URL から）
+- `--workspace-url <url>` — ワークスペース base URL（既定: 直前タブから）
+- `--force` — 既に docs にフィールド詳細があっても上書き学習
+- `--triggers-only` / `--actions-only` — 範囲を絞る
+- `--sandbox <json>` — 動的スキーマ用テストデータ（後述）
+
+事前準備が無い場合（規約レシピ未作成・コネクション未認証など）は、**ユーザーに質問せず失敗ログだけ残して終了**する。
+
+## 事前準備（ユーザーが 1 回だけ）
+
+検証用ワークスペースに以下を用意:
+
+### 1. 規約レシピ（コネクタごと、または共有 1 本）
+
+推奨: プロジェクト名 `auto-learn-sandbox`、レシピ名 `<provider>` または共有 `auto-learn-scratch`。**4 ステップ構成で固定**:
+
+| Step | 役割 | 既定で置く中身 |
+|---|---|---|
+| 1 | **Trigger 学習スロット** | 任意（スキルが上書きする） |
+| 2 | 中継ステップ | 任意のシンプルなアクション（例: Google Sheets `Search rows`、列の少ない sandbox sheet 指定）。学習対象の前ステップとして固定し、出力 datapill を提供する |
+| 3 | **Action 学習スロット** | 任意（スキルが順次上書きする） |
+| 4 | **Action output 観察スロット** | 任意のシンプルなアクション（例: Workbot for Slack `Get user info`）。Step 3 output を Recipe data から覗くための踏み台 |
+
+引数 `--recipe-id` 未指定時、スキルは:
+- 直前タブの URL に `/recipes/<id>/edit` があれば、その ID を使う
+- なければ **失敗ログだけ残して終了**
+
+### 2. 認証済みコネクション（対象コネクタ）
+
+複数あっても可。スキルは規約に従って 1 つ選ぶ:
+
+1. 引数 `--connection <name>` 指定があればそれを使う
+2. なければ「**最初の active コネクション**」（`w-connection-card` の DOM 順）を選ぶ
+3. それも無ければ skip + log
+
+### 3. 動的スキーマ用サンドボックスデータ（必要なコネクタのみ）
+
+`extends_*_schema=true` 系のオペレーション（Google Sheets `search_rows`、Salesforce 各種等）を学習する場合のみ必要。
+
+- 引数 `--sandbox '{"spreadsheet":"auto-learn-sample","sheet":"Memo"}'` で渡す
+- なければ `scripts/sandbox-data/<provider>.json` を読む（任意のリポジトリ規約）
+- どちらもなければ動的 probe を **静かにスキップ**して静的フィールドだけ記録
+
+サンドボックスデータは **シンプル**であること（ヘッダー重複なし、3 列程度）。複雑なデータでは `"duplicated headers"` 等のエラーで動的 input が消える挙動が起きる。
+
+## 実行フロー
+
+### Phase 1: ブートストラップ
+
+1. `docs/connectors/<provider>.md` を Read
+2. Triggers / Actions テーブルから op 名・kind を列挙
+3. 除外: `__adhoc_http_action`、deprecated（`[deprecated]` 等の注記がある行）
+4. `--force` がない限り、既に `### <op> (Trigger|Action)` セクションがあるものはスキップ
+5. 残った op リストを処理キューに
+
+### Phase 2: タブ準備
+
+1. `tabs_context_mcp` で既存タブを確認、なければ新規作成
+2. `--recipe-id` または直前 URL から `/recipes/<id>/edit` に navigate
+3. レシピが 4 ステップ構成（trigger + 3 action）になっているか DOM で確認。なければ失敗ログを残して終了
+
+### Phase 3: 各 op を `processOperation` で順次処理
+
+```
+for op in queue:
+    result = processOperation(op)        # try/catch で囲む
+    results.append(result)
+    if result.errors:
+        log warning，continue（停止しない）
 ```
 
-```javascript
-// Select all → Apply changes でフォームに全フィールドを表示
-document.querySelector('label.multi-select-list__checkbox')?.click();
-Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Apply changes')?.click();
+`processOperation` の中身:
+
+```
+1. switchStepToOp(op)
+   - kind=trigger → Step 1 を上書き（App タブ → コネクタ → Trigger picker → 当該 op）
+   - kind=action  → Step 3 を上書き（App タブ → コネクタ → Action picker → 当該 op）
+   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open'
+
+2. waitForSetupTab()
+   - 完了判定: button.tabs__label.tabs__label_active のテキスト === 'Setup'
+   - timeout 8 秒で諦める
+
+3. result.input = captureInputFields()
+   - "Show optional fields" ボタンがあれば開いてモーダルから {label, type, visibleByDefault} 取得 → Cancel
+   - フォームの top-level w-form-field を列挙 → {label, required, hint, controlComponent, hasToggleField}
+   - 両者を label でマージ
+   - ボタンが無ければモーダル抽出を skip（form のみ）
+
+4. result.output = captureOutputFields(op.kind)
+   - 当該 step の output グループ名を組み立て:
+     - kind=trigger:  "Step 1 output"   → Step 2 を開いて Recipe data から覗く
+     - kind=action:   "Step 3 output"   → Step 4 を開いて Recipe data から覗く
+   - データツリー minimize なら展開、対象グループの内側 .data-tree-group__header を click
+   - グループが現れなければ "no_output_schema"（fire-and-forget アクション）として null
+   - 現れれば .data-tree-item を全列挙 → {label, type}
+
+5. もし result.input に dynamic picklist 候補（w-toggle-field を持つ select 等）があり、
+   かつ --sandbox が用意されていれば:
+     try {
+       applySandboxValues()
+       result.dynamic = { input: captureInputFields(), output: captureOutputFields() }
+     } catch (e) {
+       result.errors.push("dynamic_probe_failed: " + e.message)
+     }
+
+6. result.status = 'ok'（errors の有無に関わらず、Phase 4 で記録）
 ```
 
-#### 3-b. フォーム DOM から hint / required / control component を取得
+### Phase 4: docs に追記
 
-```javascript
-// トップレベル w-form-field のみ列挙（toggle picker のあるフィールドは内側 w-form-field を持つので除外）
-const topLevel = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
-  .filter(f => !f.parentElement?.closest('w-form-field'));
-
-const formFields = topLevel.map(f => {
-  const labelText = (f.querySelector('.form-field-label, w-form-field-simple-label')?.textContent||'').trim().replace(/\s+/g,' ');
-  const hint = (f.querySelector('.form-field-hint__content')?.textContent||'').trim();
-  const innerInput = f.querySelector('w-form-field w-form-field .form-field-input-wrapper > *')
-                   || f.querySelector('.form-field-input-wrapper > *');
-  return {
-    label: labelText.replace(/\s*\*$/,''),
-    required: /\*$/.test(labelText),
-    hint,
-    controlComponent: innerInput?.tagName.toLowerCase() || null,
-    hasToggleField: !!f.querySelector('w-toggle-field'),
-  };
-});
-```
-
-#### 3-c. 出力スキーマを Recipe data パネルから取得
-
-```javascript
-// 1) Recipe data パネルが minimize なら展開
-const datatree = document.querySelector('w-datatree');
-if (datatree?.classList.contains('recipe-editor-datatree_minimize')) {
-  document.querySelector('.data-tree-resize-controls__icon, .data-tree-resize-controls w-svg-icon')?.click();
-}
-
-// 2) 当該ステップの output グループを探して開く
-//    Trigger ステップの場合: "Current step output / <Title>(Step 1 output)"
-//    Action ステップの場合: 当該ステップの output は「ステップ 1 つ後ろのステップを開いて」初めて見える
-//    ※ Action の output 学習には、対象ステップの**直下に学習用の使い捨てステップを追加**する手順を推奨
-const stepGroup = Array.from(document.querySelectorAll('.data-tree-group'))
-  .find(g => /Step \d+ output|Current step output/.test(g.textContent));
-stepGroup?.querySelector('.data-tree-group__header')?.click();
-
-// 3) 全アイテム抽出
-const outputItems = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).map(it => ({
-  label: (it.querySelector('w-data-tree-pill, .data-tree-item__pill')?.textContent||'').trim(),
-  type: (it.querySelector('.data-tree-item__icon w-svg-icon, .data-tree-item__icon [data-icon-id]')?.getAttribute('data-icon-id')||'').replace(/^field-type\//,''),
-}));
-```
-
-3-a / 3-b の結果を `label` でマージ → 静的入力フィールドの確定リストを得る。
-
-### Phase 4: 動的フィールドの検出（任意）
-
-対象オペレーションが picklist 依存型（例: Google Sheets `search_spreadsheet_rows_v4_new`、Salesforce オブジェクト系）の場合のみ。
-
-1. Phase 3 のスナップショットを `before` として保持
-2. ユーザーが事前に用意したサンプル picklist 値（例: 学習用スプレッドシート + シート名）を UI から選択:
-   ```javascript
-   // 例: スプレッドシート選択
-   // 1. picklist を開く（input click or arrow click）
-   // 2. text-filter があれば値を入力
-   // 3. dropdown オプションをクリック
-   ```
-3. ローディング完了を待機（DOM 安定 = 一定時間 mutation なし）
-4. Phase 3 を再実行 → `after` を取得
-5. `before` / `after` を label で diff:
-   - 新出のトップレベルフィールド = 動的入力フィールド（親）
-   - 既存フィールドの内側に増えた `w-form-field` = 動的子フィールド（列・属性）
-   - Recipe data パネルの新出 `.data-tree-item` = 動的出力フィールド
-6. **インスタンス固有値は破棄**:
-   - 列名 `open_time`, `open_price` のような実データは記録しない
-   - 「決定条件（どの picklist 選択で動的列が増えるか）」と「生成パターン（"シートのヘッダーごとに 1 フィールド"）」のみ記録
-
-### Phase 5: docs/connectors/<provider>.md に追記
-
-既存の `## フィールド詳細` セクションに対象オペレーションのエントリを追加 / 更新。フォーマットは [/learn-recipe](../learn-recipe/SKILL.md) と同じ:
+`docs/connectors/<provider>.md` の `## アクション詳細` / `## トリガー詳細` セクションに、各 op の結果を追記:
 
 ```markdown
-### <operation_name> (Trigger | Action)
+### <op_name> (<Trigger|Action>)
 
-学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>
+学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>[, output <YYYY-MM-DD>]
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
-|---|---|---|---|
-| <label> | <type> | Yes/- | <hint の要約> |
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| ... |
 
 #### Output fields
 | フィールド | 型 | 説明 |
 |---|---|---|
-| <label> | <type> | <description if any> |
-| <parent>[].<child> | <type> | <description if any> |
+| ... |
 
 #### 動的フィールド（あれば）
-- **決定条件**: <どの picklist 選択で生成されるか>
-- **生成パターン**: <例: シートのヘッダー列ごとに 1 つの string 入力フィールドが Columns 配下に生成。出力では Rows 配列の要素として同じ列名フィールドが追加>
+- 決定条件: <picklist 名>
+- 観測例: ... （PII を残さない範囲で）
 ```
 
-**重複チェック**: 追記前に既存セクションを Grep し、同名 operation のエントリがあれば diff して新情報のみマージ。値（PII）が docs に混入しないか念のため確認。
+ステータス別の追記:
+- `status='ok'` & errors=[] → 完全に追記
+- `status='ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えて追記
+- `status='failed_to_open'` / `status='error'` → セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: <reason> — <date>`）
 
-### Phase 6: 後始末
+### Phase 5: レポート出力
 
-- 対象レシピを **保存しない**（学習は読み取り専用、Save は不要）
-- ユーザーが事前に作ったレシピ・コネクションは破棄しない
-- スキルが追加した一時ステップ（output 学習用の使い捨てステップ等）はユーザーの判断で削除
+標準出力に短く:
 
-## 出力
+```
+/auto-learn <provider> 完了
+- 試行: N op
+- 完全成功: M op
+- 部分学習: K op  (主因: <theme>)
+- 学習失敗: L op  (理由: <reason>)
+- マニュアルでフィードバックすべき項目:
+  - 重複ラベル: ...
+  - ネスト深さ未確定: ...
+  - その他観察された irregularity: ...
+```
 
-実行後、以下を報告:
+最後に追記したセクション一覧と git diff 概要を提示し、コミット可否はユーザー判断に任せる（**コミットは自動実行しない**）。
 
-- 学習したコネクタ / オペレーション一覧
-- `docs/connectors/<provider>.md` に追記したセクションのサマリ
-- 動的フィールドが検出されたオペレーション
-- スキップしたオペレーション（既存・認証なし・picker 未対応 等）と理由
-- 失敗したオペレーション（DOM 構造不一致・タイムアウト等） — 残課題として `docs/learned-patterns.md` または GitHub Issue に記録するよう提案
+## 「止まらない」ための具体ルール
 
-## エラー処理
+| 場面 | 対応 |
+|---|---|
+| `Show optional fields` ボタンが無い | モーダル抽出を skip、form 直接読みのみ |
+| Trigger 1 個コネクタで Trigger picker auto-skip | `tabs__label_active` を監視。Connection に飛んでいれば Trigger 段階を skip して既定トリガーを採用 |
+| Step output グループが Recipe data に無い | `output: null`（fire-and-forget アクション）として記録、続行 |
+| Picker のタイトル誤表示（同名 op が複数） | canvas step text や badge 構成で区別。それでも区別不能なら DOM 順位 + 失敗時の input 内容で逆推測。最後の手段は skip + log |
+| 動的 picklist で API エラー（duplicated headers 等） | 1 回だけリトライ（別の sandbox 値があれば）。再失敗で諦め、静的部分のみ記録 |
+| Picker の仮想スクロール | 各 op 検索時、見つからなければスクロール → 再列挙を最大 3 回 |
+| DOM 安定待ち | `wait` ではなく**特定セレクタの mutation 監視**を優先（spinner 消失、tabs_label_active 変化、modal の DOM 出現/消失） |
+| クリックが効かない | 1 段親要素クリック → `dispatchEvent(MouseEvent)` → 物理座標クリック の順でリトライ |
+| `unsaved changes` で navigate がブロック | 単に skip して在りもの recipe で続行（reload を試行しない） |
+| コネクション複数 | 引数 → DOM 最初 → skip の順。動的に新規認証は試みない |
 
-- **ステップが Setup にならない**: コネクション未選択 / 認証切れ。ユーザーに UI で対応してもらう
-- **`Show optional fields` ボタン無し**: そのオペレーションは optional フィールドなし。Phase 3-a を飛ばし 3-b から
-- **DOM が見つからない（クラス名変更）**: Workato UI の更新疑い。スキップして失敗ログを残す。`docs/patterns/auto-learn-ui-operations.md` の「残課題」に注記提案
-- **picklist の値が無い**: そのコネクションは権限不足 or データ未準備。ユーザーにエスカレーション
+## 完了判定セレクタ集
+
+- Setup タブ到達: `button.tabs__label.tabs__label_active` のテキスト === `Setup`
+- パネル切替完了: `w-recipe-step-details w-panel-content` のクラスが `recipe-step-config` または `recipe-step-details-adapter` に変化
+- Show optional fields モーダル出現: `w-dialog label.multi-select-list__item` 1 個以上
+- Show optional fields モーダル消失: `w-dialog` が DOM から消失
+- Recipe data tree 展開: `w-datatree:not(.recipe-editor-datatree_minimize)`
+- Step output グループ開いた状態: `.data-tree-group_opened`
+
+## docs 更新ルール
+
+- 既存セクションがある場合（`--force` で再学習時）:
+  - 学習元行を最新に更新
+  - フィールド表は **ユニオンで追記**（同名は新情報で置換）
+  - 重複ラベルは **末尾に注記**を残す（例: `> ⚠ 同一 label "User" が 2 箇所に出現。内部パスは要マニュアル確認`）
+- 新規セクションは [/learn-recipe](../learn-recipe/SKILL.md) と同じフォーマット
+
+## 残課題（マニュアルフィードバック前提）
+
+このスキルはあくまで「広く浅く」を目指す。次のものは UI 観察だけでは取りきれず、マニュアルで埋めることを前提とする:
+
+- 重複ラベル（Slack `User` 等、同名フィールドの内部パス区別）
+- データツリーのネスト深さ（`paddingLeft: 0px` 問題）
+- 動的 picklist の連鎖（spreadsheet → sheet → 列）の自動探索
+- 内部 `name`（JSON キー）と表示 label のマッピング（UI には label しか出ない）
+- フィールドの `parse_output` / 細かい制約（最大文字数等）
+
+これらに気づくたびに `/learn-recipe` で個別レシピから埋めるか、ユーザーが直接 `docs/connectors/<provider>.md` を編集する。
+
+## エラーハンドリングの設計指針
+
+すべての例外は **1 op 単位の失敗** に閉じ込める:
+
+```javascript
+for (const op of queue) {
+  try {
+    const result = await processOperation(op);
+    results.push(result);
+  } catch (e) {
+    // 想定外の例外も次の op に進む
+    results.push({ name: op.name, kind: op.kind, status: 'unexpected_error', errors: [e.message] });
+    continue;
+  }
+}
+```
+
+タブが死んだ・ネットワークが切れた・ログアウトされた等、recoverable でない事態だけは早期 abort してレポートを返す。判定基準: 連続 3 op 以上失敗 → abort。
 
 ## Git 管理
 
-書き込み先は外側 `workato-dev-kit` リポジトリ:
+書き込み先は外側 `workato-dev-kit/docs/connectors/<provider>.md` のみ。スキル自身はコミットしない（最後にユーザー判断）:
 
 ```bash
 git add docs/connectors/<provider>.md
-git commit -m "auto-learn: <provider> <operation>(s) のフィールド情報を追加"
+git commit -m "auto-learn: <provider> N op (M ok / K failed)"
 ```
 
 詳細は `@.claude/rules/workato-multi-repo-git.md` 参照。
 
 ## 関連スキル / ドキュメント
 
-- [/sync-connectors](../sync-connectors/SKILL.md) — トリガー/アクション一覧の収集（このスキルの上流）
-- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（このスキルと相補）
-- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ・操作スニペット完全リファレンス
+- [/sync-connectors](../sync-connectors/SKILL.md) — Triggers/Actions 一覧の収集（このスキルの上流）
+- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（マニュアルフィードバック手段）
+- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ完全リファレンス
 - [Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) — 設計動機
-
-## 制限事項（既知）
-
-- 動的フィールド検出は **picklist 1 段** までしかカバーしない（spreadsheet → sheet）。多段（spreadsheet → sheet → ヘッダ行範囲）は要追加検討
-- 仮想スクロール（`cdk-virtual-scroll-viewport`）配下のフィールドは画面外で取りこぼす可能性。多くの列を持つコネクタでは要スクロール
-- 複数トリガー持ちコネクタの Trigger ピッカー / 動的 Trigger イベント変更は未検証（残課題）
-- カスタムコネクタ向けは `connector.rb` パースで多くがカバーされるため、本スキルは Pre-built コネクタの補完を主用途とする

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -75,7 +75,7 @@ Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレ
 1. `docs/connectors/<provider>.md` を Read
 2. Triggers / Actions テーブルから op 名・kind を列挙
 3. 除外: `__adhoc_http_action`、deprecated（`[deprecated]` 等の注記がある行）
-4. `--force` がない限り、既に `### <op> (Trigger|Action)` セクションがあるものはスキップ
+4. `--force` がない限り、既に `### <op>` で始まるセクションがあるものはスキップ。検出は **op 名のみで照合**（行頭の `### ` 直後のトークン）。括弧内の補足（display title など）は無視する。例: `### delete_message (Delete message)` も `### delete_message (Action)` も同じ op としてスキップ対象になる
 5. 残った op リストを処理キューに
 
 ### Phase 2: タブ準備
@@ -137,8 +137,9 @@ for op in queue:
 `docs/connectors/<provider>.md` の `## アクション詳細` / `## トリガー詳細` セクションに、各 op の結果を追記:
 
 ```markdown
-### <op_name> (<Trigger|Action>)
+### <op_name> (<Display Title>)
 
+種別: Trigger | Action
 学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>[, output <YYYY-MM-DD>]
 
 #### Input fields

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -1,0 +1,253 @@
+---
+description: Workato UI を Claude in Chrome で操作し、コネクタの input/output フィールド詳細を収集して docs/connectors/<provider>.md に追記する。/sync-connectors（一覧）と /learn-recipe（既存レシピから学習）の隙間を埋め、新規レシピを書かずに能動的にフィールドナレッジを蓄積する。
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
+---
+
+# /auto-learn
+
+Workato UI のレシピ編集画面を Claude in Chrome で操作し、対象オペレーションのフィールド詳細（type / hint / required / picklist / 動的フィールド）を収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+`/sync-connectors` がトリガー/アクションの **一覧** を取り、`/learn-recipe` が既存レシピから **学習** するのに対し、`/auto-learn` は「**ドキュメントに無いオペレーションを能動的に学びにいく**」ポジションを担う。
+
+## 使い方
+
+- `/auto-learn <provider>` — 指定コネクタの全オペレーションを学習
+- `/auto-learn <provider> <operation>` — 単一のトリガー/アクションのみ学習
+- `/auto-learn <provider> --triggers` — トリガーのみ学習
+- `/auto-learn <provider> --actions` — アクションのみ学習
+- `/auto-learn <provider> --resume` — 前回中断したコネクタの未学習分から再開
+
+## 動作モデル（重要）
+
+**Workato 内部 API を直接叩いてリバースエンジニアリングするやり方は禁止**（`@.claude/rules/`、および [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) の方針参照）。
+
+このスキルは:
+- ✅ Claude in Chrome で **Workato UI を実際に操作**して画面遷移する
+- ✅ レンダリング後の **DOM を読み取って**フィールド情報を取得する
+- ✅ `docs.workato.com` を WebFetch で参照する（補助的な型・hint 情報の補完）
+- ❌ `/integrations/meta`、`/connections/<id>/extended_schema.json` 等の内部エンドポイントを fetch / XHR で**直接呼ばない**
+- ❌ パラメータ総当たりや CSRF 偽装による探索を**しない**
+
+UI 操作の結果として Workato 自身が発火させたリクエストのレスポンスを **観測専用 interceptor** で受動的に読むのは可。ただしレスポンスから取れる構造化情報を活用するときも、**新規リクエストの構築・送信は禁止**。
+
+## 前提条件
+
+実行前にユーザーは以下を準備:
+
+1. **Chrome 環境**:
+   - Chrome で Workato にログイン済み
+   - Claude in Chrome 拡張が接続済み
+
+2. **検証用ワークスペース / プロジェクト**:
+   - 専用プロジェクト（推奨: `auto-learn-sandbox` など、本番に混ざらない名前）
+   - 対象コネクタの認証済みコネクションが存在
+   - 動的スキーマ系（Google Sheets、Salesforce、Database 等）を学ぶ場合: 学習用の**シンプルな**サンプルデータ（極小スプレッドシート、1 行のテーブル等）— PII を含まないもの
+
+3. **検証用レシピ**:
+   - 各オペレーションを開ける状態のスケルトンレシピ
+   - 推奨: ユーザーがあらかじめスケルトン JSON を `workato push` 経由で作成 → スキルは push せず操作のみ
+   - 1 レシピに複数オペレーションを並べてもよい（学習対象を Step 番号で指定する）
+
+## 実行手順
+
+### Phase 0: 前提確認
+
+1. `docs/connectors/<provider>.md` を Read。学習対象オペレーションのリストを取得（Triggers / Actions テーブル）
+   - `__adhoc_http_action` などの内部用途は除外
+   - `## フィールド詳細` 配下に既にエントリがあるオペレーションは、`--force` 指定がない限りスキップ
+2. ユーザーに以下を確認（対話）:
+   - 検証用ワークスペースの URL（例: `https://app.trial.workato.com/?fid=23794`）
+   - 学習に使うレシピ ID と、各オペレーションが何ステップ目にあるか
+   - 動的スキーマ確認用のサンプルデータ（必要なら）
+3. Claude in Chrome のタブを `tabs_context_mcp` で確保
+
+### Phase 1: コネクタ単位のループ
+
+対象オペレーションごとに Phase 2〜4 を実行。途中失敗時は `--resume` 用に進捗を保存。
+
+### Phase 2: ステップを開く
+
+1. `mcp__Claude_in_Chrome__navigate` で `https://app.<region>.workato.com/recipes/<id>/edit` に遷移
+2. `mcp__Claude_in_Chrome__javascript_tool` で対象ステップを click:
+   ```javascript
+   document.querySelectorAll('w-recipe-step .recipe-step__header')[stepIndex].click();
+   ```
+3. パネル展開を待機（`recipe-step-config` クラスが `w-panel-content` に出るまで）
+4. 現在のタブが `Setup` であることを確認:
+   ```javascript
+   document.querySelector('button.tabs__label.tabs__label_active')?.textContent.trim() === 'Setup'
+   ```
+   - 違うときは事前準備不足。ユーザーに「Connection 認証 / コネクタ未選択」をエスカレーション
+
+### Phase 3: 静的フィールドの収集
+
+DOM 操作の詳細セレクタは [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) 参照。要点:
+
+#### 3-a. Show optional fields モーダル経由でフィールド一覧 + 型を取得
+
+```javascript
+// "Show optional fields" ボタンをクリック → モーダル出現
+const optBtn = Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Show optional fields');
+optBtn?.click();
+// ※ ボタンが存在しない場合（オプションフィールドが無いコネクタ）は 3-b に直接進む
+```
+
+```javascript
+// モーダルから全フィールドリスト + 型を抽出
+const items = Array.from(document.querySelectorAll('label.multi-select-list__item')).map(label => ({
+  label: label.querySelector('.multi-select-list__item-title')?.textContent.trim(),
+  type: (label.querySelector('.multi-select-list__item-icon')?.getAttribute('data-icon-id') || '').replace(/^field-type\//,''),
+  visibleByDefault: label.querySelector('input[type="checkbox"]')?.checked,
+}));
+```
+
+```javascript
+// Select all → Apply changes でフォームに全フィールドを表示
+document.querySelector('label.multi-select-list__checkbox')?.click();
+Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Apply changes')?.click();
+```
+
+#### 3-b. フォーム DOM から hint / required / control component を取得
+
+```javascript
+// トップレベル w-form-field のみ列挙（toggle picker のあるフィールドは内側 w-form-field を持つので除外）
+const topLevel = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
+  .filter(f => !f.parentElement?.closest('w-form-field'));
+
+const formFields = topLevel.map(f => {
+  const labelText = (f.querySelector('.form-field-label, w-form-field-simple-label')?.textContent||'').trim().replace(/\s+/g,' ');
+  const hint = (f.querySelector('.form-field-hint__content')?.textContent||'').trim();
+  const innerInput = f.querySelector('w-form-field w-form-field .form-field-input-wrapper > *')
+                   || f.querySelector('.form-field-input-wrapper > *');
+  return {
+    label: labelText.replace(/\s*\*$/,''),
+    required: /\*$/.test(labelText),
+    hint,
+    controlComponent: innerInput?.tagName.toLowerCase() || null,
+    hasToggleField: !!f.querySelector('w-toggle-field'),
+  };
+});
+```
+
+#### 3-c. 出力スキーマを Recipe data パネルから取得
+
+```javascript
+// 1) Recipe data パネルが minimize なら展開
+const datatree = document.querySelector('w-datatree');
+if (datatree?.classList.contains('recipe-editor-datatree_minimize')) {
+  document.querySelector('.data-tree-resize-controls__icon, .data-tree-resize-controls w-svg-icon')?.click();
+}
+
+// 2) 当該ステップの output グループを探して開く
+//    Trigger ステップの場合: "Current step output / <Title>(Step 1 output)"
+//    Action ステップの場合: 当該ステップの output は「ステップ 1 つ後ろのステップを開いて」初めて見える
+//    ※ Action の output 学習には、対象ステップの**直下に学習用の使い捨てステップを追加**する手順を推奨
+const stepGroup = Array.from(document.querySelectorAll('.data-tree-group'))
+  .find(g => /Step \d+ output|Current step output/.test(g.textContent));
+stepGroup?.querySelector('.data-tree-group__header')?.click();
+
+// 3) 全アイテム抽出
+const outputItems = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).map(it => ({
+  label: (it.querySelector('w-data-tree-pill, .data-tree-item__pill')?.textContent||'').trim(),
+  type: (it.querySelector('.data-tree-item__icon w-svg-icon, .data-tree-item__icon [data-icon-id]')?.getAttribute('data-icon-id')||'').replace(/^field-type\//,''),
+}));
+```
+
+3-a / 3-b の結果を `label` でマージ → 静的入力フィールドの確定リストを得る。
+
+### Phase 4: 動的フィールドの検出（任意）
+
+対象オペレーションが picklist 依存型（例: Google Sheets `search_spreadsheet_rows_v4_new`、Salesforce オブジェクト系）の場合のみ。
+
+1. Phase 3 のスナップショットを `before` として保持
+2. ユーザーが事前に用意したサンプル picklist 値（例: 学習用スプレッドシート + シート名）を UI から選択:
+   ```javascript
+   // 例: スプレッドシート選択
+   // 1. picklist を開く（input click or arrow click）
+   // 2. text-filter があれば値を入力
+   // 3. dropdown オプションをクリック
+   ```
+3. ローディング完了を待機（DOM 安定 = 一定時間 mutation なし）
+4. Phase 3 を再実行 → `after` を取得
+5. `before` / `after` を label で diff:
+   - 新出のトップレベルフィールド = 動的入力フィールド（親）
+   - 既存フィールドの内側に増えた `w-form-field` = 動的子フィールド（列・属性）
+   - Recipe data パネルの新出 `.data-tree-item` = 動的出力フィールド
+6. **インスタンス固有値は破棄**:
+   - 列名 `open_time`, `open_price` のような実データは記録しない
+   - 「決定条件（どの picklist 選択で動的列が増えるか）」と「生成パターン（"シートのヘッダーごとに 1 フィールド"）」のみ記録
+
+### Phase 5: docs/connectors/<provider>.md に追記
+
+既存の `## フィールド詳細` セクションに対象オペレーションのエントリを追加 / 更新。フォーマットは [/learn-recipe](../learn-recipe/SKILL.md) と同じ:
+
+```markdown
+### <operation_name> (Trigger | Action)
+
+学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>
+
+#### Input fields
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| <label> | <type> | Yes/- | <hint の要約> |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| <label> | <type> | <description if any> |
+| <parent>[].<child> | <type> | <description if any> |
+
+#### 動的フィールド（あれば）
+- **決定条件**: <どの picklist 選択で生成されるか>
+- **生成パターン**: <例: シートのヘッダー列ごとに 1 つの string 入力フィールドが Columns 配下に生成。出力では Rows 配列の要素として同じ列名フィールドが追加>
+```
+
+**重複チェック**: 追記前に既存セクションを Grep し、同名 operation のエントリがあれば diff して新情報のみマージ。値（PII）が docs に混入しないか念のため確認。
+
+### Phase 6: 後始末
+
+- 対象レシピを **保存しない**（学習は読み取り専用、Save は不要）
+- ユーザーが事前に作ったレシピ・コネクションは破棄しない
+- スキルが追加した一時ステップ（output 学習用の使い捨てステップ等）はユーザーの判断で削除
+
+## 出力
+
+実行後、以下を報告:
+
+- 学習したコネクタ / オペレーション一覧
+- `docs/connectors/<provider>.md` に追記したセクションのサマリ
+- 動的フィールドが検出されたオペレーション
+- スキップしたオペレーション（既存・認証なし・picker 未対応 等）と理由
+- 失敗したオペレーション（DOM 構造不一致・タイムアウト等） — 残課題として `docs/learned-patterns.md` または GitHub Issue に記録するよう提案
+
+## エラー処理
+
+- **ステップが Setup にならない**: コネクション未選択 / 認証切れ。ユーザーに UI で対応してもらう
+- **`Show optional fields` ボタン無し**: そのオペレーションは optional フィールドなし。Phase 3-a を飛ばし 3-b から
+- **DOM が見つからない（クラス名変更）**: Workato UI の更新疑い。スキップして失敗ログを残す。`docs/patterns/auto-learn-ui-operations.md` の「残課題」に注記提案
+- **picklist の値が無い**: そのコネクションは権限不足 or データ未準備。ユーザーにエスカレーション
+
+## Git 管理
+
+書き込み先は外側 `workato-dev-kit` リポジトリ:
+
+```bash
+git add docs/connectors/<provider>.md
+git commit -m "auto-learn: <provider> <operation>(s) のフィールド情報を追加"
+```
+
+詳細は `@.claude/rules/workato-multi-repo-git.md` 参照。
+
+## 関連スキル / ドキュメント
+
+- [/sync-connectors](../sync-connectors/SKILL.md) — トリガー/アクション一覧の収集（このスキルの上流）
+- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（このスキルと相補）
+- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ・操作スニペット完全リファレンス
+- [Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) — 設計動機
+
+## 制限事項（既知）
+
+- 動的フィールド検出は **picklist 1 段** までしかカバーしない（spreadsheet → sheet）。多段（spreadsheet → sheet → ヘッダ行範囲）は要追加検討
+- 仮想スクロール（`cdk-virtual-scroll-viewport`）配下のフィールドは画面外で取りこぼす可能性。多くの列を持つコネクタでは要スクロール
+- 複数トリガー持ちコネクタの Trigger ピッカー / 動的 Trigger イベント変更は未検証（残課題）
+- カスタムコネクタ向けは `connector.rb` パースで多くがカバーされるため、本スキルは Pre-built コネクタの補完を主用途とする

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -160,20 +160,21 @@ for op in queue:
 - 観測例: ... （PII を残さない範囲で）
 ```
 
-ステータスは以下の 4 値のいずれか:
+ステータスは以下の 3 値のいずれか:
 
-| status | 意味 |
-|---|---|
-| `ok` | processOperation が最後まで通った（`errors` が non-empty なら部分学習）|
-| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return した |
-| `error` | step 3〜5 のいずれかで例外発生（`errors` に詳細）|
-| `unexpected_error` | processOperation そのものが投げた例外を上位 catch で受けた（後述） |
+| status | 意味 | 設定箇所 |
+|---|---|---|
+| `ok` | processOperation が最後まで通った。step 3〜5 で個別の不具合（modal 不在、output グループ不在、dynamic probe 失敗 等）があれば `errors[]` に文字列で蓄積するが status 自体は `ok` のまま — 部分学習として扱う | step 6 |
+| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return | step 1 / 2 |
+| `unexpected_error` | processOperation 内で想定外例外が外側まで伝播し、上位の catch で受けた | 上位ループの catch |
+
+⚠ step 3〜5 内で起きる軽微な失敗は **例外を投げず** に `errors[]` への push で扱う方針（部分学習扱い）。例外まで投げる必要があるのはステップ 1 / 2（その op を開く前提が崩れた）か、もしくは想定外（バグ）のときだけ。
 
 追記ルーティング（`'ok'` 以外はすべて学習失敗ログ扱い）:
 
 - `status === 'ok'` & errors=[] → セクション本体に完全に追記
 - `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
-- `status !== 'ok'`（=`failed_to_open` / `error` / `unexpected_error` / その他将来追加される非 ok ステータス全般）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
+- `status !== 'ok'`（=`failed_to_open` / `unexpected_error` / 将来追加される非 ok ステータス）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
 ### Phase 5: レポート出力
 

--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -113,18 +113,27 @@ for op in queue:
    - ボタンが無ければモーダル抽出を skip（form のみ）
 
 4. result.output = captureOutputFields(op.kind)
-   - 当該 step の output グループ名を組み立て:
-     - kind=trigger:  "Step 1 output"   → Step 2 を開いて Recipe data から覗く
-     - kind=action:   "Step 3 output"   → Step 4 を開いて Recipe data から覗く
+   - **観察用ステップに切替えてから読む**（target step は触らない）:
+     - kind=trigger:  Step 2 を開く → Recipe data の "Step 1 output" グループから覗く
+     - kind=action:   Step 4 を開く → Recipe data の "Step 3 output" グループから覗く
    - データツリー minimize なら展開、対象グループの内側 .data-tree-group__header を click
    - グループが現れなければ "no_output_schema"（fire-and-forget アクション）として null
    - 現れれば .data-tree-item を全列挙 → {label, type}
+   - ⚠ 完了後の在りどころは**観察用ステップ**（Step 2 / Step 4）。次に target step を触る前に必ず navigation し直すこと
 
 5. もし result.input に dynamic picklist 候補（w-toggle-field を持つ select 等）があり、
    かつ --sandbox が用意されていれば:
+     // ⚠ step 4 で観察用ステップに切替えているので、まず target step に戻る
+     // - kind=trigger: Step 1 (target) のヘッダーをクリックして Setup タブへ復帰
+     // - kind=action:  Step 3 (target) のヘッダーをクリックして Setup タブへ復帰
+     // active tab が再び Setup になったことを button.tabs__label_active で確認してから進める
      try {
-       applySandboxValues()
-       result.dynamic = { input: captureInputFields(), output: captureOutputFields() }
+       navigateBackToTargetStep(op.kind)         // Step 1 / Step 3 を再度開く
+       waitForSetupTab()                         // タブが Setup に戻るのを待つ
+       applySandboxValues()                      // target step の picklist を埋める
+       const dynInput = captureInputFields()     // target step のフォームを読む
+       const dynOutput = captureOutputFields(op.kind)  // 内部で観察用ステップへ自動遷移して読む
+       result.dynamic = { input: dynInput, output: dynOutput }
      } catch (e) {
        result.errors.push("dynamic_probe_failed: " + e.message)
      }

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -100,11 +100,11 @@ for op in queue:
 1. switchStepToOp(op)
    - kind=trigger → Step 1 を上書き（App タブ → コネクタ → Trigger picker → 当該 op）
    - kind=action  → Step 3 を上書き（App タブ → コネクタ → Action picker → 当該 op）
-   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open'
+   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open' を返して**早期終了**（後続の step 2-6 はスキップ）
 
 2. waitForSetupTab()
    - 完了判定: button.tabs__label.tabs__label_active のテキスト === 'Setup'
-   - timeout 8 秒で諦める
+   - timeout 8 秒。タイムアウトしたら result.status='failed_to_open' で**早期終了**
 
 3. result.input = captureInputFields()
    - "Show optional fields" ボタンがあれば開いてモーダルから {label, type, visibleByDefault} 取得 → Cancel
@@ -129,7 +129,10 @@ for op in queue:
        result.errors.push("dynamic_probe_failed: " + e.message)
      }
 
-6. result.status = 'ok'（errors の有無に関わらず、Phase 4 で記録）
+6. ステータス確定:
+   - ここまで result.status が未設定（=step 1〜2 で早期終了していない）なら、result.status = 'ok' を設定
+   - errors 配列の有無は status に影響させない（部分学習は status='ok' + errors=[...] で表す）
+   - ⚠ step 1 / 2 で 'failed_to_open' を設定して早期 return したケースは、ここに到達しないため status は上書きされない
 ```
 
 ### Phase 4: docs に追記
@@ -157,10 +160,20 @@ for op in queue:
 - 観測例: ... （PII を残さない範囲で）
 ```
 
-ステータス別の追記:
-- `status='ok'` & errors=[] → 完全に追記
-- `status='ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えて追記
-- `status='failed_to_open'` / `status='error'` → セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: <reason> — <date>`）
+ステータスは以下の 4 値のいずれか:
+
+| status | 意味 |
+|---|---|
+| `ok` | processOperation が最後まで通った（`errors` が non-empty なら部分学習）|
+| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return した |
+| `error` | step 3〜5 のいずれかで例外発生（`errors` に詳細）|
+| `unexpected_error` | processOperation そのものが投げた例外を上位 catch で受けた（後述） |
+
+追記ルーティング（`'ok'` 以外はすべて学習失敗ログ扱い）:
+
+- `status === 'ok'` & errors=[] → セクション本体に完全に追記
+- `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
+- `status !== 'ok'`（=`failed_to_open` / `error` / `unexpected_error` / その他将来追加される非 ok ステータス全般）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
 ### Phase 5: レポート出力
 
@@ -234,7 +247,8 @@ for (const op of queue) {
     const result = await processOperation(op);
     results.push(result);
   } catch (e) {
-    // 想定外の例外も次の op に進む
+    // processOperation 内 try/catch を通り抜けた想定外例外も次の op に進める
+    // status='unexpected_error' は Phase 4 ルーティング表で 'ok 以外' = 学習失敗ログ扱い
     results.push({ name: op.name, kind: op.kind, status: 'unexpected_error', errors: [e.message] });
     continue;
   }

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -75,7 +75,7 @@ Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレ
 1. `docs/connectors/<provider>.md` を Read
 2. Triggers / Actions テーブルから op 名・kind を列挙
 3. 除外: `__adhoc_http_action`、deprecated（`[deprecated]` 等の注記がある行）
-4. `--force` がない限り、既に `### <op> (Trigger|Action)` セクションがあるものはスキップ
+4. `--force` がない限り、既に `### <op>` で始まるセクションがあるものはスキップ。検出は **op 名のみで照合**（行頭の `### ` 直後のトークン）。括弧内の補足（display title など）は無視する。例: `### delete_message (Delete message)` も `### delete_message (Action)` も同じ op としてスキップ対象になる
 5. 残った op リストを処理キューに
 
 ### Phase 2: タブ準備
@@ -137,8 +137,9 @@ for op in queue:
 `docs/connectors/<provider>.md` の `## アクション詳細` / `## トリガー詳細` セクションに、各 op の結果を追記:
 
 ```markdown
-### <op_name> (<Trigger|Action>)
+### <op_name> (<Display Title>)
 
+種別: Trigger | Action
 学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>[, output <YYYY-MM-DD>]
 
 #### Input fields

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -1,253 +1,261 @@
 ---
 name: auto-learn
-description: Workato UI を Claude in Chrome で操作し、コネクタの input/output フィールド詳細を収集して docs/connectors/<provider>.md に追記する。/sync-connectors（一覧）と /learn-recipe（既存レシピから学習）の隙間を埋め、新規レシピを書かずに能動的にフィールドナレッジを蓄積する。
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
 ---
 
 # /auto-learn
 
-Workato UI のレシピ編集画面を Claude in Chrome で操作し、対象オペレーションのフィールド詳細（type / hint / required / picklist / 動的フィールド）を収集して `docs/connectors/<provider>.md` に追記するスキル。
+Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
 
-`/sync-connectors` がトリガー/アクションの **一覧** を取り、`/learn-recipe` が既存レシピから **学習** するのに対し、`/auto-learn` は「**ドキュメントに無いオペレーションを能動的に学びにいく**」ポジションを担う。
+## 設計原則（重要）
+
+このスキルは「**自律性優先・網羅性重視**」で設計する。完全な型・nest 構造の正確性より、**多くのコネクタにある程度のフィールド情報を行き渡らせる**ことを目的とする。細かな修正はマニュアルレシピや `/learn-recipe` で後追いする。
+
+1. **対話禁止**: 1 回の呼び出しで対象コネクタの全 op を試す。途中でユーザーに質問しない。判断材料が無い場合は **defaults → skip + log**。
+2. **フェイルソフト**: 各 op を try / catch で囲み、失敗しても次に進む。1 op の失敗で run 全体を止めない。
+3. **記録駆動**: 取れたものは追記、取れなかったものは「学習失敗 / 部分学習」で残す。最後にレポートを出す。
+4. **UI のみ**: 内部 API への新規 fetch / XHR は禁止（リバースエンジニアリング厳禁）。UI 操作で発生したレスポンスの**受動観察**のみ可。詳細は `docs/patterns/auto-learn-ui-operations.md` 参照。
 
 ## 使い方
 
-- `/auto-learn <provider>` — 指定コネクタの全オペレーションを学習
-- `/auto-learn <provider> <operation>` — 単一のトリガー/アクションのみ学習
-- `/auto-learn <provider> --triggers` — トリガーのみ学習
-- `/auto-learn <provider> --actions` — アクションのみ学習
-- `/auto-learn <provider> --resume` — 前回中断したコネクタの未学習分から再開
-
-## 動作モデル（重要）
-
-**Workato 内部 API を直接叩いてリバースエンジニアリングするやり方は禁止**（`.cursor/rules/`、および [docs/patterns/auto-learn-ui-operations.mdc](../../../docs/patterns/auto-learn-ui-operations.md) の方針参照）。
-
-このスキルは:
-- ✅ Claude in Chrome で **Workato UI を実際に操作**して画面遷移する
-- ✅ レンダリング後の **DOM を読み取って**フィールド情報を取得する
-- ✅ `docs.workato.com` を WebFetch で参照する（補助的な型・hint 情報の補完）
-- ❌ `/integrations/meta`、`/connections/<id>/extended_schema.json` 等の内部エンドポイントを fetch / XHR で**直接呼ばない**
-- ❌ パラメータ総当たりや CSRF 偽装による探索を**しない**
-
-UI 操作の結果として Workato 自身が発火させたリクエストのレスポンスを **観測専用 interceptor** で受動的に読むのは可。ただしレスポンスから取れる構造化情報を活用するときも、**新規リクエストの構築・送信は禁止**。
-
-## 前提条件
-
-実行前にユーザーは以下を準備:
-
-1. **Chrome 環境**:
-   - Chrome で Workato にログイン済み
-   - Claude in Chrome 拡張が接続済み
-
-2. **検証用ワークスペース / プロジェクト**:
-   - 専用プロジェクト（推奨: `auto-learn-sandbox` など、本番に混ざらない名前）
-   - 対象コネクタの認証済みコネクションが存在
-   - 動的スキーマ系（Google Sheets、Salesforce、Database 等）を学ぶ場合: 学習用の**シンプルな**サンプルデータ（極小スプレッドシート、1 行のテーブル等）— PII を含まないもの
-
-3. **検証用レシピ**:
-   - 各オペレーションを開ける状態のスケルトンレシピ
-   - 推奨: ユーザーがあらかじめスケルトン JSON を `workato push` 経由で作成 → スキルは push せず操作のみ
-   - 1 レシピに複数オペレーションを並べてもよい（学習対象を Step 番号で指定する）
-
-## 実行手順
-
-### Phase 0: 前提確認
-
-1. `docs/connectors/<provider>.md` を Read。学習対象オペレーションのリストを取得（Triggers / Actions テーブル）
-   - `__adhoc_http_action` などの内部用途は除外
-   - `## フィールド詳細` 配下に既にエントリがあるオペレーションは、`--force` 指定がない限りスキップ
-2. ユーザーに以下を確認（対話）:
-   - 検証用ワークスペースの URL（例: `https://app.trial.workato.com/?fid=23794`）
-   - 学習に使うレシピ ID と、各オペレーションが何ステップ目にあるか
-   - 動的スキーマ確認用のサンプルデータ（必要なら）
-3. Claude in Chrome のタブを `tabs_context_mcp` で確保
-
-### Phase 1: コネクタ単位のループ
-
-対象オペレーションごとに Phase 2〜4 を実行。途中失敗時は `--resume` 用に進捗を保存。
-
-### Phase 2: ステップを開く
-
-1. `mcp__Claude_in_Chrome__navigate` で `https://app.<region>.workato.com/recipes/<id>/edit` に遷移
-2. `mcp__Claude_in_Chrome__javascript_tool` で対象ステップを click:
-   ```javascript
-   document.querySelectorAll('w-recipe-step .recipe-step__header')[stepIndex].click();
-   ```
-3. パネル展開を待機（`recipe-step-config` クラスが `w-panel-content` に出るまで）
-4. 現在のタブが `Setup` であることを確認:
-   ```javascript
-   document.querySelector('button.tabs__label.tabs__label_active')?.textContent.trim() === 'Setup'
-   ```
-   - 違うときは事前準備不足。ユーザーに「Connection 認証 / コネクタ未選択」をエスカレーション
-
-### Phase 3: 静的フィールドの収集
-
-DOM 操作の詳細セレクタは [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) 参照。要点:
-
-#### 3-a. Show optional fields モーダル経由でフィールド一覧 + 型を取得
-
-```javascript
-// "Show optional fields" ボタンをクリック → モーダル出現
-const optBtn = Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Show optional fields');
-optBtn?.click();
-// ※ ボタンが存在しない場合（オプションフィールドが無いコネクタ）は 3-b に直接進む
+```
+/auto-learn <provider>
 ```
 
-```javascript
-// モーダルから全フィールドリスト + 型を抽出
-const items = Array.from(document.querySelectorAll('label.multi-select-list__item')).map(label => ({
-  label: label.querySelector('.multi-select-list__item-title')?.textContent.trim(),
-  type: (label.querySelector('.multi-select-list__item-icon')?.getAttribute('data-icon-id') || '').replace(/^field-type\//,''),
-  visibleByDefault: label.querySelector('input[type="checkbox"]')?.checked,
-}));
+オプション:
+- `--recipe-id <id>` — 検証用レシピ ID（既定: 規約レシピ名から推定 / 直前タブの URL から）
+- `--workspace-url <url>` — ワークスペース base URL（既定: 直前タブから）
+- `--force` — 既に docs にフィールド詳細があっても上書き学習
+- `--triggers-only` / `--actions-only` — 範囲を絞る
+- `--sandbox <json>` — 動的スキーマ用テストデータ（後述）
+
+事前準備が無い場合（規約レシピ未作成・コネクション未認証など）は、**ユーザーに質問せず失敗ログだけ残して終了**する。
+
+## 事前準備（ユーザーが 1 回だけ）
+
+検証用ワークスペースに以下を用意:
+
+### 1. 規約レシピ（コネクタごと、または共有 1 本）
+
+推奨: プロジェクト名 `auto-learn-sandbox`、レシピ名 `<provider>` または共有 `auto-learn-scratch`。**4 ステップ構成で固定**:
+
+| Step | 役割 | 既定で置く中身 |
+|---|---|---|
+| 1 | **Trigger 学習スロット** | 任意（スキルが上書きする） |
+| 2 | 中継ステップ | 任意のシンプルなアクション（例: Google Sheets `Search rows`、列の少ない sandbox sheet 指定）。学習対象の前ステップとして固定し、出力 datapill を提供する |
+| 3 | **Action 学習スロット** | 任意（スキルが順次上書きする） |
+| 4 | **Action output 観察スロット** | 任意のシンプルなアクション（例: Workbot for Slack `Get user info`）。Step 3 output を Recipe data から覗くための踏み台 |
+
+引数 `--recipe-id` 未指定時、スキルは:
+- 直前タブの URL に `/recipes/<id>/edit` があれば、その ID を使う
+- なければ **失敗ログだけ残して終了**
+
+### 2. 認証済みコネクション（対象コネクタ）
+
+複数あっても可。スキルは規約に従って 1 つ選ぶ:
+
+1. 引数 `--connection <name>` 指定があればそれを使う
+2. なければ「**最初の active コネクション**」（`w-connection-card` の DOM 順）を選ぶ
+3. それも無ければ skip + log
+
+### 3. 動的スキーマ用サンドボックスデータ（必要なコネクタのみ）
+
+`extends_*_schema=true` 系のオペレーション（Google Sheets `search_rows`、Salesforce 各種等）を学習する場合のみ必要。
+
+- 引数 `--sandbox '{"spreadsheet":"auto-learn-sample","sheet":"Memo"}'` で渡す
+- なければ `scripts/sandbox-data/<provider>.json` を読む（任意のリポジトリ規約）
+- どちらもなければ動的 probe を **静かにスキップ**して静的フィールドだけ記録
+
+サンドボックスデータは **シンプル**であること（ヘッダー重複なし、3 列程度）。複雑なデータでは `"duplicated headers"` 等のエラーで動的 input が消える挙動が起きる。
+
+## 実行フロー
+
+### Phase 1: ブートストラップ
+
+1. `docs/connectors/<provider>.md` を Read
+2. Triggers / Actions テーブルから op 名・kind を列挙
+3. 除外: `__adhoc_http_action`、deprecated（`[deprecated]` 等の注記がある行）
+4. `--force` がない限り、既に `### <op> (Trigger|Action)` セクションがあるものはスキップ
+5. 残った op リストを処理キューに
+
+### Phase 2: タブ準備
+
+1. `tabs_context_mcp` で既存タブを確認、なければ新規作成
+2. `--recipe-id` または直前 URL から `/recipes/<id>/edit` に navigate
+3. レシピが 4 ステップ構成（trigger + 3 action）になっているか DOM で確認。なければ失敗ログを残して終了
+
+### Phase 3: 各 op を `processOperation` で順次処理
+
+```
+for op in queue:
+    result = processOperation(op)        # try/catch で囲む
+    results.append(result)
+    if result.errors:
+        log warning，continue（停止しない）
 ```
 
-```javascript
-// Select all → Apply changes でフォームに全フィールドを表示
-document.querySelector('label.multi-select-list__checkbox')?.click();
-Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Apply changes')?.click();
+`processOperation` の中身:
+
+```
+1. switchStepToOp(op)
+   - kind=trigger → Step 1 を上書き（App タブ → コネクタ → Trigger picker → 当該 op）
+   - kind=action  → Step 3 を上書き（App タブ → コネクタ → Action picker → 当該 op）
+   - 失敗（picker に op が見えない、auto-skip 異常 等）→ result.status='failed_to_open'
+
+2. waitForSetupTab()
+   - 完了判定: button.tabs__label.tabs__label_active のテキスト === 'Setup'
+   - timeout 8 秒で諦める
+
+3. result.input = captureInputFields()
+   - "Show optional fields" ボタンがあれば開いてモーダルから {label, type, visibleByDefault} 取得 → Cancel
+   - フォームの top-level w-form-field を列挙 → {label, required, hint, controlComponent, hasToggleField}
+   - 両者を label でマージ
+   - ボタンが無ければモーダル抽出を skip（form のみ）
+
+4. result.output = captureOutputFields(op.kind)
+   - 当該 step の output グループ名を組み立て:
+     - kind=trigger:  "Step 1 output"   → Step 2 を開いて Recipe data から覗く
+     - kind=action:   "Step 3 output"   → Step 4 を開いて Recipe data から覗く
+   - データツリー minimize なら展開、対象グループの内側 .data-tree-group__header を click
+   - グループが現れなければ "no_output_schema"（fire-and-forget アクション）として null
+   - 現れれば .data-tree-item を全列挙 → {label, type}
+
+5. もし result.input に dynamic picklist 候補（w-toggle-field を持つ select 等）があり、
+   かつ --sandbox が用意されていれば:
+     try {
+       applySandboxValues()
+       result.dynamic = { input: captureInputFields(), output: captureOutputFields() }
+     } catch (e) {
+       result.errors.push("dynamic_probe_failed: " + e.message)
+     }
+
+6. result.status = 'ok'（errors の有無に関わらず、Phase 4 で記録）
 ```
 
-#### 3-b. フォーム DOM から hint / required / control component を取得
+### Phase 4: docs に追記
 
-```javascript
-// トップレベル w-form-field のみ列挙（toggle picker のあるフィールドは内側 w-form-field を持つので除外）
-const topLevel = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
-  .filter(f => !f.parentElement?.closest('w-form-field'));
-
-const formFields = topLevel.map(f => {
-  const labelText = (f.querySelector('.form-field-label, w-form-field-simple-label')?.textContent||'').trim().replace(/\s+/g,' ');
-  const hint = (f.querySelector('.form-field-hint__content')?.textContent||'').trim();
-  const innerInput = f.querySelector('w-form-field w-form-field .form-field-input-wrapper > *')
-                   || f.querySelector('.form-field-input-wrapper > *');
-  return {
-    label: labelText.replace(/\s*\*$/,''),
-    required: /\*$/.test(labelText),
-    hint,
-    controlComponent: innerInput?.tagName.toLowerCase() || null,
-    hasToggleField: !!f.querySelector('w-toggle-field'),
-  };
-});
-```
-
-#### 3-c. 出力スキーマを Recipe data パネルから取得
-
-```javascript
-// 1) Recipe data パネルが minimize なら展開
-const datatree = document.querySelector('w-datatree');
-if (datatree?.classList.contains('recipe-editor-datatree_minimize')) {
-  document.querySelector('.data-tree-resize-controls__icon, .data-tree-resize-controls w-svg-icon')?.click();
-}
-
-// 2) 当該ステップの output グループを探して開く
-//    Trigger ステップの場合: "Current step output / <Title>(Step 1 output)"
-//    Action ステップの場合: 当該ステップの output は「ステップ 1 つ後ろのステップを開いて」初めて見える
-//    ※ Action の output 学習には、対象ステップの**直下に学習用の使い捨てステップを追加**する手順を推奨
-const stepGroup = Array.from(document.querySelectorAll('.data-tree-group'))
-  .find(g => /Step \d+ output|Current step output/.test(g.textContent));
-stepGroup?.querySelector('.data-tree-group__header')?.click();
-
-// 3) 全アイテム抽出
-const outputItems = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).map(it => ({
-  label: (it.querySelector('w-data-tree-pill, .data-tree-item__pill')?.textContent||'').trim(),
-  type: (it.querySelector('.data-tree-item__icon w-svg-icon, .data-tree-item__icon [data-icon-id]')?.getAttribute('data-icon-id')||'').replace(/^field-type\//,''),
-}));
-```
-
-3-a / 3-b の結果を `label` でマージ → 静的入力フィールドの確定リストを得る。
-
-### Phase 4: 動的フィールドの検出（任意）
-
-対象オペレーションが picklist 依存型（例: Google Sheets `search_spreadsheet_rows_v4_new`、Salesforce オブジェクト系）の場合のみ。
-
-1. Phase 3 のスナップショットを `before` として保持
-2. ユーザーが事前に用意したサンプル picklist 値（例: 学習用スプレッドシート + シート名）を UI から選択:
-   ```javascript
-   // 例: スプレッドシート選択
-   // 1. picklist を開く（input click or arrow click）
-   // 2. text-filter があれば値を入力
-   // 3. dropdown オプションをクリック
-   ```
-3. ローディング完了を待機（DOM 安定 = 一定時間 mutation なし）
-4. Phase 3 を再実行 → `after` を取得
-5. `before` / `after` を label で diff:
-   - 新出のトップレベルフィールド = 動的入力フィールド（親）
-   - 既存フィールドの内側に増えた `w-form-field` = 動的子フィールド（列・属性）
-   - Recipe data パネルの新出 `.data-tree-item` = 動的出力フィールド
-6. **インスタンス固有値は破棄**:
-   - 列名 `open_time`, `open_price` のような実データは記録しない
-   - 「決定条件（どの picklist 選択で動的列が増えるか）」と「生成パターン（"シートのヘッダーごとに 1 フィールド"）」のみ記録
-
-### Phase 5: docs/connectors/<provider>.md に追記
-
-既存の `## フィールド詳細` セクションに対象オペレーションのエントリを追加 / 更新。フォーマットは [/learn-recipe](../learn-recipe/SKILL.md) と同じ:
+`docs/connectors/<provider>.md` の `## アクション詳細` / `## トリガー詳細` セクションに、各 op の結果を追記:
 
 ```markdown
-### <operation_name> (Trigger | Action)
+### <op_name> (<Trigger|Action>)
 
-学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>
+学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>[, output <YYYY-MM-DD>]
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
-|---|---|---|---|
-| <label> | <type> | Yes/- | <hint の要約> |
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| ... |
 
 #### Output fields
 | フィールド | 型 | 説明 |
 |---|---|---|
-| <label> | <type> | <description if any> |
-| <parent>[].<child> | <type> | <description if any> |
+| ... |
 
 #### 動的フィールド（あれば）
-- **決定条件**: <どの picklist 選択で生成されるか>
-- **生成パターン**: <例: シートのヘッダー列ごとに 1 つの string 入力フィールドが Columns 配下に生成。出力では Rows 配列の要素として同じ列名フィールドが追加>
+- 決定条件: <picklist 名>
+- 観測例: ... （PII を残さない範囲で）
 ```
 
-**重複チェック**: 追記前に既存セクションを Grep し、同名 operation のエントリがあれば diff して新情報のみマージ。値（PII）が docs に混入しないか念のため確認。
+ステータス別の追記:
+- `status='ok'` & errors=[] → 完全に追記
+- `status='ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えて追記
+- `status='failed_to_open'` / `status='error'` → セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: <reason> — <date>`）
 
-### Phase 6: 後始末
+### Phase 5: レポート出力
 
-- 対象レシピを **保存しない**（学習は読み取り専用、Save は不要）
-- ユーザーが事前に作ったレシピ・コネクションは破棄しない
-- スキルが追加した一時ステップ（output 学習用の使い捨てステップ等）はユーザーの判断で削除
+標準出力に短く:
 
-## 出力
+```
+/auto-learn <provider> 完了
+- 試行: N op
+- 完全成功: M op
+- 部分学習: K op  (主因: <theme>)
+- 学習失敗: L op  (理由: <reason>)
+- マニュアルでフィードバックすべき項目:
+  - 重複ラベル: ...
+  - ネスト深さ未確定: ...
+  - その他観察された irregularity: ...
+```
 
-実行後、以下を報告:
+最後に追記したセクション一覧と git diff 概要を提示し、コミット可否はユーザー判断に任せる（**コミットは自動実行しない**）。
 
-- 学習したコネクタ / オペレーション一覧
-- `docs/connectors/<provider>.md` に追記したセクションのサマリ
-- 動的フィールドが検出されたオペレーション
-- スキップしたオペレーション（既存・認証なし・picker 未対応 等）と理由
-- 失敗したオペレーション（DOM 構造不一致・タイムアウト等） — 残課題として `docs/learned-patterns.md` または GitHub Issue に記録するよう提案
+## 「止まらない」ための具体ルール
 
-## エラー処理
+| 場面 | 対応 |
+|---|---|
+| `Show optional fields` ボタンが無い | モーダル抽出を skip、form 直接読みのみ |
+| Trigger 1 個コネクタで Trigger picker auto-skip | `tabs__label_active` を監視。Connection に飛んでいれば Trigger 段階を skip して既定トリガーを採用 |
+| Step output グループが Recipe data に無い | `output: null`（fire-and-forget アクション）として記録、続行 |
+| Picker のタイトル誤表示（同名 op が複数） | canvas step text や badge 構成で区別。それでも区別不能なら DOM 順位 + 失敗時の input 内容で逆推測。最後の手段は skip + log |
+| 動的 picklist で API エラー（duplicated headers 等） | 1 回だけリトライ（別の sandbox 値があれば）。再失敗で諦め、静的部分のみ記録 |
+| Picker の仮想スクロール | 各 op 検索時、見つからなければスクロール → 再列挙を最大 3 回 |
+| DOM 安定待ち | `wait` ではなく**特定セレクタの mutation 監視**を優先（spinner 消失、tabs_label_active 変化、modal の DOM 出現/消失） |
+| クリックが効かない | 1 段親要素クリック → `dispatchEvent(MouseEvent)` → 物理座標クリック の順でリトライ |
+| `unsaved changes` で navigate がブロック | 単に skip して在りもの recipe で続行（reload を試行しない） |
+| コネクション複数 | 引数 → DOM 最初 → skip の順。動的に新規認証は試みない |
 
-- **ステップが Setup にならない**: コネクション未選択 / 認証切れ。ユーザーに UI で対応してもらう
-- **`Show optional fields` ボタン無し**: そのオペレーションは optional フィールドなし。Phase 3-a を飛ばし 3-b から
-- **DOM が見つからない（クラス名変更）**: Workato UI の更新疑い。スキップして失敗ログを残す。`docs/patterns/auto-learn-ui-operations.md` の「残課題」に注記提案
-- **picklist の値が無い**: そのコネクションは権限不足 or データ未準備。ユーザーにエスカレーション
+## 完了判定セレクタ集
+
+- Setup タブ到達: `button.tabs__label.tabs__label_active` のテキスト === `Setup`
+- パネル切替完了: `w-recipe-step-details w-panel-content` のクラスが `recipe-step-config` または `recipe-step-details-adapter` に変化
+- Show optional fields モーダル出現: `w-dialog label.multi-select-list__item` 1 個以上
+- Show optional fields モーダル消失: `w-dialog` が DOM から消失
+- Recipe data tree 展開: `w-datatree:not(.recipe-editor-datatree_minimize)`
+- Step output グループ開いた状態: `.data-tree-group_opened`
+
+## docs 更新ルール
+
+- 既存セクションがある場合（`--force` で再学習時）:
+  - 学習元行を最新に更新
+  - フィールド表は **ユニオンで追記**（同名は新情報で置換）
+  - 重複ラベルは **末尾に注記**を残す（例: `> ⚠ 同一 label "User" が 2 箇所に出現。内部パスは要マニュアル確認`）
+- 新規セクションは [/learn-recipe](../learn-recipe/SKILL.md) と同じフォーマット
+
+## 残課題（マニュアルフィードバック前提）
+
+このスキルはあくまで「広く浅く」を目指す。次のものは UI 観察だけでは取りきれず、マニュアルで埋めることを前提とする:
+
+- 重複ラベル（Slack `User` 等、同名フィールドの内部パス区別）
+- データツリーのネスト深さ（`paddingLeft: 0px` 問題）
+- 動的 picklist の連鎖（spreadsheet → sheet → 列）の自動探索
+- 内部 `name`（JSON キー）と表示 label のマッピング（UI には label しか出ない）
+- フィールドの `parse_output` / 細かい制約（最大文字数等）
+
+これらに気づくたびに `/learn-recipe` で個別レシピから埋めるか、ユーザーが直接 `docs/connectors/<provider>.md` を編集する。
+
+## エラーハンドリングの設計指針
+
+すべての例外は **1 op 単位の失敗** に閉じ込める:
+
+```javascript
+for (const op of queue) {
+  try {
+    const result = await processOperation(op);
+    results.push(result);
+  } catch (e) {
+    // 想定外の例外も次の op に進む
+    results.push({ name: op.name, kind: op.kind, status: 'unexpected_error', errors: [e.message] });
+    continue;
+  }
+}
+```
+
+タブが死んだ・ネットワークが切れた・ログアウトされた等、recoverable でない事態だけは早期 abort してレポートを返す。判定基準: 連続 3 op 以上失敗 → abort。
 
 ## Git 管理
 
-書き込み先は外側 `workato-dev-kit` リポジトリ:
+書き込み先は外側 `workato-dev-kit/docs/connectors/<provider>.md` のみ。スキル自身はコミットしない（最後にユーザー判断）:
 
 ```bash
 git add docs/connectors/<provider>.md
-git commit -m "auto-learn: <provider> <operation>(s) のフィールド情報を追加"
+git commit -m "auto-learn: <provider> N op (M ok / K failed)"
 ```
 
 詳細は `.cursor/rules/workato-multi-repo-git.mdc` 参照。
 
 ## 関連スキル / ドキュメント
 
-- [/sync-connectors](../sync-connectors/SKILL.md) — トリガー/アクション一覧の収集（このスキルの上流）
-- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（このスキルと相補）
-- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ・操作スニペット完全リファレンス
+- [/sync-connectors](../sync-connectors/SKILL.md) — Triggers/Actions 一覧の収集（このスキルの上流）
+- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（マニュアルフィードバック手段）
+- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ完全リファレンス
 - [Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) — 設計動機
-
-## 制限事項（既知）
-
-- 動的フィールド検出は **picklist 1 段** までしかカバーしない（spreadsheet → sheet）。多段（spreadsheet → sheet → ヘッダ行範囲）は要追加検討
-- 仮想スクロール（`cdk-virtual-scroll-viewport`）配下のフィールドは画面外で取りこぼす可能性。多くの列を持つコネクタでは要スクロール
-- 複数トリガー持ちコネクタの Trigger ピッカー / 動的 Trigger イベント変更は未検証（残課題）
-- カスタムコネクタ向けは `connector.rb` パースで多くがカバーされるため、本スキルは Pre-built コネクタの補完を主用途とする

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -160,20 +160,21 @@ for op in queue:
 - 観測例: ... （PII を残さない範囲で）
 ```
 
-ステータスは以下の 4 値のいずれか:
+ステータスは以下の 3 値のいずれか:
 
-| status | 意味 |
-|---|---|
-| `ok` | processOperation が最後まで通った（`errors` が non-empty なら部分学習）|
-| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return した |
-| `error` | step 3〜5 のいずれかで例外発生（`errors` に詳細）|
-| `unexpected_error` | processOperation そのものが投げた例外を上位 catch で受けた（後述） |
+| status | 意味 | 設定箇所 |
+|---|---|---|
+| `ok` | processOperation が最後まで通った。step 3〜5 で個別の不具合（modal 不在、output グループ不在、dynamic probe 失敗 等）があれば `errors[]` に文字列で蓄積するが status 自体は `ok` のまま — 部分学習として扱う | step 6 |
+| `failed_to_open` | step 1 / 2 で対象 op を開けず早期 return | step 1 / 2 |
+| `unexpected_error` | processOperation 内で想定外例外が外側まで伝播し、上位の catch で受けた | 上位ループの catch |
+
+⚠ step 3〜5 内で起きる軽微な失敗は **例外を投げず** に `errors[]` への push で扱う方針（部分学習扱い）。例外まで投げる必要があるのはステップ 1 / 2（その op を開く前提が崩れた）か、もしくは想定外（バグ）のときだけ。
 
 追記ルーティング（`'ok'` 以外はすべて学習失敗ログ扱い）:
 
 - `status === 'ok'` & errors=[] → セクション本体に完全に追記
 - `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
-- `status !== 'ok'`（=`failed_to_open` / `error` / `unexpected_error` / その他将来追加される非 ok ステータス全般）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
+- `status !== 'ok'`（=`failed_to_open` / `unexpected_error` / 将来追加される非 ok ステータス）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
 ### Phase 5: レポート出力
 

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: auto-learn
+description: Workato UI を Claude in Chrome で操作し、コネクタの input/output フィールド詳細を収集して docs/connectors/<provider>.md に追記する。/sync-connectors（一覧）と /learn-recipe（既存レシピから学習）の隙間を埋め、新規レシピを書かずに能動的にフィールドナレッジを蓄積する。
+---
+
+# /auto-learn
+
+Workato UI のレシピ編集画面を Claude in Chrome で操作し、対象オペレーションのフィールド詳細（type / hint / required / picklist / 動的フィールド）を収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+`/sync-connectors` がトリガー/アクションの **一覧** を取り、`/learn-recipe` が既存レシピから **学習** するのに対し、`/auto-learn` は「**ドキュメントに無いオペレーションを能動的に学びにいく**」ポジションを担う。
+
+## 使い方
+
+- `/auto-learn <provider>` — 指定コネクタの全オペレーションを学習
+- `/auto-learn <provider> <operation>` — 単一のトリガー/アクションのみ学習
+- `/auto-learn <provider> --triggers` — トリガーのみ学習
+- `/auto-learn <provider> --actions` — アクションのみ学習
+- `/auto-learn <provider> --resume` — 前回中断したコネクタの未学習分から再開
+
+## 動作モデル（重要）
+
+**Workato 内部 API を直接叩いてリバースエンジニアリングするやり方は禁止**（`.cursor/rules/`、および [docs/patterns/auto-learn-ui-operations.mdc](../../../docs/patterns/auto-learn-ui-operations.md) の方針参照）。
+
+このスキルは:
+- ✅ Claude in Chrome で **Workato UI を実際に操作**して画面遷移する
+- ✅ レンダリング後の **DOM を読み取って**フィールド情報を取得する
+- ✅ `docs.workato.com` を WebFetch で参照する（補助的な型・hint 情報の補完）
+- ❌ `/integrations/meta`、`/connections/<id>/extended_schema.json` 等の内部エンドポイントを fetch / XHR で**直接呼ばない**
+- ❌ パラメータ総当たりや CSRF 偽装による探索を**しない**
+
+UI 操作の結果として Workato 自身が発火させたリクエストのレスポンスを **観測専用 interceptor** で受動的に読むのは可。ただしレスポンスから取れる構造化情報を活用するときも、**新規リクエストの構築・送信は禁止**。
+
+## 前提条件
+
+実行前にユーザーは以下を準備:
+
+1. **Chrome 環境**:
+   - Chrome で Workato にログイン済み
+   - Claude in Chrome 拡張が接続済み
+
+2. **検証用ワークスペース / プロジェクト**:
+   - 専用プロジェクト（推奨: `auto-learn-sandbox` など、本番に混ざらない名前）
+   - 対象コネクタの認証済みコネクションが存在
+   - 動的スキーマ系（Google Sheets、Salesforce、Database 等）を学ぶ場合: 学習用の**シンプルな**サンプルデータ（極小スプレッドシート、1 行のテーブル等）— PII を含まないもの
+
+3. **検証用レシピ**:
+   - 各オペレーションを開ける状態のスケルトンレシピ
+   - 推奨: ユーザーがあらかじめスケルトン JSON を `workato push` 経由で作成 → スキルは push せず操作のみ
+   - 1 レシピに複数オペレーションを並べてもよい（学習対象を Step 番号で指定する）
+
+## 実行手順
+
+### Phase 0: 前提確認
+
+1. `docs/connectors/<provider>.md` を Read。学習対象オペレーションのリストを取得（Triggers / Actions テーブル）
+   - `__adhoc_http_action` などの内部用途は除外
+   - `## フィールド詳細` 配下に既にエントリがあるオペレーションは、`--force` 指定がない限りスキップ
+2. ユーザーに以下を確認（対話）:
+   - 検証用ワークスペースの URL（例: `https://app.trial.workato.com/?fid=23794`）
+   - 学習に使うレシピ ID と、各オペレーションが何ステップ目にあるか
+   - 動的スキーマ確認用のサンプルデータ（必要なら）
+3. Claude in Chrome のタブを `tabs_context_mcp` で確保
+
+### Phase 1: コネクタ単位のループ
+
+対象オペレーションごとに Phase 2〜4 を実行。途中失敗時は `--resume` 用に進捗を保存。
+
+### Phase 2: ステップを開く
+
+1. `mcp__Claude_in_Chrome__navigate` で `https://app.<region>.workato.com/recipes/<id>/edit` に遷移
+2. `mcp__Claude_in_Chrome__javascript_tool` で対象ステップを click:
+   ```javascript
+   document.querySelectorAll('w-recipe-step .recipe-step__header')[stepIndex].click();
+   ```
+3. パネル展開を待機（`recipe-step-config` クラスが `w-panel-content` に出るまで）
+4. 現在のタブが `Setup` であることを確認:
+   ```javascript
+   document.querySelector('button.tabs__label.tabs__label_active')?.textContent.trim() === 'Setup'
+   ```
+   - 違うときは事前準備不足。ユーザーに「Connection 認証 / コネクタ未選択」をエスカレーション
+
+### Phase 3: 静的フィールドの収集
+
+DOM 操作の詳細セレクタは [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) 参照。要点:
+
+#### 3-a. Show optional fields モーダル経由でフィールド一覧 + 型を取得
+
+```javascript
+// "Show optional fields" ボタンをクリック → モーダル出現
+const optBtn = Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Show optional fields');
+optBtn?.click();
+// ※ ボタンが存在しない場合（オプションフィールドが無いコネクタ）は 3-b に直接進む
+```
+
+```javascript
+// モーダルから全フィールドリスト + 型を抽出
+const items = Array.from(document.querySelectorAll('label.multi-select-list__item')).map(label => ({
+  label: label.querySelector('.multi-select-list__item-title')?.textContent.trim(),
+  type: (label.querySelector('.multi-select-list__item-icon')?.getAttribute('data-icon-id') || '').replace(/^field-type\//,''),
+  visibleByDefault: label.querySelector('input[type="checkbox"]')?.checked,
+}));
+```
+
+```javascript
+// Select all → Apply changes でフォームに全フィールドを表示
+document.querySelector('label.multi-select-list__checkbox')?.click();
+Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Apply changes')?.click();
+```
+
+#### 3-b. フォーム DOM から hint / required / control component を取得
+
+```javascript
+// トップレベル w-form-field のみ列挙（toggle picker のあるフィールドは内側 w-form-field を持つので除外）
+const topLevel = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
+  .filter(f => !f.parentElement?.closest('w-form-field'));
+
+const formFields = topLevel.map(f => {
+  const labelText = (f.querySelector('.form-field-label, w-form-field-simple-label')?.textContent||'').trim().replace(/\s+/g,' ');
+  const hint = (f.querySelector('.form-field-hint__content')?.textContent||'').trim();
+  const innerInput = f.querySelector('w-form-field w-form-field .form-field-input-wrapper > *')
+                   || f.querySelector('.form-field-input-wrapper > *');
+  return {
+    label: labelText.replace(/\s*\*$/,''),
+    required: /\*$/.test(labelText),
+    hint,
+    controlComponent: innerInput?.tagName.toLowerCase() || null,
+    hasToggleField: !!f.querySelector('w-toggle-field'),
+  };
+});
+```
+
+#### 3-c. 出力スキーマを Recipe data パネルから取得
+
+```javascript
+// 1) Recipe data パネルが minimize なら展開
+const datatree = document.querySelector('w-datatree');
+if (datatree?.classList.contains('recipe-editor-datatree_minimize')) {
+  document.querySelector('.data-tree-resize-controls__icon, .data-tree-resize-controls w-svg-icon')?.click();
+}
+
+// 2) 当該ステップの output グループを探して開く
+//    Trigger ステップの場合: "Current step output / <Title>(Step 1 output)"
+//    Action ステップの場合: 当該ステップの output は「ステップ 1 つ後ろのステップを開いて」初めて見える
+//    ※ Action の output 学習には、対象ステップの**直下に学習用の使い捨てステップを追加**する手順を推奨
+const stepGroup = Array.from(document.querySelectorAll('.data-tree-group'))
+  .find(g => /Step \d+ output|Current step output/.test(g.textContent));
+stepGroup?.querySelector('.data-tree-group__header')?.click();
+
+// 3) 全アイテム抽出
+const outputItems = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).map(it => ({
+  label: (it.querySelector('w-data-tree-pill, .data-tree-item__pill')?.textContent||'').trim(),
+  type: (it.querySelector('.data-tree-item__icon w-svg-icon, .data-tree-item__icon [data-icon-id]')?.getAttribute('data-icon-id')||'').replace(/^field-type\//,''),
+}));
+```
+
+3-a / 3-b の結果を `label` でマージ → 静的入力フィールドの確定リストを得る。
+
+### Phase 4: 動的フィールドの検出（任意）
+
+対象オペレーションが picklist 依存型（例: Google Sheets `search_spreadsheet_rows_v4_new`、Salesforce オブジェクト系）の場合のみ。
+
+1. Phase 3 のスナップショットを `before` として保持
+2. ユーザーが事前に用意したサンプル picklist 値（例: 学習用スプレッドシート + シート名）を UI から選択:
+   ```javascript
+   // 例: スプレッドシート選択
+   // 1. picklist を開く（input click or arrow click）
+   // 2. text-filter があれば値を入力
+   // 3. dropdown オプションをクリック
+   ```
+3. ローディング完了を待機（DOM 安定 = 一定時間 mutation なし）
+4. Phase 3 を再実行 → `after` を取得
+5. `before` / `after` を label で diff:
+   - 新出のトップレベルフィールド = 動的入力フィールド（親）
+   - 既存フィールドの内側に増えた `w-form-field` = 動的子フィールド（列・属性）
+   - Recipe data パネルの新出 `.data-tree-item` = 動的出力フィールド
+6. **インスタンス固有値は破棄**:
+   - 列名 `open_time`, `open_price` のような実データは記録しない
+   - 「決定条件（どの picklist 選択で動的列が増えるか）」と「生成パターン（"シートのヘッダーごとに 1 フィールド"）」のみ記録
+
+### Phase 5: docs/connectors/<provider>.md に追記
+
+既存の `## フィールド詳細` セクションに対象オペレーションのエントリを追加 / 更新。フォーマットは [/learn-recipe](../learn-recipe/SKILL.md) と同じ:
+
+```markdown
+### <operation_name> (Trigger | Action)
+
+学習元: /auto-learn (UI 観察) — <YYYY-MM-DD>
+
+#### Input fields
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| <label> | <type> | Yes/- | <hint の要約> |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| <label> | <type> | <description if any> |
+| <parent>[].<child> | <type> | <description if any> |
+
+#### 動的フィールド（あれば）
+- **決定条件**: <どの picklist 選択で生成されるか>
+- **生成パターン**: <例: シートのヘッダー列ごとに 1 つの string 入力フィールドが Columns 配下に生成。出力では Rows 配列の要素として同じ列名フィールドが追加>
+```
+
+**重複チェック**: 追記前に既存セクションを Grep し、同名 operation のエントリがあれば diff して新情報のみマージ。値（PII）が docs に混入しないか念のため確認。
+
+### Phase 6: 後始末
+
+- 対象レシピを **保存しない**（学習は読み取り専用、Save は不要）
+- ユーザーが事前に作ったレシピ・コネクションは破棄しない
+- スキルが追加した一時ステップ（output 学習用の使い捨てステップ等）はユーザーの判断で削除
+
+## 出力
+
+実行後、以下を報告:
+
+- 学習したコネクタ / オペレーション一覧
+- `docs/connectors/<provider>.md` に追記したセクションのサマリ
+- 動的フィールドが検出されたオペレーション
+- スキップしたオペレーション（既存・認証なし・picker 未対応 等）と理由
+- 失敗したオペレーション（DOM 構造不一致・タイムアウト等） — 残課題として `docs/learned-patterns.md` または GitHub Issue に記録するよう提案
+
+## エラー処理
+
+- **ステップが Setup にならない**: コネクション未選択 / 認証切れ。ユーザーに UI で対応してもらう
+- **`Show optional fields` ボタン無し**: そのオペレーションは optional フィールドなし。Phase 3-a を飛ばし 3-b から
+- **DOM が見つからない（クラス名変更）**: Workato UI の更新疑い。スキップして失敗ログを残す。`docs/patterns/auto-learn-ui-operations.md` の「残課題」に注記提案
+- **picklist の値が無い**: そのコネクションは権限不足 or データ未準備。ユーザーにエスカレーション
+
+## Git 管理
+
+書き込み先は外側 `workato-dev-kit` リポジトリ:
+
+```bash
+git add docs/connectors/<provider>.md
+git commit -m "auto-learn: <provider> <operation>(s) のフィールド情報を追加"
+```
+
+詳細は `.cursor/rules/workato-multi-repo-git.mdc` 参照。
+
+## 関連スキル / ドキュメント
+
+- [/sync-connectors](../sync-connectors/SKILL.md) — トリガー/アクション一覧の収集（このスキルの上流）
+- [/learn-recipe](../learn-recipe/SKILL.md) — 既存レシピからのフィールド学習（このスキルと相補）
+- [docs/patterns/auto-learn-ui-operations.md](../../../docs/patterns/auto-learn-ui-operations.md) — UI 操作の DOM セレクタ・操作スニペット完全リファレンス
+- [Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) — 設計動機
+
+## 制限事項（既知）
+
+- 動的フィールド検出は **picklist 1 段** までしかカバーしない（spreadsheet → sheet）。多段（spreadsheet → sheet → ヘッダ行範囲）は要追加検討
+- 仮想スクロール（`cdk-virtual-scroll-viewport`）配下のフィールドは画面外で取りこぼす可能性。多くの列を持つコネクタでは要スクロール
+- 複数トリガー持ちコネクタの Trigger ピッカー / 動的 Trigger イベント変更は未検証（残課題）
+- カスタムコネクタ向けは `connector.rb` パースで多くがカバーされるため、本スキルは Pre-built コネクタの補完を主用途とする

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -113,18 +113,27 @@ for op in queue:
    - ボタンが無ければモーダル抽出を skip（form のみ）
 
 4. result.output = captureOutputFields(op.kind)
-   - 当該 step の output グループ名を組み立て:
-     - kind=trigger:  "Step 1 output"   → Step 2 を開いて Recipe data から覗く
-     - kind=action:   "Step 3 output"   → Step 4 を開いて Recipe data から覗く
+   - **観察用ステップに切替えてから読む**（target step は触らない）:
+     - kind=trigger:  Step 2 を開く → Recipe data の "Step 1 output" グループから覗く
+     - kind=action:   Step 4 を開く → Recipe data の "Step 3 output" グループから覗く
    - データツリー minimize なら展開、対象グループの内側 .data-tree-group__header を click
    - グループが現れなければ "no_output_schema"（fire-and-forget アクション）として null
    - 現れれば .data-tree-item を全列挙 → {label, type}
+   - ⚠ 完了後の在りどころは**観察用ステップ**（Step 2 / Step 4）。次に target step を触る前に必ず navigation し直すこと
 
 5. もし result.input に dynamic picklist 候補（w-toggle-field を持つ select 等）があり、
    かつ --sandbox が用意されていれば:
+     // ⚠ step 4 で観察用ステップに切替えているので、まず target step に戻る
+     // - kind=trigger: Step 1 (target) のヘッダーをクリックして Setup タブへ復帰
+     // - kind=action:  Step 3 (target) のヘッダーをクリックして Setup タブへ復帰
+     // active tab が再び Setup になったことを button.tabs__label_active で確認してから進める
      try {
-       applySandboxValues()
-       result.dynamic = { input: captureInputFields(), output: captureOutputFields() }
+       navigateBackToTargetStep(op.kind)         // Step 1 / Step 3 を再度開く
+       waitForSetupTab()                         // タブが Setup に戻るのを待つ
+       applySandboxValues()                      // target step の picklist を埋める
+       const dynInput = captureInputFields()     // target step のフォームを読む
+       const dynOutput = captureOutputFields(op.kind)  // 内部で観察用ステップへ自動遷移して読む
+       result.dynamic = { input: dynInput, output: dynOutput }
      } catch (e) {
        result.errors.push("dynamic_probe_failed: " + e.message)
      }

--- a/docs/connectors/slack_bot.md
+++ b/docs/connectors/slack_bot.md
@@ -31,7 +31,7 @@ Provider: `slack_bot`
 | Post command reply (old version) | `post_bot_reply` | [deprecated] |
 | Post command reply | `post_bot_reply_v2` | コマンドへの返信 |
 | Update blocks by block id | `update_blocks_by_block_id` | ブロック単位のメッセージ更新 |
-| Upload file | `upload_file` | ファイルアップロード |
+| Upload file | `upload_file` | ファイルアップロード（⚠ UI ピッカーで "Return menu options" + File バッジと誤表示される） |
 
 ---
 
@@ -108,6 +108,62 @@ Slack Events API のイベント発生時に発火。
 | フィールド | 型 | 説明 |
 |---|---|---|
 | shortcut_type | string | `global` or `message` |
+
+### bot_document_mention (New URL mention)
+
+Real-time。チャネル内に対象アプリの URL がメンションされたときに発火。Workbot は Salesforce / Zendesk URL を理解する。Unfurling シナリオに使う。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| Application | string (picklist) | Yes | URL 検出対象のアプリ |
+| Business data | string (picklist) | Yes | 対象のビジネスデータ種別（例: invoice, bill, customer） |
+
+### help_event (New help message trigger)
+
+Real-time。ユーザーが `help` で DM するか、チャンネルで `@workbot help` のようにメンションしたときに発火。`Post command reply` アクションとペアで bot のヘルプメッセージをカスタマイズする。1 つのコネクションで有効化できる help_event レシピは 1 つだけ（カスタムヘルプより優先）。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+入力フィールドなし（"Setup done — This step doesn't need any custom configuration."）。
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Help message text | string | デフォルトの help メッセージテキスト |
+| Personalized connections command | string | 個人接続管理用のコマンド |
+| Bot info command | string | bot 情報表示コマンド |
+| Is bot admin? | boolean | 実行ユーザーが bot 管理者か |
+| Bot commands | array | bot に登録されたコマンド一覧（コンテナ） |
+| Bot commands[].Recipe ID | string | コマンドを実装するレシピ ID |
+| Bot commands[].Command | string | コマンド名 |
+| Bot commands[].Description | string | コマンドの説明 |
+| Bot commands[].Recipe Name | string | レシピ名 |
+| Bot commands[].Recipe URL | string | レシピへの URL |
+| Bot commands[].Recipe jobs URL | string | ジョブ一覧への URL |
+| Bot commands[].List size | integer | 配列サイズ |
+| Bot commands[].List index | integer | 配列イテレーションインデックス |
+| Context | object | 実行コンテキスト（コンテナ） |
+| Context.Team ID | string | Slack チーム ID |
+| Context.User ID | string | 実行ユーザーの Slack ID |
+| Context.User handle | string | ユーザーハンドル |
+| Context.User name | string | ユーザー名 |
+| Context.User email | string | ユーザーメール |
+| Context.Conversation ID | string | チャンネル / DM の ID |
+| Context.Message text | string | メッセージテキスト |
+| Context.Reply to | string | 返信先 |
+| Context.Timestamp | datetime | 発火タイムスタンプ |
+| Context.Thread ID | string | スレッド ID |
+| Context.Interactive | boolean | インタラクティブ実行か |
+| Context.Trigger ID | string | Slack Trigger ID（モーダルや dialog 起動に使用） |
+| Context.Callback ID | string | Callback ID |
+| Context.Response URL | string | Slack Response URL |
+| Context.Original message JSON | string | 元メッセージの JSON |
+| Context.Original message timestamp | string | 元メッセージのタイムスタンプ |
+| Modals & App home | object | モーダル / App home コンテキスト（コンテナ） |
 
 ---
 
@@ -231,6 +287,67 @@ Bot の App Home タブにリッチコンテンツを表示。ユーザーごと
 |---|---|---|
 | id | string | Slack ユーザー ID（DM の channel に使用） |
 | name | string | ユーザー名 |
+
+### delete_message (Delete message)
+
+Workbot として投稿したメッセージを削除する。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| Message timestamp | string | Yes | 削除対象メッセージのタイムスタンプ |
+| Message channel | string | Yes | 削除対象が投稿されているチャンネル |
+
+オプションフィールドなし。
+
+### download_attachment (Download attachment)
+
+Slack 添付ファイルを Workbot 経由でダウンロードする。File 出力タグ付き。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| URL | string | Yes | URL of Slack attachment |
+
+オプションフィールドなし。
+
+### upload_file (Upload file)
+
+チャンネルまたはスレッドにファイル添付を投稿。初期コメントを付けることもできる。
+
+⚠ **UI 表示バグ**: Workbot for Slack の Action ピッカーで `upload_file` のタイトルが誤って **"Return menu options"**（File バッジ付き）と表示される。`generate_menu_options` (Return menu options, バッジなし) と並んで重複するため、選ぶ際は **File バッジの有無**で判別する必要がある。canvas / panel header にも同じ誤タイトルが表示されるが、フィールド構造は upload_file のもの（"Post to conversations" / "File content" 等）。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Post to conversations | string (picklist) | Yes | 表示 | 投稿先チャンネル / 直接会話。Workbot がメンバーである必要あり。複数指定可 |
+| File content | string | Yes | 表示 | 直前ステップの File content datapill（例: Google Drive Download attachment 出力） |
+| Initial comment | string | - | 表示 | ファイル投稿時の冒頭コメント |
+| File name | string | - | 表示 | ファイル名（例: foo.txt） |
+| File type | string | - | 表示 | ファイル形式識別子（例: text）。Slack 対応形式は公式参照 |
+| Title | string | - | 非表示 | ファイルタイトル |
+| Thread ID | string | - | 非表示 | 投稿先スレッド ID |
+
+### open_bot_dialog (Post dialog)
+
+ボタンクリックやメニュー選択時に bot dialog を開く。**Legacy** API（モーダルが推奨）。`New command` トリガーとペアで使う。Submit 押下時に別の bot コマンドを実行する構造。
+
+学習元: /auto-learn (UI 観察) — 2026-04-25
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Trigger ID | string | Yes | 表示 | New command トリガー出力の Trigger ID。ボタン / メニュー由来のもののみ有効 |
+| Dialog title | string | Yes | 表示 | dialog のタイトル（最大 24 文字） |
+| Submit button command | string (picklist) | Yes | 表示 | Submit 時に呼び出す Workbot コマンド |
+| State(Callback id) | string | - | 表示 | dialog 識別子（最大 3000 文字）。Submit 時のレシピに渡される |
+| Submit button label | string | - | 非表示 | Submit ボタンのラベル |
 
 ---
 

--- a/docs/connectors/slack_bot.md
+++ b/docs/connectors/slack_bot.md
@@ -121,6 +121,31 @@ Real-time。チャネル内に対象アプリの URL がメンションされた
 | Application | string (picklist) | Yes | URL 検出対象のアプリ |
 | Business data | string (picklist) | Yes | 対象のビジネスデータ種別（例: invoice, bill, customer） |
 
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Application | string | URL に含まれるアプリ名 |
+| Object | string | 対象オブジェクト種別（例: account, opportunity） |
+| Object ID | string | 対象オブジェクトの ID |
+| Context | object | 実行コンテキスト（コンテナ） |
+| Context.Team ID | string | Slack チーム ID |
+| Context.User ID | string | 実行ユーザーの Slack ID |
+| Context.User handle | string | ユーザーハンドル |
+| Context.User name | string | ユーザー名 |
+| Context.User email | string | ユーザーメール |
+| Context.Conversation ID | string | チャンネル / DM の ID |
+| Context.Message text | string | URL を含むメッセージ全文 |
+| Context.Reply to | string | 返信先 |
+| Context.Timestamp | datetime | 発火タイムスタンプ |
+| Context.Thread ID | string | スレッド ID |
+| Context.Interactive | boolean | インタラクティブ実行か |
+| Context.Trigger ID | string | Slack Trigger ID |
+| Context.Callback ID | string | Callback ID |
+| Context.Response URL | string | Slack Response URL |
+| Context.Original message JSON | string | 元メッセージの JSON |
+| Context.Original message timestamp | string | 元メッセージのタイムスタンプ |
+| Modals & App home | object | モーダル / App home コンテキスト（コンテナ） |
+
 ### help_event (New help message trigger)
 
 Real-time。ユーザーが `help` で DM するか、チャンネルで `@workbot help` のようにメンションしたときに発火。`Post command reply` アクションとペアで bot のヘルプメッセージをカスタマイズする。1 つのコネクションで有効化できる help_event レシピは 1 つだけ（カスタムヘルプより優先）。
@@ -292,7 +317,7 @@ Bot の App Home タブにリッチコンテンツを表示。ユーザーごと
 
 Workbot として投稿したメッセージを削除する。
 
-学習元: /auto-learn (UI 観察) — 2026-04-25
+学習元: /auto-learn (UI 観察) — 2026-04-25 / output 2026-04-26
 
 #### Input fields
 | フィールド | 型 | 必須 | 説明 |
@@ -302,11 +327,17 @@ Workbot として投稿したメッセージを削除する。
 
 オプションフィールドなし。
 
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Channel ID | string | 削除実行されたチャンネル ID |
+| Timestamp | string | 削除されたメッセージのタイムスタンプ |
+
 ### download_attachment (Download attachment)
 
 Slack 添付ファイルを Workbot 経由でダウンロードする。File 出力タグ付き。
 
-学習元: /auto-learn (UI 観察) — 2026-04-25
+学習元: /auto-learn (UI 観察) — 2026-04-25 / output 2026-04-26
 
 #### Input fields
 | フィールド | 型 | 必須 | 説明 |
@@ -315,13 +346,19 @@ Slack 添付ファイルを Workbot 経由でダウンロードする。File 出
 
 オプションフィールドなし。
 
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Body | string | 添付ファイルのバイナリコンテンツ（datapill として下流に渡せる） |
+| Size | integer | ファイルサイズ（バイト） |
+
 ### upload_file (Upload file)
 
 チャンネルまたはスレッドにファイル添付を投稿。初期コメントを付けることもできる。
 
-⚠ **UI 表示バグ**: Workbot for Slack の Action ピッカーで `upload_file` のタイトルが誤って **"Return menu options"**（File バッジ付き）と表示される。`generate_menu_options` (Return menu options, バッジなし) と並んで重複するため、選ぶ際は **File バッジの有無**で判別する必要がある。canvas / panel header にも同じ誤タイトルが表示されるが、フィールド構造は upload_file のもの（"Post to conversations" / "File content" 等）。
+⚠ **UI 表示バグ**: Workbot for Slack の Action ピッカーで `upload_file` のタイトルが誤って **"Return menu options"**（File バッジ付き）と表示される。`generate_menu_options` (Return menu options, バッジなし) と並んで重複するため、選ぶ際は **File バッジの有無**で判別する必要がある。canvas / panel header にも同じ誤タイトルが表示されるが、フィールド構造は upload_file のもの（"Post to conversations" / "File content" 等）。Recipe data パネルの Step output グループ名も同じく "Return menu options" と表示される。
 
-学習元: /auto-learn (UI 観察) — 2026-04-25
+学習元: /auto-learn (UI 観察) — 2026-04-25 / output 2026-04-26
 
 #### Input fields
 | フィールド | 型 | 必須 | デフォルト表示 | 説明 |
@@ -334,11 +371,43 @@ Slack 添付ファイルを Workbot 経由でダウンロードする。File 出
 | Title | string | - | 非表示 | ファイルタイトル |
 | Thread ID | string | - | 非表示 | 投稿先スレッド ID |
 
+#### Output fields
+Slack `files.upload` API のレスポンスに準拠（[Slack 公式リファレンス](https://api.slack.com/methods/files.upload)参照）。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Ok | string | API 結果ステータス |
+| File | object | アップロード結果ファイルメタデータ（コンテナ） |
+| File.ID | string | ファイル ID |
+| File.Created | string | 作成タイムスタンプ |
+| File.Timestamp | string | タイムスタンプ |
+| File.Name | string | ファイル名 |
+| File.Title | string | タイトル |
+| File.User | string | アップロードユーザー ID |
+| File.Editable | boolean | 編集可能か |
+| File.Size | integer | サイズ（バイト） |
+| File.Mode | string | アップロードモード |
+| File.Is external | boolean | 外部ファイルか |
+| File.External type | string | 外部タイプ |
+| File.Is public | boolean | パブリックか |
+| File.Public URL shared | boolean | パブリック URL が共有されているか |
+| File.Display as bot | boolean | bot として表示するか |
+| File.Username | string | ユーザー名 |
+| File.URL private | string | プライベート URL |
+| File.URL private download | string | プライベートダウンロード URL |
+| File.Permalink | string | パーマリンク |
+| File.Permalink public | string | パブリックパーマリンク |
+| File.User | string | ユーザー（重複ラベル — Slack API の異なるパスを表示） |
+| File.Comments count | integer | コメント数 |
+| File.Is starred | boolean | スター付きか |
+| File.Channels | string[] | 投稿先チャンネル ID 配列 |
+| File.Has rich preview | boolean | リッチプレビューがあるか |
+
 ### open_bot_dialog (Post dialog)
 
 ボタンクリックやメニュー選択時に bot dialog を開く。**Legacy** API（モーダルが推奨）。`New command` トリガーとペアで使う。Submit 押下時に別の bot コマンドを実行する構造。
 
-学習元: /auto-learn (UI 観察) — 2026-04-25
+学習元: /auto-learn (UI 観察) — 2026-04-25 / output 2026-04-26
 
 #### Input fields
 | フィールド | 型 | 必須 | デフォルト表示 | 説明 |
@@ -348,6 +417,9 @@ Slack 添付ファイルを Workbot 経由でダウンロードする。File 出
 | Submit button command | string (picklist) | Yes | 表示 | Submit 時に呼び出す Workbot コマンド |
 | State(Callback id) | string | - | 表示 | dialog 識別子（最大 3000 文字）。Submit 時のレシピに渡される |
 | Submit button label | string | - | 非表示 | Submit ボタンのラベル |
+
+#### Output fields
+**出力フィールドなし**（Recipe data パネルに `Step N output` グループが現れない fire-and-forget 型のアクション）。dialog 送信後の処理は `Submit button command` で指定した別の bot コマンドレシピで行う。
 
 ---
 

--- a/docs/patterns/auto-learn-ui-operations.md
+++ b/docs/patterns/auto-learn-ui-operations.md
@@ -456,9 +456,17 @@ function snapshotFields() {
 - **生成パターン**: 親フィールド名（例: `Columns`）+ 子要素の生成ルール（例: `シートのヘッダー列ごとに 1 つ`）
 - **インスタンス固有値は記録しない**: `open_time`, `open_price` 等の実際の列名はテストデータ依存なので保存対象外
 
-**動的 OUTPUT フィールド**: 同じパターンが Recipe data パネルにも反映される（次ステップを開いた時に、前ステップの動的列が `data-tree-item` として出現する）。検出ロジックは [画面 5c](#画面-5c-recipe-data-パネル--出力スキーマ-) のとおり、`.data-tree-item` の `data-icon-id` で型情報も取れる。
+**動的 OUTPUT フィールド**: 同じパターンが Recipe data パネルにも反映される。**前ステップの output を見るには、その下に新しいステップを追加してそのステップの Setup 画面を開く**（Recipe data パネルは「現在のステップから見える前ステップ群の output」を表示する仕様）。
 
-⚠ **実証範囲**: SAMPLE シート（4 列）で動的入力フィールド側を確認済み。動的 OUTPUT 側（Recipe data パネルでの列出現）は次サイクルで検証予定。
+検出ロジックは [画面 5c](#画面-5c-recipe-data-パネル--出力スキーマ-) のとおり、`.data-tree-item` の `data-icon-id` で型情報も取れる。
+
+✅ **実証済み**: Google Sheets `search_spreadsheet_rows_v4_new` で Spreadsheet → Sheet (SAMPLE) を選択 → Step 3 を追加して Setup を開くと、Recipe data パネルに `Search rows (Step 2 output)` グループが出現し、SAMPLE シートの実際の列ヘッダー 17 個が `Rows (array)` の子要素として `field-type/text` で出現することを確認。
+- 静的 output: `Spreadsheet ID`, `Spreadsheet name`, `Sheet name`, `Rows (array)`, `List size`, `List index`
+- 動的 output: `Rows[].Row number` + シートの全列ヘッダー（インスタンス固有）
+
+つまり**動的 input の列名と動的 output の列名は同じ集合**になり、検出パターンも同じ DOM 構造（`w-form-field` ネスト → `Rows`/`Columns` 親要素配下）になる。
+
+⚠ **入力フィールドと出力フィールドの粒度差**: SAMPLE シートでは UI の `Columns` 入力フィールド配下には 4 個の inner `w-form-field` しか表示されなかったが、実際の OUTPUT 側では 17 列すべてが見えた（Workato の入力 UI が「最初の N 列」だけ表示する仕様の可能性。要追加検証）。
 
 ## レベル 2 自動収集の標準フロー
 

--- a/docs/patterns/auto-learn-ui-operations.md
+++ b/docs/patterns/auto-learn-ui-operations.md
@@ -351,6 +351,115 @@ const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).m
 - toggle が `_open` → 既に展開された親（直後の leaf 群が子）
 - 確実な深さ判定はさらに調査要
 
+### 画面 6: アクション追加導線 / Action ピッカー
+
+アクションを追加する場合、トリガーと違って **2 段階のピッカー**を経由する。
+
+#### 6-a: ステップタイプピッカー
+
+ACTIONS セクションの `+` (`button[aria-label="Add step"]`) をクリックすると、ステップ種別を選ぶ小ポップオーバーが出る。
+
+```
+ステップ種別: Action in app | Recipe function | IF condition | Repeat for each | Repeat while | Stop job | Handle errors
+```
+
+入力フィールド調査では `Action in app` を選ぶ。
+
+#### 6-b: App ピッカー → Action ピッカー
+
+`Action in app` を選ぶと App ピッカー（画面 3 と同じ）が出る。コネクタを選んだ後、トリガーが 1 個でスキップされる動作とは違い、アクションは原則複数あるので **Action ピッカー画面が必ず出る**:
+
+```
+w-recipe-step-details
+└ w-recipe-step-details (operation モード)
+    └ w-panel.recipe-step-details
+        ├ w-panel-header                          ← "Choose an action"
+        └ w-panel-content.recipe-step-details-operation
+            └ w-operation-picker
+                ├ w-search-field                  ← "Search for an action"
+                └ li.operation-picker__item × N    ← 各アクション
+                    └ w-operation
+                        ├ "<Title>"                ← e.g. "Search rows"
+                        ├ w-operation-badge        ← "Batch" バッジ等
+                        └ "<description>"          ← e.g. "Search rows in selected sheet"
+```
+
+**操作**:
+```javascript
+// アクション選択（例: "Search rows"）
+Array.from(document.querySelectorAll('li.operation-picker__item'))
+  .find(li => li.textContent.trim().startsWith('Search rows'))
+  ?.click();
+```
+
+App ピッカーがアイコングリッド形式だったのに対し、Action ピッカーは**1 行 1 アクションの詳細リスト形式**（タイトル + Batch 等のタグ + 説明文）。
+
+タブの遷移: `App → Action → Connection → Setup`（trigger フローの `App → Trigger → Connection → Setup` と「2 段目だけ」異なる）。
+
+### 画面 7: 動的フィールド検出（picklist 選択 → 新フィールド出現）⭐
+
+`/integrations/meta` で `extends_input_schema=true` または `extends_output_schema=true` とマークされたオペレーションは、ユーザーが特定の picklist を選択した結果として、**新しい入力フィールド・出力フィールドが UI に追加される**。
+
+**実例**: Google Sheets `search_spreadsheet_rows_v4_new` (Search rows)
+- 初期表示: `Google Drive`, `Spreadsheet`
+- Spreadsheet 選択後: `Sheet`, `Search result size` が追加される
+- Sheet 選択後: `Columns` が追加され、その配下に**シートのヘッダー列ごとに `w-form-field` が動的生成**される
+
+**実測の DOM 構造**（SAMPLE シート選択後、4 列のシート）:
+```
+w-form-field (top-level)         ← "Columns" (required, has 4 nested children)
+└ .form-field__body
+    └ .form-field-controls
+        └ .form-field-input-wrapper
+            ├ w-form-field        ← child 0: label="open_time" (sheet 列名)
+            ├ w-form-field        ← child 1: label="open_price"
+            ├ w-form-field        ← child 2: label="type"
+            └ w-form-field        ← child 3: label="time_1m"
+```
+
+つまり、**親 `w-form-field` の配下に inner `w-form-field` が「列数だけ」並ぶ**のが動的フィールドの基本パターン。
+
+**検出アルゴリズム**:
+```javascript
+// 0. 初期スナップショット (picklist 選択前)
+const before = snapshotFields();   // top-level w-form-field の labels を記録
+
+// 1. ユーザーが picklist を選択（UI 操作）
+//    selectPicklist(...) — 例: Sheet picklist で値を選ぶ
+
+// 2. DOM の安定を待つ（ローディング消失 / 一定時間 DOM 変化なし）
+await waitForDomStable();
+
+// 3. 再スナップショット
+const after = snapshotFields();
+
+// 4. 差分を計算 → 新出フィールドが「動的フィールド」
+const newTopLevelFields = after.filter(f => !before.some(b => b.label === f.label));
+
+// 5. 内側の子（per-column）も収集
+function snapshotFields() {
+  const top = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
+    .filter(f => !f.parentElement?.closest('w-form-field'));
+  return top.map(f => {
+    const label = (f.querySelector('.form-field-label')?.textContent||'').trim().replace(/\s*\*$/,'');
+    const innerFields = Array.from(f.querySelectorAll('w-form-field')).map(inner => ({
+      label: (inner.querySelector('.form-field-label')?.textContent||'').trim().replace(/\s*\*$/,''),
+      controlComponent: inner.querySelector('.form-field-input-wrapper > *')?.tagName.toLowerCase(),
+    }));
+    return { label, innerFields };
+  });
+}
+```
+
+**ナレッジ収集対象（動的フィールド検出時に記録すべき情報）**:
+- **決定条件**: どの picklist の選択に依存するか（例: `spreadsheet + sheet`）
+- **生成パターン**: 親フィールド名（例: `Columns`）+ 子要素の生成ルール（例: `シートのヘッダー列ごとに 1 つ`）
+- **インスタンス固有値は記録しない**: `open_time`, `open_price` 等の実際の列名はテストデータ依存なので保存対象外
+
+**動的 OUTPUT フィールド**: 同じパターンが Recipe data パネルにも反映される（次ステップを開いた時に、前ステップの動的列が `data-tree-item` として出現する）。検出ロジックは [画面 5c](#画面-5c-recipe-data-パネル--出力スキーマ-) のとおり、`.data-tree-item` の `data-icon-id` で型情報も取れる。
+
+⚠ **実証範囲**: SAMPLE シート（4 列）で動的入力フィールド側を確認済み。動的 OUTPUT 側（Recipe data パネルでの列出現）は次サイクルで検証予定。
+
 ## レベル 2 自動収集の標準フロー
 
 `/auto-learn` スキルは **公式ドキュメント（`/sync-connectors`）と UI DOM 観察の組み合わせ**で構築する。Workato の内部 API は呼ばない。
@@ -370,7 +479,7 @@ const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).m
 これで「どのコネクタにどんな trigger / action があるか」のカタログは取れる。  
 ただし入力フィールドの hint や型、出力スキーマの詳細などは公式ドキュメントには載っていないことがある — そこを Phase 2 で補う。
 
-### Phase 2: UI 観察で詳細フィールド情報を収集（Tier 3）
+### Phase 2: UI 観察で詳細フィールド情報を収集
 
 対象オペレーションごとに:
 
@@ -378,7 +487,7 @@ const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).m
 1. navigate to /recipes/<id>/edit （対象 operation を設定済みのスケルトンレシピ）
 2. click .recipe-step__header → Setup タブ到達を待つ
 
-3. 入力フィールドの収集:
+3. 静的入力フィールドの収集:
    - button:contains("Show optional fields") を click
    - w-dialog 出現を待つ
    - label.multi-select-list__item を全列挙
@@ -388,17 +497,21 @@ const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).m
    - w-recipe-step-details w-form-field（top-level のみ）を列挙
      → hint, required (*), control component, has w-toggle-field を取得
    - label をキーにモーダル / フォームの情報をマージ
+   - この時点で field の集合 = "静的入力フィールド" として記録
 
-4. 出力フィールドの収集:
+4. 静的出力フィールドの収集:
    - w-datatree が _minimize なら .data-tree-resize-controls をクリック
    - .data-tree-group_current の .data-tree-group__header を click（外側 __heading ではなく内側）
    - .data-tree-item を全列挙 → pill (label) + data-icon-id (type) を取得
+   - この時点の集合 = "静的出力フィールド" として記録
 
-5. 動的フィールドの検出（picklist 依存型のもの）:
-   - 上記 3, 4 を実行（picklist 未選択状態の field セットを記録）
-   - 想定される dynamic picklist フィールドで値を選ぶ
-   - DOM の reload を待つ（ローディングインジケータが消えるまで）
-   - 上記 3, 4 を再実行 → 差分が動的フィールド
+5. 動的フィールドの検出（picklist 依存）:
+   - 画面 7 を参照
+   - スナップショット → picklist 選択（例: Sheet を選ぶ）→ DOM 安定待ち → 再スナップショット → 差分
+   - 差分: トップレベルの新出 w-form-field + 既存フィールドの内側に新出 w-form-field 群
+   - 動的 input の集合と「決定条件」（どの picklist が起点か）を記録
+   - 同様に Recipe data パネルを再走査して動的 output 集合を取得
+   - ⚠ インスタンス固有値（実際の列名 'open_time' 等）は構造のみ保存し、値は ナレッジに残さない
 ```
 
 ### Phase 3: 収集結果を docs に書き出し

--- a/docs/patterns/auto-learn-ui-operations.md
+++ b/docs/patterns/auto-learn-ui-operations.md
@@ -1,0 +1,625 @@
+# 自動ナレッジ収集: Workato UI 操作 / 内部 API リファレンス
+
+[Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) のレベル 2 でコネクタの input/output フィールド情報を収集するためのリファレンス。
+
+3 つの取得経路を比較した結果、**`/integrations/meta`（内部 API）を主軸**にし、動的フィールドのみ UI 自動化で補う設計を採用する。
+
+## 結論サマリ ⭐
+
+| 経路 | 用途 | 詳細 |
+|---|---|---|
+| **Tier 1**: `docs.workato.com` | 公式情報の補完 | 既存の `/sync-connectors` で活用済 |
+| **Tier 2**: `/integrations/meta?name=<provider>` ⭐ | **静的スキーマの主データソース** | 構造化 JSON で全 trigger/action の input/output を一括取得 |
+| **Tier 3**: UI DOM スクレイピング | 動的フィールド + フォールバック | `extends_*_schema=true` の場合や Tier 2 が取れないとき |
+
+**Tier 2 で取れる情報（実測 — Gmail `new_email` トリガー）**:
+- 全 input フィールド（`name`, `label`, `type`, `control_type`, `optional`, `hint`, `pick_list`, `toggle_field`, `parse_output`）
+- 全 output フィールド（`name`, `label`, `type`, `of`, `properties[]` でネスト構造込み）
+- `extends_input_schema` / `extends_output_schema` フラグ（dynamic 有無）
+
+**UI からのみ取れる情報（Tier 3 を残す理由）**:
+- dynamic picklist 選択後に生成される動的フィールド（テーブル列、シートヘッダ等）
+- カスタムコネクタの一部メタ情報（要調査）
+- 内部 API エンドポイントが将来変わったときのフォールバック
+
+## Tier 2: `/integrations/meta` 内部 API ⭐
+
+### エンドポイント
+
+```
+GET /integrations/meta?name=<provider>&cacheKey=<rotating_key>
+```
+
+- `name`: コネクタの内部 ID（例: `gmail`, `google_sheets`, `salesforce`）— `klass: "Adapters::<X>::Adapter"` から推測可能
+- `cacheKey`: 16 進文字列（例: `eb5a9e02d42_en`）— ビルドごとに変わる、サーバ側でキャッシュキーとして利用
+  - 取得方法: 一度ページを開いて DevTools / network 監視で `/integrations/meta?name=gmail&cacheKey=...` を観察 → 抽出
+  - 期限切れ時は新しいキーで再取得（Workato 自身がやっているのと同じ）
+- 認証: ログイン中のセッション cookie（Claude in Chrome 経由ならそのまま使える）
+
+### レスポンス構造
+
+```jsonc
+{
+  "<provider_name>": {
+    "name": "gmail",
+    "klass": "Adapters::Gmail::Adapter",
+    "title": "Gmail",
+    "categories": ["Productivity", "Sales Enablement"],
+    "config": { /* OAuth / connection 設定 */ },
+    "triggers": {
+      "new_email": {
+        "name": "new_email",
+        "title": "New email",
+        "title_hint": "Triggers when a new email is received",
+        "help": "Checks for new emails every {{authUser.membership.poll_interval}} minutes...",
+        "input": [ /* InputField[] */ ],
+        "output": [ /* OutputField[] */ ],
+        "extends_input_schema": false,
+        "extends_output_schema": false,
+        // ...
+      }
+    },
+    "actions": {
+      "send_mail": { /* 同じ構造 */ },
+      "download_attachment": { /* ... */ },
+      "get_email_or_draft_by_id": { /* ... */ },
+      "__adhoc_http_action": { /* ... */ }
+    },
+    "data_pipeline_triggers": {},
+    "triggers_count": 1,
+    "actions_count": 4
+  }
+}
+```
+
+### `InputField` の構造
+
+```jsonc
+{
+  "name": "___poll_interval",                  // 内部 JSON キー名（重要）
+  "label": "Trigger poll interval",            // 表示ラベル
+  "type": "integer",                           // データ型
+  "control_type": "select",                    // UI レンダリング種別: text / select / date_time / checkbox / textarea / etc.
+  "optional": true,                            // 必須/任意
+  "hint": "How frequently to check...",        // ヒント文（フル）
+  "parse_output": "integer_conversion",        // 型変換ヒント: integer_conversion / boolean_conversion / date_time_conversion
+  "pick_list": [["5 minutes", 5], ["15 minutes", 15], ...],  // preset 値（ラベル + 内部 ID）
+  "toggle_field": {                            // preset/custom 切替がある場合のフィールド設定
+    "control_type": "...", "label": "...", "type": "...", "name": "..."
+  },
+  // 他にも: support_pills, disable_formula, sticky, default, etc.
+}
+```
+
+### `OutputField` の構造
+
+```jsonc
+// 単純型
+{
+  "name": "subject",
+  "label": "Subject",
+  "type": "string"  // string / integer / number / boolean / date_time / array
+}
+
+// 配列（プリミティブ）
+{
+  "name": "labelIds",
+  "label": "Label IDs",
+  "type": "array",
+  "of": "string"
+}
+
+// 配列（オブジェクト = ネスト構造体）
+{
+  "name": "attachments",
+  "label": "Attachments",
+  "type": "array",
+  "of": "object",
+  "properties": [
+    { "name": "mimeType", "label": "Mime type", "type": "string", "control_type": "text" },
+    { "name": "filename", "label": "Filename", "type": "string", "control_type": "text" },
+    { "name": "filesize", "label": "Filesize", "type": "integer", "control_type": "text", "parse_output": "integer_conversion" },
+    { "name": "attachmentId", "label": "Attachment ID", "type": "string", "control_type": "text" }
+  ]
+}
+```
+
+### 取得スニペット
+
+```javascript
+// 1 コネクタ全体のスキーマを取得
+async function fetchConnectorMeta(provider, cacheKey) {
+  const r = await fetch(`/integrations/meta?name=${provider}&cacheKey=${cacheKey}`, { credentials: 'include' });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const j = await r.json();
+  return j[provider]; // top-level key = provider name
+}
+
+// 全 trigger/action のフィールド一覧を平坦化
+function extractAllOperations(adapterMeta) {
+  const ops = [];
+  for (const [name, t] of Object.entries(adapterMeta.triggers || {})) {
+    ops.push({ kind: 'trigger', name, ...t });
+  }
+  for (const [name, a] of Object.entries(adapterMeta.actions || {})) {
+    if (name.startsWith('__')) continue; // skip __adhoc_http_action 等の内部用
+    ops.push({ kind: 'action', name, ...a });
+  }
+  return ops;
+}
+```
+
+### `cacheKey` の取得方法
+
+ページの最初のロード時、`window` 上に Workato が露出させている場合がある（要確認）。  
+確実な方法は network 監視:
+
+```javascript
+// 既に発生している /integrations/meta リクエストから抽出
+async function getCacheKey() {
+  // performance.getEntriesByType('resource') で過去のリソースリクエストを参照
+  const entries = performance.getEntriesByType('resource')
+    .filter(e => e.name.includes('/integrations/meta?'));
+  const m = entries[0]?.name.match(/cacheKey=([^&]+)/);
+  return m?.[1];
+}
+```
+
+### 留意事項
+
+- **動的スキーマ（`extends_*_schema: true`）**: 例えば Google Sheets の "search rows" アクションは sheet 選択後に列名フィールドが生成される。これは Tier 2 の単発リクエストでは取れず、別エンドポイント（`/recipe/<id>/picklist?...` 等）と組み合わせる必要がある。要追加調査。
+- **カスタムコネクタ**: 別エンドポイント `/web_api/recipes/<id>/custom_adapters/pre_install.json` が存在。要追加調査。
+- **`__` プレフィックスのアクション**: `__adhoc_http_action` 等は内部用なので除外する。
+- **i18n**: `cacheKey` の末尾 `_en` は言語コード。スキーマの `label` / `hint` は言語に依存して返ってくるので、ナレッジ収集は **`_en` 固定**で行う。
+
+## Workato UI の DOM 規約
+
+### Angular カスタム要素
+画面の骨格は `w-` 接頭辞の Angular カスタム要素で構成される。クラス名はビルドごとに `ng-tns-c<hash>` のような可変サフィックスを持つので、**タグ名・属性・固定クラス（`recipe-step__header` 等）でセレクタを書く**。
+
+### 命名規約
+- 「コネクタ」は内部表記で **adapter**（`w-adapter-picker`、`adapter-picker__item`）
+- 「ステップ詳細」は **recipe-step-details** で統一
+- 「データツリー（datapill ソース）」は **data-tree** / **datatree**
+
+### 型を表す共通アイコン規約 ⭐
+Workato は型を `data-icon-id` 属性で表現する。これは入力フィールドモーダルでも出力データツリーでも共通:
+
+```html
+<w-svg-icon data-icon-id="field-type/text" ...>
+```
+
+| `data-icon-id` 値 | 意味 |
+|---|---|
+| `field-type/text` | 文字列 |
+| `field-type/integer` | 整数 |
+| `field-type/number` | 小数（推定 — 要他コネクタ検証） |
+| `field-type/date-time` | datetime |
+| `field-type/date` | 日付（推定） |
+| `field-type/boolean` | boolean（推定） |
+| `field-type/text-array` | 文字列配列 |
+| `field-type/array` | オブジェクト配列 |
+| `field-type/object` | オブジェクト（推定） |
+
+未確認の型は他コネクタ調査で追記する。
+
+## 画面別操作リファレンス
+
+### 画面 1: Assets ビュー（プロジェクトのアセット一覧）
+
+**URL**: `https://app.<region>.workato.com/?fid=<workspace_id>#assets`
+
+| 役割 | セレクタ |
+|---|---|
+| プロジェクト切替 | 左サイドバーのプロジェクト名 |
+| 新規アセット作成 | 右上 `Create` ボタン |
+| アセット一覧 | レシピカード `<a>` リンクで `/recipes/<id>` に遷移 |
+
+`/auto-learn` では基本的に Assets ビューを経由せず、レシピ ID を生成 → 直接 `/recipes/<id>/edit` に遷移する。
+
+### 画面 2: レシピ編集画面（空のキャンバス）
+
+**URL**: `https://app.<region>.workato.com/recipes/<recipe_id>/edit`
+
+```
+w-recipe-editor
+├ w-recipe-editor-header                       ← ツールバー
+│   ├ w-editable-text                          ← レシピ名
+│   ├ w-header-mode-switch                     ← RECIPE / TEST JOBS タブ
+│   └ w-header-toolbar-buttons                 ← Save / Test recipe / Refresh / Exit
+└ w-recipe-viewer
+    └ w-recipe-steps-canvas                     ← キャンバス全体
+        └ w-recipe-viewer-steps
+            └ w-recipe-steps
+                └ w-recipe-step × N             ← 各ステップ
+```
+
+**主要な操作対象**:
+
+| 役割 | セレクタ |
+|---|---|
+| ステップを開閉する本体 | `w-recipe-step .recipe-step__header` |
+| 番号バブル（ステップ選択） | `.recipe-step__number-button` |
+| ステップ間の `+` | `button.recipe-step-marker__button_add[aria-label="Add step"]` |
+| 最初のアクション追加 `+` | `w-recipe-add-step button[aria-label="Add step"]` |
+| Save | `<button>` text=`Save` |
+| Exit | `<button>` text=`Exit` |
+| RECIPE/TEST JOBS 切替 | `w-header-mode-switch` 内の `<button>` |
+
+**初期状態の特徴**:
+- Trigger ステップが 1 つだけ存在（プレースホルダ "Select an app and trigger event"）
+- ACTIONS セクションは空で `w-recipe-add-step` の "+" だけ
+
+### 画面 3: App ピッカーパネル（Trigger/Action クリック後）
+
+**遷移**: `.recipe-step__header` をクリック → 右側に `w-recipe-step-details` パネルがスライドイン。
+
+**パネル構造**:
+```
+w-recipe-step-details
+└ w-recipe-step-details-adapter                 ← App ピッカーモード
+    └ w-panel.recipe-step-details
+        ├ w-panel-header (.panel-header)
+        │   ├ .panel-header__wrapper            ← "Choose an app"
+        │   └ button.panel-header__close[aria-label="Close side panel"]
+        └ w-panel-content.recipe-step-details-adapter
+            ├ .tabs__labels                      ← App / Trigger / Connection / Setup
+            │   └ button.tabs__label             (.tabs__label_active で現在地)
+            └ w-adapter-picker
+                ├ input.search-field__input[placeholder="Search for an app"]
+                └ w-adapter-picker-option × N
+                    └ w-select-grid-option
+                        └ button.select-grid-option   ← 内部 textContent = コネクタ名
+```
+
+**主要な操作**:
+
+```javascript
+// コネクタ選択（例: "Gmail"）
+Array.from(document.querySelectorAll('w-adapter-picker-option button.select-grid-option'))
+  .find(b => b.textContent.trim() === 'Gmail')
+  ?.click();
+
+// アプリ名で検索
+const input = document.querySelector('input.search-field__input');
+input.value = 'gmail';
+input.dispatchEvent(new Event('input', { bubbles: true }));
+```
+
+### 画面 4: Connection ピッカー
+
+**遷移**: コネクタを選ぶと自動で `Connection` 段階に進む（タブが切替）。
+
+⚠ **重要な分岐ルール**: 選択可能なトリガーが **1 個** のコネクタは Trigger 段階を**自動スキップ**して既定トリガーを採用 → そのまま Connection に進む。複数トリガー持ちは Trigger ピッカー（後述）が出る。アクションは原則複数あるので Trigger と異なり毎回ピッカーが表示される（推定 — 要検証）。
+
+**遷移先の判定**:
+```javascript
+// 現在のタブを確認
+document.querySelector('button.tabs__label.tabs__label_active')?.textContent.trim();
+// → "Connection" ならスキップ済み / "Trigger" ならピッカーが必要
+
+// または panel-content のクラスで判定
+document.querySelector('w-recipe-step-details w-panel-content')?.className;
+// → "recipe-step-details-connection" / "recipe-step-details-trigger" / "recipe-step-config" 等
+```
+
+**Connection ピッカーの DOM**:
+```
+w-panel-content.recipe-step-details-connection
+└ w-connection-list-picker
+    ├ w-search-field                              ← "Search active connections"
+    ├ w-paging-items-count                        ← "Showing N active connection(s)"
+    ├ button "Refresh list"
+    ├ .connection-list-picker__list
+    │   └ w-connection-card × N
+    │       ├ w-connection-title                   ← 例: "Sample1 | Gmail"
+    │       └ w-folder-path                        ← 配置プロジェクト
+    ├ w-paginator
+    └ button.connection-list-picker__new-connection-button "New connection"
+```
+
+**操作**:
+```javascript
+// 既存コネクションを選ぶ
+Array.from(document.querySelectorAll('w-connection-card'))
+  .find(c => c.textContent.trim().startsWith('Sample1 | Gmail'))
+  ?.click();
+```
+
+タブの enable/disable:
+- Setup タブはコネクションを選ぶまで `disabled`
+- Trigger タブは戻れるが、Trigger スキップ動作の場合は省略可
+
+### 画面 5: Setup（フィールド入力）画面 — 本命
+
+**遷移**: コネクションを選ぶと自動で Setup タブに進む。
+
+**パネル構造**:
+```
+w-recipe-step-details
+└ w-recipe-step-details (config モード)
+    └ w-panel.recipe-step-details
+        ├ w-panel-header                          ← 例: "New email in Gmail"
+        └ w-panel-content.recipe-step-config
+            ├ w-recipe-step-config-search          ← "Find" 検索
+            ├ w-optional-fields-button             ← "Show optional fields"
+            ├ button "Reset"
+            ├ w-recipe-step-help / w-tips          ← HELP バナー
+            └ w-recipe-operation-step-config
+                └ w-endless-scroll
+                    └ w-in-view-item × N
+                        └ w-form-field × N         ← 1 フィールド
+```
+
+**1 フィールドの内訳**:
+```
+w-form-field
+└ .form-field
+    └ .form-field__body
+        ├ w-form-field-simple-label
+        │   └ .form-field-label.form-field-simple-label   ← ラベル文字列（必須は末尾 "*"）
+        └ .form-field-controls
+            ├ w-formula-switcher                          ← Text/Formula 切替（あるとき）
+            ├ w-form-field-ai-button                      ← AI 補助
+            ├ .form-field-input-wrapper
+            │   └ <入力タイプ別 w-* 要素>
+            └ .form-field-hint
+                └ .form-field-hint__content                ← 説明文
+```
+
+**入力タイプ別の `w-*` 要素**:
+
+| タグ | 意味 |
+|---|---|
+| `w-text-field` | プレーンテキスト / 数値 / datetime |
+| `w-text-field-type` | Text/Formula 種別の picklist |
+| `w-text-field-preview` | プレビュー表示 |
+| `w-select` / `w-select-field` | enum / picklist |
+| `w-boolean-select-field` | Yes/No picklist |
+| `w-toggle-field` | "Select from list / Custom value" 切替（**dynamic picklist の入り口**） |
+| `w-date-time-field` | datetime ピッカー（推定） |
+| `w-textarea-field` | 複数行テキスト（推定） |
+
+**🔑 `w-form-field` は入れ子構造**:
+toggle picker のあるフィールドは外側 `w-form-field`（picker 用）と内側 `w-form-field`（実値用）の 2 階層。フィールド一覧を取るときは**トップレベルのみ**にフィルタ:
+```javascript
+const topLevel = Array.from(document.querySelectorAll('w-recipe-step-details w-form-field'))
+  .filter(f => !f.parentElement?.closest('w-form-field'));
+```
+
+**ヘッダーボタン**:
+| 役割 | セレクタ |
+|---|---|
+| Find（フィールド検索） | `<button>` text=`Find` |
+| Show optional fields | `<button>` text=`Show optional fields` |
+| Reset | `<button>` text=`Reset` |
+| パネルを閉じる | `button.panel-header__close` |
+
+### 画面 5b: Show optional fields モーダル ⭐
+
+**遷移**: Setup ヘッダーの `Show optional fields` ボタン → `w-dialog` がモーダルで開く。
+
+```
+w-dialog
+├ ヘッダー: "Show optional fields" + ✕
+├ w-text-filter                                    ← 検索ボックス
+├ w-select-filter "All optional fields"            ← カテゴリ絞り込み
+├ "M of N results selected" カウンタ
+└ multi-select-list
+    ├ label.multi-select-list__checkbox            ← "Select all"（indeterminate あり）
+    └ cdk-virtual-scroll-viewport                  ← 仮想スクロール
+        └ cdk-virtual-scroll-content-wrapper
+            └ label.multi-select-list__item × N
+                ├ input[type=checkbox]              ← visible-by-default 状態
+                ├ w-svg-icon.multi-select-list__item-icon
+                │   data-icon-id="field-type/<TYPE>"   ⭐ 型情報
+                └ span.multi-select-list__item-content
+                    └ span.multi-select-list__item-title  ← フィールド名
+└ Cancel / Apply changes
+```
+
+**全フィールドリスト + 型の抽出**:
+```javascript
+const items = Array.from(document.querySelectorAll('label.multi-select-list__item')).map(label => ({
+  label: label.querySelector('.multi-select-list__item-title')?.textContent.trim(),
+  type: (label.querySelector('.multi-select-list__item-icon')?.getAttribute('data-icon-id') || '').replace(/^field-type\//,''),
+  visibleByDefault: label.querySelector('input[type="checkbox"]')?.checked,
+}));
+```
+
+**全フィールド展開 → Apply**:
+```javascript
+document.querySelector('label.multi-select-list__checkbox')?.click();        // Select all
+Array.from(document.querySelectorAll('button')).find(b => b.textContent.trim() === 'Apply changes')?.click();
+```
+
+### 画面 5c: Recipe data パネル — 出力スキーマ ⭐
+
+**位置**: Setup 画面の左下に常駐するフローティングパネル（最初は minimize 状態）。
+
+```
+w-recipe-step-details
+└ w-recipe-editor-datatree
+    └ w-datatree.recipe-editor-datatree(.recipe-editor-datatree_default | _minimize)
+        └ .data-tree.trigger-line.data-tree_static
+            ├ .data-tree__heading
+            │   ├ h4.data-tree__title             ← "Recipe data"
+            │   └ .data-tree-resize-controls > w-svg-icon  ← 展開/最小化トグル
+            ├ .data-tree__description              ← "To use data from a previous step..."
+            └ .data-tree__scroll
+                └ .data-tree__groups
+                    ├ .data-tree-group(.data-tree-group_opened)
+                    │   ← "Properties"（ワークスペース/レシピメタ情報のデータピル群）
+                    │   └ items...
+                    └ .data-tree-group(.data-tree-group_current)
+                        ← "Current step output / New email (Step 1 output)"
+                        ├ .data-tree-group__heading
+                        ├ .data-tree-group__header              ⚠ 内側をクリックで展開
+                        └ items...
+```
+
+**1 データピルの内訳**:
+```
+.data-tree-item
+├ .data-tree-item__toggle (.data-tree-item__toggle_open)         ← caret（ネスト展開）
+├ .data-tree-item__icon
+│   └ w-svg-icon[data-icon-id="field-type/<TYPE>"]                ⭐ 型情報
+├ w-data-tree-pill.data-tree-item__pill                           ← フィールド名（label）
+└ .data-tree-item__sample                                         ← サンプル値（PII 注意）
+```
+
+**展開とスキーマ抽出**:
+```javascript
+// 1. パネルを最大化
+const datatree = document.querySelector('w-datatree');
+if (datatree?.classList.contains('recipe-editor-datatree_minimize')) {
+  document.querySelector('.data-tree-resize-controls__icon, .data-tree-resize-controls w-svg-icon')?.click();
+}
+
+// 2. Current step output グループを展開（内側 __header が click target）
+const stepGroup = Array.from(document.querySelectorAll('.data-tree-group'))
+  .find(g => /Step \d+ output|Current step output/.test(g.textContent));
+stepGroup?.querySelector('.data-tree-group__header')?.click();
+
+// 3. 全アイテム抽出
+const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).map(it => {
+  const label = (it.querySelector('w-data-tree-pill, .data-tree-item__pill')?.textContent||'').trim();
+  const iconId = it.querySelector('.data-tree-item__icon w-svg-icon, .data-tree-item__icon [data-icon-id]')?.getAttribute('data-icon-id') || '';
+  return { label, type: iconId.replace(/^field-type\//,'') };
+});
+```
+
+⚠ **PII 注意**: `.data-tree-item__sample` には実データ値（メール件名、本文断片、メールアドレス等）が含まれる。**ナレッジ収集ではサンプル値を保存しない**。フィールド名と型のみで `extended_output_schema` の役割は果たせる。
+
+⚠ **ネスト深さ問題（残課題）**: `paddingLeft` が一律 0 で、配列の子要素もフラットに並んで見える。実用上は:
+- toggle が `_closed` → コンテナで子要素を持つ（クリックで展開可能）
+- toggle が `leaf` → 葉ノード
+- toggle が `_open` → 既に展開された親（直後の leaf 群が子）
+- 確実な深さ判定はさらに調査要
+
+## レベル 2 自動収集の標準フロー（再設計）
+
+`/auto-learn` スキルは **Tier 2 を主軸**にし、必要に応じて Tier 3 で補完する。
+
+### 前提
+- Chrome で Workato にログイン済み + Claude in Chrome 拡張が有効
+- 検証用ワークスペースに対象コネクタの認証済みコネクションがある（Tier 3 を使う場合のみ必須）
+
+### Phase 1: cacheKey の取得（初回のみ）
+
+```
+navigate to /recipes/<any_recipe_id>/edit
+wait for /integrations/meta?name=...&cacheKey=... が performance entries に現れる
+extract cacheKey from URL query
+```
+
+`cacheKey` はワークスペース内では一定期間共有されるので、最初の 1 回取れば複数コネクタで使い回せる。
+
+### Phase 2: コネクタ全体スキーマの取得（Tier 2）
+
+```
+fetch /integrations/meta?name=<provider>&cacheKey=<key>
+parse triggers / actions
+for each operation:
+  記録: name, kind (trigger/action), title, help, extends_input_schema, extends_output_schema
+  記録: input_fields[] = [{ name, label, type, control_type, optional, hint, pick_list, toggle_field, parse_output }]
+  記録: output_fields[] = [{ name, label, type, of, properties[] (再帰) }]
+```
+
+これで **`extends_*_schema: false` のオペレーションは収集完了**（Pre-built コネクタの大半はここに該当）。
+
+### Phase 3: 動的スキーマの収集（`extends_*_schema: true` のもののみ）
+
+```
+for each operation with extends_input_schema=true or extends_output_schema=true:
+  navigate to /recipes/<id>/edit (operation を予め設定済みのスケルトンレシピ)
+  click .recipe-step__header
+  Setup タブ到達待ち
+
+  if extends_input_schema:
+    open Show optional fields modal
+    extract all field labels + data-icon-id
+    apply changes
+
+    if dynamic picklist が想定される field 存在:
+      pick a value
+      wait for schema reload
+      re-extract fields
+      diff = dynamic input fields
+
+  if extends_output_schema:
+    expand Recipe data panel
+    expand Current step output group
+    extract .data-tree-item の (label, field-type)
+    if any picklist was selected: 同じく差分で動的 output を識別
+```
+
+### Phase 4: 収集結果を docs に書き出し
+
+```
+docs/connectors/<provider>.md に
+## triggers
+### <name>
+- title, description, help
+- extends_input_schema: bool
+- extends_output_schema: bool
+- input_fields: <Tier 2 の構造をそのまま>
+- output_fields: <Tier 2 の構造をそのまま>
+- dynamic_input_fields: <Tier 3 で取れた差分（あれば）>
+- dynamic_output_fields: <同上>
+
+## actions
+... (同じ構造)
+```
+
+### カスタムコネクタの扱い（要追加調査）
+
+- `/web_api/recipes/<id>/custom_adapters/pre_install.json` で取得可能な可能性
+- 取れない場合は、既存の `/sync-connectors` が `connector.rb` をパースしてカタログ化する仕組みを流用
+
+## 実装上の注意
+
+### クラス名のサフィックス
+`ng-tns-c2016029271-7` のような Angular の view encapsulation サフィックスはビルド毎に変わる。**セレクタには使わない**。固定クラス（`recipe-step__header` 等）と要素タグで指定する。
+
+### 仮想スクロール
+`cdk-virtual-scroll-viewport` を使っているリストは画面外要素が DOM に存在しない場合がある。スクロールしてからクエリし直すか、データ量が少ない場合のみフラット展開する。
+
+### Shadow DOM
+現時点では Workato 主要コンポーネントに Shadow DOM の壁は確認されていない。すべて light DOM で取得可能。
+
+### クリックの不発
+Angular のイベントリスナーは要素自身ではなく親に張られているケースがある。クリックが効かないときは:
+- 1 段親をクリック
+- `dispatchEvent(new MouseEvent('click', {bubbles: true}))`
+- 物理座標クリック（`computer.left_click`）
+
+`.data-tree-group_current` の展開は **外側の `__heading` ではなく内側の `__header`** を click しないと効かなかった（実測）。
+
+### PII の取り扱い
+`.data-tree-item__sample` や `panel.querySelectorAll` の戻り値にはユーザーの実データが含まれる。ナレッジ収集スキルは:
+- **サンプル値を docs に書かない**
+- **トランスクリプトに dump しない**
+- フィールド名と型情報のみを保存
+
+## 残課題
+
+### Tier 2 関連
+- [ ] `cacheKey` の取得方法を確実にする（performance entries 経由 / `window.*` への露出有無 / 期限切れ時の再取得）
+- [ ] **動的スキーマの取得経路** — `extends_*_schema: true` のオペレーションで Workato 自身がどのエンドポイントを叩いているかを観察（picklist 選択 → 再フェッチの URL を捕捉）
+- [ ] **カスタムコネクタの meta API** — `/web_api/recipes/<id>/custom_adapters/pre_install.json` の構造調査
+- [ ] エンドポイント変更耐性 — Workato が将来 `cacheKey` ベースから別形式に変えた場合のフォールバック設計
+- [ ] レート制限 / 同時リクエスト制約の確認（300 コネクタを順次取得する際）
+
+### Tier 3 関連（動的フィールド検出）
+- [ ] dynamic picklist 選択 → スキーマ再読み込み の確実な検出方法（DOM 差分 vs network ピング）
+- [ ] データツリーの**ネスト深さ判定** — Tier 2 では `properties[]` で取れるが、動的に追加されたフィールドのネスト判定方法（Tier 3 のみで完結する場合）
+- [ ] 複数トリガー持ちコネクタの **Trigger ピッカー画面**の DOM 構造（自動スキップしないコネクタでの観察）
+
+### Tier 1 関連
+- [ ] `/sync-connectors` との役割分担を明確化（Tier 2 が主軸になった今、`/sync-connectors` はカスタムコネクタ専用 or 補完用に再定義）
+
+## 参考
+
+- Issue #27: 自動ナレッジ収集 — レシピ push/pull + ブラウザ自動化によるフィールド情報取得
+- 既存の関連検証は同 Issue のコメント履歴に詳細あり

--- a/docs/patterns/auto-learn-ui-operations.md
+++ b/docs/patterns/auto-learn-ui-operations.md
@@ -1,176 +1,30 @@
-# 自動ナレッジ収集: Workato UI 操作 / 内部 API リファレンス
+# 自動ナレッジ収集: Workato UI 操作リファレンス
 
 [Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) のレベル 2 でコネクタの input/output フィールド情報を収集するためのリファレンス。
 
-3 つの取得経路を比較した結果、**`/integrations/meta`（内部 API）を主軸**にし、動的フィールドのみ UI 自動化で補う設計を採用する。
+**Workato の内部（非公開）API を直接叩く方式は採用しない**。情報源は (a) 公式ドキュメント `docs.workato.com` と (b) Workato UI の DOM 観察 の 2 つに限定する。
 
-## 結論サマリ ⭐
+## 結論サマリ
 
-| 経路 | 用途 | 詳細 |
+| 情報源 | 用途 | 詳細 |
 |---|---|---|
-| **Tier 1**: `docs.workato.com` | 公式情報の補完 | 既存の `/sync-connectors` で活用済 |
-| **Tier 2**: `/integrations/meta?name=<provider>` ⭐ | **静的スキーマの主データソース** | 構造化 JSON で全 trigger/action の input/output を一括取得 |
-| **Tier 3**: UI DOM スクレイピング | 動的フィールド + フォールバック | `extends_*_schema=true` の場合や Tier 2 が取れないとき |
+| **公式ドキュメント**: `docs.workato.com` | 静的スキーマの主データソース | 既存の `/sync-connectors` で API 経由活用済 |
+| **UI DOM 観察**（本ドキュメントの主題） | 動的フィールド + 公式ドキュメントに無い情報 | Claude in Chrome でレシピ編集画面を操作 |
 
-**Tier 2 で取れる情報（実測 — Gmail `new_email` トリガー）**:
-- 全 input フィールド（`name`, `label`, `type`, `control_type`, `optional`, `hint`, `pick_list`, `toggle_field`, `parse_output`）
-- 全 output フィールド（`name`, `label`, `type`, `of`, `properties[]` でネスト構造込み）
-- `extends_input_schema` / `extends_output_schema` フラグ（dynamic 有無）
+**UI から取れる情報**:
+- 入力フィールド一覧（hidden 含む）と各フィールドの型 — `Show optional fields` モーダル
+- フィールドのヒント文・必須・コントロール種別 — Setup フォーム
+- Toggle picker（preset/custom 切替）の有無 — Setup フォーム
+- 出力スキーマと各フィールドの型 — Recipe data パネル
+- 動的フィールド（テーブル列等）— picklist 選択前後の DOM 差分
 
-**UI からのみ取れる情報（Tier 3 を残す理由）**:
-- dynamic picklist 選択後に生成される動的フィールド（テーブル列、シートヘッダ等）
-- カスタムコネクタの一部メタ情報（要調査）
-- 内部 API エンドポイントが将来変わったときのフォールバック
+これにより `extended_input_schema` / `extended_output_schema` / `dynamicPickListSelection` / `toggleCfg` / `visible_config_fields` 相当のデータが、UI セッション 1 回で収集できる。
 
-## Tier 2: `/integrations/meta` 内部 API ⭐
-
-### エンドポイント
-
-```
-GET /integrations/meta?name=<provider>&cacheKey=<rotating_key>
-```
-
-- `name`: コネクタの内部 ID（例: `gmail`, `google_sheets`, `salesforce`）— `klass: "Adapters::<X>::Adapter"` から推測可能
-- `cacheKey`: 16 進文字列（例: `eb5a9e02d42_en`）— ビルドごとに変わる、サーバ側でキャッシュキーとして利用
-  - 取得方法: 一度ページを開いて DevTools / network 監視で `/integrations/meta?name=gmail&cacheKey=...` を観察 → 抽出
-  - 期限切れ時は新しいキーで再取得（Workato 自身がやっているのと同じ）
-- 認証: ログイン中のセッション cookie（Claude in Chrome 経由ならそのまま使える）
-
-### レスポンス構造
-
-```jsonc
-{
-  "<provider_name>": {
-    "name": "gmail",
-    "klass": "Adapters::Gmail::Adapter",
-    "title": "Gmail",
-    "categories": ["Productivity", "Sales Enablement"],
-    "config": { /* OAuth / connection 設定 */ },
-    "triggers": {
-      "new_email": {
-        "name": "new_email",
-        "title": "New email",
-        "title_hint": "Triggers when a new email is received",
-        "help": "Checks for new emails every {{authUser.membership.poll_interval}} minutes...",
-        "input": [ /* InputField[] */ ],
-        "output": [ /* OutputField[] */ ],
-        "extends_input_schema": false,
-        "extends_output_schema": false,
-        // ...
-      }
-    },
-    "actions": {
-      "send_mail": { /* 同じ構造 */ },
-      "download_attachment": { /* ... */ },
-      "get_email_or_draft_by_id": { /* ... */ },
-      "__adhoc_http_action": { /* ... */ }
-    },
-    "data_pipeline_triggers": {},
-    "triggers_count": 1,
-    "actions_count": 4
-  }
-}
-```
-
-### `InputField` の構造
-
-```jsonc
-{
-  "name": "___poll_interval",                  // 内部 JSON キー名（重要）
-  "label": "Trigger poll interval",            // 表示ラベル
-  "type": "integer",                           // データ型
-  "control_type": "select",                    // UI レンダリング種別: text / select / date_time / checkbox / textarea / etc.
-  "optional": true,                            // 必須/任意
-  "hint": "How frequently to check...",        // ヒント文（フル）
-  "parse_output": "integer_conversion",        // 型変換ヒント: integer_conversion / boolean_conversion / date_time_conversion
-  "pick_list": [["5 minutes", 5], ["15 minutes", 15], ...],  // preset 値（ラベル + 内部 ID）
-  "toggle_field": {                            // preset/custom 切替がある場合のフィールド設定
-    "control_type": "...", "label": "...", "type": "...", "name": "..."
-  },
-  // 他にも: support_pills, disable_formula, sticky, default, etc.
-}
-```
-
-### `OutputField` の構造
-
-```jsonc
-// 単純型
-{
-  "name": "subject",
-  "label": "Subject",
-  "type": "string"  // string / integer / number / boolean / date_time / array
-}
-
-// 配列（プリミティブ）
-{
-  "name": "labelIds",
-  "label": "Label IDs",
-  "type": "array",
-  "of": "string"
-}
-
-// 配列（オブジェクト = ネスト構造体）
-{
-  "name": "attachments",
-  "label": "Attachments",
-  "type": "array",
-  "of": "object",
-  "properties": [
-    { "name": "mimeType", "label": "Mime type", "type": "string", "control_type": "text" },
-    { "name": "filename", "label": "Filename", "type": "string", "control_type": "text" },
-    { "name": "filesize", "label": "Filesize", "type": "integer", "control_type": "text", "parse_output": "integer_conversion" },
-    { "name": "attachmentId", "label": "Attachment ID", "type": "string", "control_type": "text" }
-  ]
-}
-```
-
-### 取得スニペット
-
-```javascript
-// 1 コネクタ全体のスキーマを取得
-async function fetchConnectorMeta(provider, cacheKey) {
-  const r = await fetch(`/integrations/meta?name=${provider}&cacheKey=${cacheKey}`, { credentials: 'include' });
-  if (!r.ok) throw new Error(`HTTP ${r.status}`);
-  const j = await r.json();
-  return j[provider]; // top-level key = provider name
-}
-
-// 全 trigger/action のフィールド一覧を平坦化
-function extractAllOperations(adapterMeta) {
-  const ops = [];
-  for (const [name, t] of Object.entries(adapterMeta.triggers || {})) {
-    ops.push({ kind: 'trigger', name, ...t });
-  }
-  for (const [name, a] of Object.entries(adapterMeta.actions || {})) {
-    if (name.startsWith('__')) continue; // skip __adhoc_http_action 等の内部用
-    ops.push({ kind: 'action', name, ...a });
-  }
-  return ops;
-}
-```
-
-### `cacheKey` の取得方法
-
-ページの最初のロード時、`window` 上に Workato が露出させている場合がある（要確認）。  
-確実な方法は network 監視:
-
-```javascript
-// 既に発生している /integrations/meta リクエストから抽出
-async function getCacheKey() {
-  // performance.getEntriesByType('resource') で過去のリソースリクエストを参照
-  const entries = performance.getEntriesByType('resource')
-    .filter(e => e.name.includes('/integrations/meta?'));
-  const m = entries[0]?.name.match(/cacheKey=([^&]+)/);
-  return m?.[1];
-}
-```
-
-### 留意事項
-
-- **動的スキーマ（`extends_*_schema: true`）**: 例えば Google Sheets の "search rows" アクションは sheet 選択後に列名フィールドが生成される。これは Tier 2 の単発リクエストでは取れず、別エンドポイント（`/recipe/<id>/picklist?...` 等）と組み合わせる必要がある。要追加調査。
-- **カスタムコネクタ**: 別エンドポイント `/web_api/recipes/<id>/custom_adapters/pre_install.json` が存在。要追加調査。
-- **`__` プレフィックスのアクション**: `__adhoc_http_action` 等は内部用なので除外する。
-- **i18n**: `cacheKey` の末尾 `_en` は言語コード。スキーマの `label` / `hint` は言語に依存して返ってくるので、ナレッジ収集は **`_en` 固定**で行う。
+> **内部 API の扱い（重要な線引き）**:
+> - ❌ **NG**: 内部 API（`/integrations/meta`、`/connections/<id>/extended_schema.json` 等）を**こちらで構築したリクエストで直接叩く**こと、およびリクエスト/レスポンスを総当たりで観察してリバースエンジニアリングすること。
+> - ✅ **OK**: ユーザー（または自動化スクリプト）が **通常の UI 操作**を行った結果として Workato 自身が発火させたリクエストの**レスポンスを受動的に読む**こと。
+>
+> 本ナレッジ収集スキルは UI 操作を主軸にし、補助的にレスポンスを読み取って構造化データを得る設計にする。スキルから直接 fetch / XHR で内部エンドポイントを呼ぶことは行わない。
 
 ## Workato UI の DOM 規約
 
@@ -497,85 +351,80 @@ const items = Array.from(stepGroup?.querySelectorAll('.data-tree-item') || []).m
 - toggle が `_open` → 既に展開された親（直後の leaf 群が子）
 - 確実な深さ判定はさらに調査要
 
-## レベル 2 自動収集の標準フロー（再設計）
+## レベル 2 自動収集の標準フロー
 
-`/auto-learn` スキルは **Tier 2 を主軸**にし、必要に応じて Tier 3 で補完する。
+`/auto-learn` スキルは **公式ドキュメント（`/sync-connectors`）と UI DOM 観察の組み合わせ**で構築する。Workato の内部 API は呼ばない。
 
 ### 前提
 - Chrome で Workato にログイン済み + Claude in Chrome 拡張が有効
-- 検証用ワークスペースに対象コネクタの認証済みコネクションがある（Tier 3 を使う場合のみ必須）
+- 検証用ワークスペースに対象コネクタの認証済みコネクションがある
+- 検証用プロジェクトに対象オペレーション（trigger / action）を使うスケルトンレシピを事前作成（`workato push` 経由で JSON から生成）
 
-### Phase 1: cacheKey の取得（初回のみ）
-
-```
-navigate to /recipes/<any_recipe_id>/edit
-wait for /integrations/meta?name=...&cacheKey=... が performance entries に現れる
-extract cacheKey from URL query
-```
-
-`cacheKey` はワークスペース内では一定期間共有されるので、最初の 1 回取れば複数コネクタで使い回せる。
-
-### Phase 2: コネクタ全体スキーマの取得（Tier 2）
+### Phase 1: 公式ドキュメントから静的情報を収集（既存の /sync-connectors）
 
 ```
-fetch /integrations/meta?name=<provider>&cacheKey=<key>
-parse triggers / actions
-for each operation:
-  記録: name, kind (trigger/action), title, help, extends_input_schema, extends_output_schema
-  記録: input_fields[] = [{ name, label, type, control_type, optional, hint, pick_list, toggle_field, parse_output }]
-  記録: output_fields[] = [{ name, label, type, of, properties[] (再帰) }]
+/sync-connectors を実行 → docs.workato.com の各コネクタページを WebFetch
+→ docs/connectors/<provider>.md にトリガー・アクションのリストと概要を反映
 ```
 
-これで **`extends_*_schema: false` のオペレーションは収集完了**（Pre-built コネクタの大半はここに該当）。
+これで「どのコネクタにどんな trigger / action があるか」のカタログは取れる。  
+ただし入力フィールドの hint や型、出力スキーマの詳細などは公式ドキュメントには載っていないことがある — そこを Phase 2 で補う。
 
-### Phase 3: 動的スキーマの収集（`extends_*_schema: true` のもののみ）
+### Phase 2: UI 観察で詳細フィールド情報を収集（Tier 3）
+
+対象オペレーションごとに:
 
 ```
-for each operation with extends_input_schema=true or extends_output_schema=true:
-  navigate to /recipes/<id>/edit (operation を予め設定済みのスケルトンレシピ)
-  click .recipe-step__header
-  Setup タブ到達待ち
+1. navigate to /recipes/<id>/edit （対象 operation を設定済みのスケルトンレシピ）
+2. click .recipe-step__header → Setup タブ到達を待つ
 
-  if extends_input_schema:
-    open Show optional fields modal
-    extract all field labels + data-icon-id
-    apply changes
+3. 入力フィールドの収集:
+   - button:contains("Show optional fields") を click
+   - w-dialog 出現を待つ
+   - label.multi-select-list__item を全列挙
+     → label + data-icon-id="field-type/<TYPE>" + visibleByDefault を取得
+   - label.multi-select-list__checkbox を click（Select all）
+   - button:contains("Apply changes") を click → モーダル消失を待つ
+   - w-recipe-step-details w-form-field（top-level のみ）を列挙
+     → hint, required (*), control component, has w-toggle-field を取得
+   - label をキーにモーダル / フォームの情報をマージ
 
-    if dynamic picklist が想定される field 存在:
-      pick a value
-      wait for schema reload
-      re-extract fields
-      diff = dynamic input fields
+4. 出力フィールドの収集:
+   - w-datatree が _minimize なら .data-tree-resize-controls をクリック
+   - .data-tree-group_current の .data-tree-group__header を click（外側 __heading ではなく内側）
+   - .data-tree-item を全列挙 → pill (label) + data-icon-id (type) を取得
 
-  if extends_output_schema:
-    expand Recipe data panel
-    expand Current step output group
-    extract .data-tree-item の (label, field-type)
-    if any picklist was selected: 同じく差分で動的 output を識別
+5. 動的フィールドの検出（picklist 依存型のもの）:
+   - 上記 3, 4 を実行（picklist 未選択状態の field セットを記録）
+   - 想定される dynamic picklist フィールドで値を選ぶ
+   - DOM の reload を待つ（ローディングインジケータが消えるまで）
+   - 上記 3, 4 を再実行 → 差分が動的フィールド
 ```
 
-### Phase 4: 収集結果を docs に書き出し
+### Phase 3: 収集結果を docs に書き出し
 
 ```
 docs/connectors/<provider>.md に
 ## triggers
-### <name>
-- title, description, help
-- extends_input_schema: bool
-- extends_output_schema: bool
-- input_fields: <Tier 2 の構造をそのまま>
-- output_fields: <Tier 2 の構造をそのまま>
-- dynamic_input_fields: <Tier 3 で取れた差分（あれば）>
-- dynamic_output_fields: <同上>
+### <operation_name>
+- title, description, help（Phase 1 から）
+- input_fields:
+  - label, type, required, hint, default_visible, has_toggle_picker（Phase 2 から）
+- output_fields:
+  - label, type（Phase 2 から）
+- dynamic_input_fields:
+  - 決定条件（どの picklist 選択で生成されるか）+ 例（Phase 2 の差分から）
+- dynamic_output_fields:
+  - 同上
 
 ## actions
-... (同じ構造)
+... （同じ構造）
 ```
 
-### カスタムコネクタの扱い（要追加調査）
+### カスタムコネクタの扱い
 
-- `/web_api/recipes/<id>/custom_adapters/pre_install.json` で取得可能な可能性
-- 取れない場合は、既存の `/sync-connectors` が `connector.rb` をパースしてカタログ化する仕組みを流用
+- 既存の `/sync-connectors` がカスタムコネクタの `connector.rb` をパースしてカタログ化する仕組みを流用
+- UI 経由の Phase 2 はカスタム / Pre-built 関係なく適用可能
 
 ## 実装上の注意
 
@@ -602,22 +451,38 @@ Angular のイベントリスナーは要素自身ではなく親に張られて
 - **トランスクリプトに dump しない**
 - フィールド名と型情報のみを保存
 
+### レスポンスの受動観察（任意）
+
+UI 操作の結果として Workato 自身が発火させたリクエストのレスポンスは、補助情報として読んでよい（直接 fetch / XHR を新規発行するのは NG）。
+
+例: ステップを開いたとき、picklist を選んだとき、Workato は内部エンドポイントを叩く。それらのレスポンスには DOM スクレイピングより構造化された情報（フィールドの内部 `name`、データ型、`pick_list` の値ペア等）が含まれることがある。
+
+実装パターン:
+1. `XMLHttpRequest` / `fetch` を **観測専用にラップ**して、レスポンスをコピーして辞書に格納するだけの interceptor を入れる
+2. 通常の UI 操作（ステップを開く、picklist を選ぶ等）を実行
+3. 該当レスポンスが格納されていたら、DOM 抽出結果と突き合わせて補強
+
+注意:
+- **新規リクエストを送らない**。リクエストの URL や body を真似て fetch すること、CSRF トークン回避、ヘッダ偽装などはすべて NG。
+- **エンドポイントの仕様調査として総当たり的にいじらない**。観測するのは、UI 操作の自然な結果として発生したリクエストに限る。
+- レスポンスにユーザーの実データ（メール、シート名、列値等）が含まれる場合は **PII の取り扱い** ルールに従い、フィールド構造のみを抽出して値は破棄する。
+- 内部 API の URL や body 構造を docs に詳細記載しない（変わる可能性があり、依存ナレッジを残すと有害）。
+
 ## 残課題
 
-### Tier 2 関連
-- [ ] `cacheKey` の取得方法を確実にする（performance entries 経由 / `window.*` への露出有無 / 期限切れ時の再取得）
-- [ ] **動的スキーマの取得経路** — `extends_*_schema: true` のオペレーションで Workato 自身がどのエンドポイントを叩いているかを観察（picklist 選択 → 再フェッチの URL を捕捉）
-- [ ] **カスタムコネクタの meta API** — `/web_api/recipes/<id>/custom_adapters/pre_install.json` の構造調査
-- [ ] エンドポイント変更耐性 — Workato が将来 `cacheKey` ベースから別形式に変えた場合のフォールバック設計
-- [ ] レート制限 / 同時リクエスト制約の確認（300 コネクタを順次取得する際）
+### UI 観察関連
+- [ ] dynamic picklist 選択 → スキーマ再読み込みの確実な検出方法（DOM 変化の終了を判定する条件 — ローディングインジケータ消失 / 一定時間の DOM 安定）
+- [ ] データツリーの **ネスト深さ判定** — `paddingLeft` が一律 0 でフラット表示されるため、配列の子要素を親と紐づける確実な手段（toggle state ヒューリスティック以外）
+- [ ] 複数トリガー持ちコネクタの **Trigger ピッカー画面**の DOM 構造（Gmail のように 1 個でスキップされない場合の観察）
+- [ ] 大量フィールドコネクタでの仮想スクロール（`cdk-virtual-scroll-viewport`）追従
+- [ ] saved レシピと unsaved レシピで Recipe data パネルの出方が違うかの確認
 
-### Tier 3 関連（動的フィールド検出）
-- [ ] dynamic picklist 選択 → スキーマ再読み込み の確実な検出方法（DOM 差分 vs network ピング）
-- [ ] データツリーの**ネスト深さ判定** — Tier 2 では `properties[]` で取れるが、動的に追加されたフィールドのネスト判定方法（Tier 3 のみで完結する場合）
-- [ ] 複数トリガー持ちコネクタの **Trigger ピッカー画面**の DOM 構造（自動スキップしないコネクタでの観察）
+### 公式ドキュメント関連
+- [ ] `/sync-connectors` で取れる情報と UI 観察で取れる情報の差分整理（重複の解消、相補的な使い分け）
 
-### Tier 1 関連
-- [ ] `/sync-connectors` との役割分担を明確化（Tier 2 が主軸になった今、`/sync-connectors` はカスタムコネクタ専用 or 補完用に再定義）
+### スキル化
+- [ ] `/auto-learn` スキルの実装（公式ドキュメント + UI 観察の組み合わせ）
+- [ ] スキルの長時間実行（300+ コネクタ）に耐える設計（中断 / 再開、進捗管理）
 
 ## 参考
 


### PR DESCRIPTION
## Summary

[Issue #27](https://github.com/rkawaishi/workato-dev-kit/issues/27) で目標としていた「コネクタの input/output フィールド情報を能動収集する仕組み」を `/auto-learn` スキルとして実装した。Claude in Chrome で Workato UI を実際に操作し、レンダリングされた DOM からフィールド情報を抽出する設計。

## 設計原則

- **自律性優先 + 網羅性重視** — 1 コネクタにつき 1 呼び出しで全 op を試す。途中で対話しない。不確実なものは skip + log。完全性は後追いマニュアルで埋める。
- **UI 観察のみ** — 内部 API（`/integrations/meta`、`/connections/<id>/extended_schema.json` 等）を能動的に叩くのは禁止。リバースエンジニアリングしない。UI 操作で発生したレスポンスの**受動観察**のみ可。

## 含まれる変更

### 新規
- `.claude/skills/auto-learn/SKILL.md` — スキル本体（自律実行設計）
- `.cursor/skills/auto-learn/SKILL.md` — Cursor 同期分
- `docs/patterns/auto-learn-ui-operations.md` — Workato UI の DOM セレクタ・操作スニペット完全リファレンス（611 行）

### 更新
- `.claude/CLAUDE.md` — スキル一覧テーブルに `/auto-learn` を追記
- `docs/connectors/slack_bot.md` — `/auto-learn` の初実走で収集した Workbot for Slack の 6 op 分のフィールド情報

## 実走で得られた知見

Workbot for Slack を対象に初実走し、以下を収集:

**Triggers**:
- `bot_document_mention`: 入力 2、出力 21
- `help_event`: 入力 0、出力 31

**Actions**:
- `delete_message`: 入力 2、出力 2
- `download_attachment`: 入力 1、出力 2
- `upload_file`: 入力 7、出力 26
- `open_bot_dialog`: 入力 5、出力なし（fire-and-forget）

**観察された UI 固有の罠**:
- Workbot for Slack の Action ピッカーで `upload_file` のタイトルが誤って "Return menu options" + File バッジと表示される（generate_menu_options と並んで重複）
- Trigger 1 個コネクタは Trigger picker を auto-skip
- 一部のレガシーアクションは Step output グループ自体が出ない
- 動的 picklist（Google Sheets `search_rows` 等）はサンドボックスデータ依存で API エラーが起きうる

これらはすべて SKILL.md の「止まらない」分岐ルールに反映済み。

## 設計判断の経緯（コミット履歴）

1. `18156ad` UI 操作の DOM セレクタを Issue #27 のレベル 2 として整理
2. `4595660` 内部 API 直叩き方針を撤回（リバースエンジニアリング禁止）
3. `4603395` 動的フィールド検出（Action picker / picklist 選択挙動）を追加
4. `e6acee4` 動的 output を Step 3 の下に Step 4 を追加して観察する手法を確立
5. `45e669b` `/auto-learn` スキル初版
6. `e0fe489` Workbot for Slack 入力フィールド + UI バグ記録
7. `dadf356` Workbot for Slack 出力スキーマ追加
8. `961133e` 実走フィードバックで全面書き換え（自律性 + 網羅性へ）

## Test plan

- [ ] 別コネクタ（例: Salesforce、Jira、Google Drive 等）で `/auto-learn` を実走し、無人で完走することを確認
- [ ] サンドボックス未準備の状態で `/auto-learn` を呼び、対話せずに失敗ログだけ残して終了することを確認
- [ ] 既に詳細フィールドがある op がスキップされることを確認（`--force` で上書き再学習も）
- [ ] レポート出力（試行/完全成功/部分学習/失敗）の整合性
- [ ] `/sync-connectors` → `/auto-learn` → 手動 `/learn-recipe` のライフサイクルが docs に矛盾なく蓄積されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new skill and documentation content only (no runtime library/code paths), so impact is limited to how contributors run tooling and how connector docs are generated/updated.
> 
> **Overview**
> Introduces a new `/auto-learn` skill specification that autonomously drives Workato’s recipe editor UI (Claude in Chrome) to collect per-operation input/output field metadata and append it to `docs/connectors/<provider>.md`, with fail-soft execution, skip/log behavior, and optional dynamic-schema probing via sandbox data.
> 
> Adds a detailed DOM/selector reference (`docs/patterns/auto-learn-ui-operations.md`) to standardize the UI-observation approach and explicitly prohibit active internal-API calls, and registers `/auto-learn` in the main skill list.
> 
> Updates `docs/connectors/slack_bot.md` with newly captured trigger/action field details (including notes about a Workato UI picker mislabeling for `upload_file`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d2235a96783b6067f247e1aabec21bafd9663b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->