### PR TITLE
auto-learn: 7 connectors (75 fully + 23 partial / 98 ops)

### DIFF
--- a/.claude/skills/auto-learn/SKILL.md
+++ b/.claude/skills/auto-learn/SKILL.md
@@ -28,6 +28,7 @@ Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレ
 - `--force` — 既に docs にフィールド詳細があっても上書き学習
 - `--triggers-only` / `--actions-only` — 範囲を絞る
 - `--sandbox <json>` — 動的スキーマ用テストデータ（後述）
+- `--followups` — **UI 操作なしモード**。既存 `docs/connectors/*.md` の `## 学習サマリ` を集約して標準出力に出すだけ。`<provider>` 指定があれば単一コネクタ、なければ全 7+ コネクタ集約。実行フロー（Phase 1-5）は走らない。詳細は本ファイル末尾「Followups mode」参照
 
 事前準備が無い場合（規約レシピ未作成・コネクション未認証など）は、**ユーザーに質問せず失敗ログだけ残して終了**する。
 
@@ -185,9 +186,58 @@ for op in queue:
 - `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
 - `status !== 'ok'`（=`failed_to_open` / `unexpected_error` / 将来追加される非 ok ステータス）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
+### Phase 4 末尾: `## 学習サマリ` セクションの更新（必須）
+
+各 op の追記が終わったら、`docs/connectors/<provider>.md` の **末尾**（最終 `## ...` セクションのさらに下）に `## 学習サマリ` セクションを追加する。**既にあれば差し替え**（このセクションは run の最新スナップショットだけ保持し、過去の run は git 履歴で追う）。
+
+フォーマット（記入欄は run 結果から組み立てる。各リストは ` — ` 区切りで op 名を示す。空集合の場合は当該行を残して `0` と書く）:
+
+```markdown
+## 学習サマリ
+
+最終実行: <YYYY-MM-DD> by /auto-learn
+- 試行: <N> op
+- 完全成功: <M>
+- 部分学習: <K>
+- 学習失敗: <L>
+- スキップ:
+  - Deprecated: <D> — `<op1>`, `<op2>`, ...
+  - adhoc: <A> — `__adhoc_http_action`
+  - 既学習: <S> — `<op1>`, `<op2>`, ...
+
+### 要 follow-up
+
+カテゴリ別。errors[] の prefix と理由文を見てルーティングする:
+
+- **Dynamic schema (要 /learn-recipe)** — `dynamic schema unresolved`, `output_group_missing` (project not selected) 等
+  - `<op>` — <短い説明>
+- **Fire-and-forget (UI 仕様・追加学習不要)** — `output_group_not_found`, `no_output_schema`
+  - `<op>` — <短い説明>
+- **Internal key 不明 (要 /learn-recipe)** — `webhook_suffix` 等の内部キーマッピング不明
+  - `<op>` — <短い説明>
+- **Other** — 上記に当てはまらない部分学習
+  - `<op>` — <reason>
+
+該当カテゴリが空の場合は、そのカテゴリ見出しごと削除して構わない。
+
+### 構造的注記（参考）
+
+各 op section 内の `> ⚠` インライン注記（`> ⚠ 部分学習:` 以外）を 1 行ずつコピー集約:
+
+- 重複ラベル: `<label>` (op: `<op_name>`)
+- paddingLeft=0 によるネスト不可視: ...
+- 動的入力（input picklist 依存）: ...
+
+該当なしなら本見出しごと削除。
+```
+
+このセクションが**「follow-up 出して」依頼に対する単一の参照点**となる。`grep "^## 学習サマリ" docs/connectors/*.md -A 200` で全コネクタの follow-up を一覧できる。
+
+`--followups` モードはこのセクションのみを読んで集約する（Phase 1-3 を走らせない）。詳細は本ファイル末尾「Followups mode」参照。
+
 ### Phase 5: レポート出力
 
-標準出力に短く:
+標準出力に短く（Phase 4 で書いた `## 学習サマリ` の中身と整合させる。出力にズレがあるのは禁止。テキストはそのまま貼る運用で OK）:
 
 ```
 /auto-learn <provider> 完了
@@ -195,6 +245,7 @@ for op in queue:
 - 完全成功: M op
 - 部分学習: K op  (主因: <theme>)
 - 学習失敗: L op  (理由: <reason>)
+- 永続化: docs/connectors/<provider>.md の `## 学習サマリ` を更新
 - マニュアルでフィードバックすべき項目:
   - 重複ラベル: ...
   - ネスト深さ未確定: ...
@@ -202,6 +253,8 @@ for op in queue:
 ```
 
 最後に追記したセクション一覧と git diff 概要を提示し、コミット可否はユーザー判断に任せる（**コミットは自動実行しない**）。
+
+将来「follow-up を出して」と依頼されたら、`docs/connectors/*.md` の `## 学習サマリ` を読むだけで答えられる。新規セッションでも決定的に再現できる。
 
 ## 「止まらない」ための具体ルール
 
@@ -266,6 +319,56 @@ for (const op of queue) {
 ```
 
 タブが死んだ・ネットワークが切れた・ログアウトされた等、recoverable でない事態だけは早期 abort してレポートを返す。判定基準: 連続 3 op 以上失敗 → abort。
+
+## Followups mode (`--followups`)
+
+通常の `/auto-learn` 実行（UI 操作あり）と独立した、**読み取り専用集約モード**。Phase 1〜5 を一切走らせず、`docs/connectors/*.md` の `## 学習サマリ` セクションを読んで follow-up を一覧化するだけ。
+
+### 起動
+
+```
+/auto-learn --followups            # 全コネクタ集約
+/auto-learn <provider> --followups # 単一コネクタのみ
+```
+
+### 動作仕様
+
+1. ターゲット連携:
+   - `<provider>` 指定あり → `docs/connectors/<provider>.md` のみ
+   - 指定なし → `docs/connectors/*.md` 全体（`_index.md` 等の非コネクタファイルは内容を見て除外）
+2. 各ファイルを Read し、`## 学習サマリ` セクションを抽出（次の `## ` または EOF まで）
+3. セクションが無い連携は「未集計」として `unknown` カテゴリにまとめる（過去 run の遺物）
+4. 標準出力に集計表とカテゴリ別 follow-up を出力:
+
+```
+/auto-learn --followups (集約: 8 コネクタ / 学習サマリあり: 7)
+
+| Connector | 試行 | 完全 | 部分 | 失敗 | 最終実行 |
+|---|---|---|---|---|---|
+| gmail | 1 | 1 | 0 | 0 | 2026-04-27 |
+| ...
+
+要 follow-up（カテゴリ別合計）:
+- Dynamic schema (要 /learn-recipe): 19 件
+  - google_big_query: insert_row, search_rows_sync, ...
+  - google_sheets: ...
+- Fire-and-forget (UI 仕様・追加学習不要): 9 件
+- Internal key 不明 (要 /learn-recipe): 1 件
+
+未集計（## 学習サマリ なし、過去 run 遺物の可能性）:
+- xxxx.md
+```
+
+### 設計上の不変条件
+
+- このモードは **UI に触らない**。Chrome MCP も呼ばない。`Read` / `Grep` / `Bash` (grep) のみ
+- `## 学習サマリ` は run の **最新スナップショット**。複数 run の累積は git 履歴で追う（このモードでは追わない）
+- `unknown` カテゴリは「セクション未生成のコネクタ」を可視化することで再 run を促す効果を持つ
+- 出力に書き込みはしない（**docs ファイルを変更しない**）
+
+### 既存セッションでの判断ルール
+
+ユーザーから「follow-up を出して」「skip した op を一覧して」「マニュアルでフィードバックすべき項目を出して」等の依頼を受けた場合、Claude は **`/auto-learn --followups` を呼ぶか、内容を直接実装する** のどちらでも構わない。重要なのは **`## 学習サマリ` のみを唯一の参照点にする**こと（テーブル本文や `> ⚠` インライン注記から再構築しない — 既に集計済みのものを読むだけ）。
 
 ## Git 管理
 

--- a/.cursor/skills/auto-learn/SKILL.md
+++ b/.cursor/skills/auto-learn/SKILL.md
@@ -28,6 +28,7 @@ Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレ
 - `--force` — 既に docs にフィールド詳細があっても上書き学習
 - `--triggers-only` / `--actions-only` — 範囲を絞る
 - `--sandbox <json>` — 動的スキーマ用テストデータ（後述）
+- `--followups` — **UI 操作なしモード**。既存 `docs/connectors/*.md` の `## 学習サマリ` を集約して標準出力に出すだけ。`<provider>` 指定があれば単一コネクタ、なければ全 7+ コネクタ集約。実行フロー（Phase 1-5）は走らない。詳細は本ファイル末尾「Followups mode」参照
 
 事前準備が無い場合（規約レシピ未作成・コネクション未認証など）は、**ユーザーに質問せず失敗ログだけ残して終了**する。
 
@@ -185,9 +186,58 @@ for op in queue:
 - `status === 'ok'` & errors!=[] → 注記行（`> ⚠ 部分学習: <errors>`）を加えてセクション本体に追記
 - `status !== 'ok'`（=`failed_to_open` / `unexpected_error` / 将来追加される非 ok ステータス）→ セクション本体は作らず、ファイル末尾「## 学習失敗ログ」セクションに 1 行追記（`- <op>: status=<status>, reason=<reason> — <date>`）
 
+### Phase 4 末尾: `## 学習サマリ` セクションの更新（必須）
+
+各 op の追記が終わったら、`docs/connectors/<provider>.md` の **末尾**（最終 `## ...` セクションのさらに下）に `## 学習サマリ` セクションを追加する。**既にあれば差し替え**（このセクションは run の最新スナップショットだけ保持し、過去の run は git 履歴で追う）。
+
+フォーマット（記入欄は run 結果から組み立てる。各リストは ` — ` 区切りで op 名を示す。空集合の場合は当該行を残して `0` と書く）:
+
+```markdown
+## 学習サマリ
+
+最終実行: <YYYY-MM-DD> by /auto-learn
+- 試行: <N> op
+- 完全成功: <M>
+- 部分学習: <K>
+- 学習失敗: <L>
+- スキップ:
+  - Deprecated: <D> — `<op1>`, `<op2>`, ...
+  - adhoc: <A> — `__adhoc_http_action`
+  - 既学習: <S> — `<op1>`, `<op2>`, ...
+
+### 要 follow-up
+
+カテゴリ別。errors[] の prefix と理由文を見てルーティングする:
+
+- **Dynamic schema (要 /learn-recipe)** — `dynamic schema unresolved`, `output_group_missing` (project not selected) 等
+  - `<op>` — <短い説明>
+- **Fire-and-forget (UI 仕様・追加学習不要)** — `output_group_not_found`, `no_output_schema`
+  - `<op>` — <短い説明>
+- **Internal key 不明 (要 /learn-recipe)** — `webhook_suffix` 等の内部キーマッピング不明
+  - `<op>` — <短い説明>
+- **Other** — 上記に当てはまらない部分学習
+  - `<op>` — <reason>
+
+該当カテゴリが空の場合は、そのカテゴリ見出しごと削除して構わない。
+
+### 構造的注記（参考）
+
+各 op section 内の `> ⚠` インライン注記（`> ⚠ 部分学習:` 以外）を 1 行ずつコピー集約:
+
+- 重複ラベル: `<label>` (op: `<op_name>`)
+- paddingLeft=0 によるネスト不可視: ...
+- 動的入力（input picklist 依存）: ...
+
+該当なしなら本見出しごと削除。
+```
+
+このセクションが**「follow-up 出して」依頼に対する単一の参照点**となる。`grep "^## 学習サマリ" docs/connectors/*.md -A 200` で全コネクタの follow-up を一覧できる。
+
+`--followups` モードはこのセクションのみを読んで集約する（Phase 1-3 を走らせない）。詳細は本ファイル末尾「Followups mode」参照。
+
 ### Phase 5: レポート出力
 
-標準出力に短く:
+標準出力に短く（Phase 4 で書いた `## 学習サマリ` の中身と整合させる。出力にズレがあるのは禁止。テキストはそのまま貼る運用で OK）:
 
 ```
 /auto-learn <provider> 完了
@@ -195,6 +245,7 @@ for op in queue:
 - 完全成功: M op
 - 部分学習: K op  (主因: <theme>)
 - 学習失敗: L op  (理由: <reason>)
+- 永続化: docs/connectors/<provider>.md の `## 学習サマリ` を更新
 - マニュアルでフィードバックすべき項目:
   - 重複ラベル: ...
   - ネスト深さ未確定: ...
@@ -202,6 +253,8 @@ for op in queue:
 ```
 
 最後に追記したセクション一覧と git diff 概要を提示し、コミット可否はユーザー判断に任せる（**コミットは自動実行しない**）。
+
+将来「follow-up を出して」と依頼されたら、`docs/connectors/*.md` の `## 学習サマリ` を読むだけで答えられる。新規セッションでも決定的に再現できる。
 
 ## 「止まらない」ための具体ルール
 
@@ -266,6 +319,56 @@ for (const op of queue) {
 ```
 
 タブが死んだ・ネットワークが切れた・ログアウトされた等、recoverable でない事態だけは早期 abort してレポートを返す。判定基準: 連続 3 op 以上失敗 → abort。
+
+## Followups mode (`--followups`)
+
+通常の `/auto-learn` 実行（UI 操作あり）と独立した、**読み取り専用集約モード**。Phase 1〜5 を一切走らせず、`docs/connectors/*.md` の `## 学習サマリ` セクションを読んで follow-up を一覧化するだけ。
+
+### 起動
+
+```
+/auto-learn --followups            # 全コネクタ集約
+/auto-learn <provider> --followups # 単一コネクタのみ
+```
+
+### 動作仕様
+
+1. ターゲット連携:
+   - `<provider>` 指定あり → `docs/connectors/<provider>.md` のみ
+   - 指定なし → `docs/connectors/*.md` 全体（`_index.md` 等の非コネクタファイルは内容を見て除外）
+2. 各ファイルを Read し、`## 学習サマリ` セクションを抽出（次の `## ` または EOF まで）
+3. セクションが無い連携は「未集計」として `unknown` カテゴリにまとめる（過去 run の遺物）
+4. 標準出力に集計表とカテゴリ別 follow-up を出力:
+
+```
+/auto-learn --followups (集約: 8 コネクタ / 学習サマリあり: 7)
+
+| Connector | 試行 | 完全 | 部分 | 失敗 | 最終実行 |
+|---|---|---|---|---|---|
+| gmail | 1 | 1 | 0 | 0 | 2026-04-27 |
+| ...
+
+要 follow-up（カテゴリ別合計）:
+- Dynamic schema (要 /learn-recipe): 19 件
+  - google_big_query: insert_row, search_rows_sync, ...
+  - google_sheets: ...
+- Fire-and-forget (UI 仕様・追加学習不要): 9 件
+- Internal key 不明 (要 /learn-recipe): 1 件
+
+未集計（## 学習サマリ なし、過去 run 遺物の可能性）:
+- xxxx.md
+```
+
+### 設計上の不変条件
+
+- このモードは **UI に触らない**。Chrome MCP も呼ばない。`Read` / `Grep` / `Bash` (grep) のみ
+- `## 学習サマリ` は run の **最新スナップショット**。複数 run の累積は git 履歴で追う（このモードでは追わない）
+- `unknown` カテゴリは「セクション未生成のコネクタ」を可視化することで再 run を促す効果を持つ
+- 出力に書き込みはしない（**docs ファイルを変更しない**）
+
+### 既存セッションでの判断ルール
+
+ユーザーから「follow-up を出して」「skip した op を一覧して」「マニュアルでフィードバックすべき項目を出して」等の依頼を受けた場合、Claude は **`/auto-learn --followups` を呼ぶか、内容を直接実装する** のどちらでも構わない。重要なのは **`## 学習サマリ` のみを唯一の参照点にする**こと（テーブル本文や `> ⚠` インライン注記から再構築しない — 既に集計済みのものを読むだけ）。
 
 ## Git 管理
 

--- a/docs/connectors/gmail.md
+++ b/docs/connectors/gmail.md
@@ -630,3 +630,19 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | markedMessageUnread[].labelIds | string | Label IDs |
 | markedMessageUnread[].messageId | string | Message ID |
 | markedMessageUnread[].id | string | ID |
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 1 op
+- 完全成功: 1
+- 部分学習: 0
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 0
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 2 — `new_email`, `download_attachment`
+
+要 follow-up なし。

--- a/docs/connectors/gmail.md
+++ b/docs/connectors/gmail.md
@@ -60,6 +60,34 @@ Provider: `gmail`
 |---|---|---|
 | content_bytes | string | 添付ファイルのバイナリコンテンツ |
 
+---
+
+### send_mail (Action)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| To | string | Yes | Yes | Provide the recipient email address(es) separated by comma. |
+| Subject | string | Yes | Yes | — |
+| Email type | select | - | Yes | Select the format of the email message（`Text` / `HTML`） |
+| Message | string | - | Yes | Plain text if selected email type is Text, HTML formatted if selected email type is HTML |
+| From | string | - | No | — |
+| Bcc | string | - | No | — |
+| Cc | string | - | No | — |
+| Reply to | string | - | No | — |
+| Attachments[].File binary content | string | - | No | リスト型のグループフィールド |
+| Attachments[].File name | string | - | No | リスト型のグループフィールド |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | 送信メールの ID |
+| thread_id | string | スレッド ID |
+| label_ids | string | 適用ラベル（例: `UNREAD`） |
+
 ## Custom Action パターン
 
 Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gmail API を直接呼び出せる。

--- a/docs/connectors/google_big_query.md
+++ b/docs/connectors/google_big_query.md
@@ -456,3 +456,35 @@ Provider: `google_big_query`
 ## 学習失敗ログ
 
 （なし — 全 op が `status=ok` で完了。一部は dynamic schema 由来の partial learning）
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 15 op
+- 完全成功: 4
+- 部分学習: 11
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 2 — `insert_rows`（→ `insert_rows_stream`）, `run_custom_sql`（→ `run_custom_sql_sync`）
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 0
+
+### 要 follow-up
+
+- **Dynamic schema (要 /learn-recipe)** — Project/Dataset/Table picklist 未選択により output schema が UI 観察では取れない
+  - `new_row` / `new_rows_batch` / `scheduled_query` — 行系トリガー
+  - `get_query_job_output` — Job ID から行を取得
+  - `insert_row` / `insert_rows_stream` — Insert 系（output schema 動的）
+  - `run_custom_sql_sync` — 同期 SQL 実行（output 出現せず要再調査）
+  - `search_rows` / `search_rows_sync` — 検索 (Legacy + 現行)
+  - `search_rows_using_custom_sql` / `search_rows_using_custom_sql_sync` — SQL 検索 (Legacy + 現行)
+- **Fire-and-forget 寄り (要再確認)**
+  - `load_data_from_file` / `load_data_from_google_table` — ファイル/GCS ロードジョブ
+
+### 構造的注記（参考）
+
+- `new_job_completed` の output で `Load` / `Extract` / `Query` / `State` が `Statistics` と `Configuration` の object 配下に重複登場（`paddingLeft: 0` 起因）
+- `Insert rows` ピッカーは新 UI では `insert_rows_stream` のみ表示（`insert_rows` は picker から非表示）
+- `Run custom SQL in BigQuery` ピッカーは `run_custom_sql_sync` のみ表示

--- a/docs/connectors/google_big_query.md
+++ b/docs/connectors/google_big_query.md
@@ -29,3 +29,430 @@ Provider: `google_big_query`
 | Select rows using custom SQL (Old) | `search_rows_using_custom_sql` | Yes |  |
 | Select rows using custom SQL | `search_rows_using_custom_sql_sync` | Yes |  |
 | Select rows using custom SQL and insert into table | `search_rows_using_custom_sql_sync_insert_table` | Yes |  |
+
+## フィールド詳細
+
+### new_job_completed (New job completed)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Defaults to fetching records created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
+| Trigger poll interval | integer | - | No | — |
+| Dataset | text | - | No | — |
+| Table | text | - | No | — |
+| All users | text | - | No | — |
+| Job type | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Kind | text | — |
+| Job reference | object | — |
+| Project ID | text | — |
+| Job ID | text | — |
+| Location | text | — |
+| State | text | — |
+| Statistics | object | — |
+| Creation time | text | — |
+| Start time | text | — |
+| End time | text | — |
+| Total bytes processed | text | — |
+| Load | object | — |
+| Completion ratio | integer | — |
+| Extract | object | — |
+| Query | object | — |
+| Total slot ms | text | — |
+| Reservation usage | array | — |
+| Reservation ID | text | — |
+| Configuration | object | — |
+| Job type | text | — |
+| COPY | object | — |
+| Status | object | — |
+| Error result | object | — |
+| Errors | array | — |
+| User email | text | — |
+
+> ⚠ `Load` / `Extract` / `Query` / `State` は Statistics と Configuration の各 object 配下に重複登場する。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+
+### new_row (New row)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Unique key |  | Yes | Yes | Select a unique key column to deduplicate rows. Performance can be improved if the selected unique key is indexed. |
+| Use Standard SQL | text | - | Yes | Set to true to use Standard SQL instead of legacy SQL. |
+| Trigger poll interval | integer | - | No | — |
+| Location | text | - | No | — |
+| Output columns | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマのため Project/Dataset/Table を選択しないと output が表示されない）
+
+### new_rows_batch (New rows)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Unique key |  | Yes | Yes | Select a unique key column to deduplicate rows. Performance can be improved if the selected unique key is indexed. |
+| Batch size | integer | - | Yes | Number of rows to process in each job. Larger batch size will increase recipe speed & data throughput. Defaults to 100. |
+| Use Standard SQL | text | - | Yes | Set to true to use Standard SQL instead of legacy SQL. |
+| Trigger poll interval | integer | - | No | — |
+| Location | text | - | No | — |
+| Output columns | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマのため Project/Dataset/Table を選択しないと output が表示されない）
+
+### scheduled_query (Scheduled query)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. It will support only select query. |
+| Automatic schema introspection | text | - | Yes | Toggle to Yes to automatically generate schema based on the query result. Defaults to No to minimize cost. To define columns manually, use the Output fields below. |
+| Schedule settings |  | - | Yes | — |
+| Unique key | text | - | No | — |
+| Max batch size | integer | - | Yes | — |
+| Location | text | - | No | — |
+| Use legacy SQL | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマのため Query の結果カラムが output になる。`Automatic schema introspection=Yes` か `Output fields` 手動定義時のみ確定）
+
+### get_query_job_output (Get batch of rows by Job ID)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Job ID | text | Yes | Yes | ID of the job. This can be found from the 'Job completed in BigQuery Trigger'. |
+| Page token | text | - | Yes | Page token, returned by a previous call, to request the next page of results. |
+| Output fields |  | Yes | Yes | Use this to manually define the columns returned in your query. Only needed when queries take too long. |
+| Page size | integer | - | No | — |
+| Start index | integer | - | No | — |
+| Location | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマ。`Output fields` の手動定義に依存して結果カラムが生成される）
+
+### insert_row (Insert row)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Ignore schema mismatch | text | - | No | — |
+| Skip invalid rows | text | - | No | — |
+
+> ⚠ 動的入力: Project/Dataset/Table 選択後に対象テーブルのカラムが入力フィールドとして展開される（UI 観察時は static のみキャプチャ）
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Errors | array | — |
+| Reason | text | — |
+| Location | text | — |
+| Debug info | text | — |
+| Message | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### insert_rows_stream (Insert rows)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Ignore schema mismatch | text | - | No | — |
+| Skip invalid rows | text | - | No | — |
+
+> ⚠ 動的入力: Project/Dataset/Table 選択後に対象テーブルのカラムが入力配列内 schema として展開される
+
+#### Output fields
+（未学習: 動的スキーマ。Batch アクションのため、insert_row と同様 `Errors[]` ベースの output が想定される）
+
+### load_data_from_file (Load data into BigQuery)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing（ファイルロードは fire-and-forget 寄りのアクションで output が空になる場合あり）
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| File contents | text | Yes | Yes | The file contents to upload to BigQuery. |
+| File size | text | Yes | Yes | Input file size in bytes. |
+| Source format | text | - | Yes | The format of the data files. The default value is CSV. |
+| Autodetect | text | - | Yes | Only applied to CSV and JSON files. Allows BigQuery to automatically infer the schema and options of the data being loaded into the table. |
+| Alter table columns when required? | text | - | Yes | ALLOW_FIELD_ADDITION: allow adding a nullable field to the schema, ALLOW_FIELD_RELAXATION: allow relaxing a required field in the original schema to nullable. |
+| Create disposition | text | - | Yes | CREATE_IF_NEEDED / CREATE_NEVER. Default CREATE_IF_NEEDED. |
+| Write disposition | text | - | No | — |
+| Schema | object | - | No | — |
+| Fields | array | - | No | — |
+| Column name | text | - | No | — |
+| Column type | text | - | No | — |
+| Mode | text | - | No | — |
+| Destination table properties | object | - | No | — |
+| Friendly name | text | - | No | — |
+| Description | text | - | No | — |
+
+#### Output fields
+（未学習: ロードジョブ系アクションは output schema を持たない可能性が高い）
+
+### load_data_from_google_table (Load data from Google Cloud Storage into BigQuery)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing（ロードジョブ系のため output schema が空の可能性）
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Source URI | text | Yes | Yes | Fully qualified URIs that point to your data in Google Cloud. |
+| Source format | text | - | Yes | The format of the data files. The default value is CSV. |
+| Autodetect | text | - | Yes | Only applied to CSV and JSON files. Allows BigQuery to automatically infer the schema and options of the data being loaded into the table. |
+| Alter table columns when required? | text | - | Yes | ALLOW_FIELD_ADDITION / ALLOW_FIELD_RELAXATION. |
+| Create disposition | text | - | Yes | CREATE_IF_NEEDED / CREATE_NEVER. Default CREATE_IF_NEEDED. |
+| Write disposition | text | - | No | — |
+| Schema | object | - | No | — |
+| Fields | array | - | No | — |
+| Column name | text | - | No | — |
+| Column type | text | - | No | — |
+| Mode | text | - | No | — |
+| Destination table properties | object | - | No | — |
+| Friendly name | text | - | No | — |
+| Description | text | - | No | — |
+
+#### Output fields
+（未学習: ロードジョブ系のため output schema が空の可能性）
+
+### run_custom_sql_sync (Run custom SQL in BigQuery)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project ID of the project that contains the destination table. |
+| Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. |
+| Use legacy SQL | text | - | Yes | Toggle to true to use legacy SQL instead of Standard SQL. |
+| Location | text | - | No | — |
+
+#### Output fields
+（未学習: 同期実行 SQL の output 構造は UI 観察時に group が出現せず。実行時に取得すべき）
+
+### search_rows_sync (Select rows)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| WHERE Predicates | array | - | Yes | Build your where conditions with predicates. All options are assumed to be joined with the AND condition. Use select rows with custom SQL for more complex queries. |
+| Wait for query to complete? |  | Yes | Yes | Set to true to wait for queries to run. This turns the action into asynchronous. |
+| Location | text | - | No | — |
+| Output columns | text | - | No | — |
+| Value | text | - | Yes | — |
+| Order by | text | - | No | — |
+| Limit | integer | - | No | — |
+| Offset | integer | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマ。Project/Dataset/Table 選択時に Rows[] 配下にテーブルのカラムが展開される）
+
+### search_rows (Select rows (Old))
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)。Legacy バージョン（新規実装は `search_rows_sync` を推奨）
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
+| Table |  | Yes | Yes | The table of the dataset to load the data to. |
+| Location | text | - | No | — |
+| Output columns | text | - | No | — |
+| Where | text | - | No | — |
+| Order by | text | - | No | — |
+| Limit | integer | - | No | — |
+| Offset | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマ）
+
+### search_rows_using_custom_sql_sync (Select rows using custom SQL)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project which contains the table. |
+| Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Use bind variables, e.g. id = @id, and the parameter field below to parameters inputs. |
+| Parameters |  | - | Yes | First provide the full name assigned to your bind variable in the WHERE condition. e.g. id. Second, provide the actual parameter value. Parameter values can be static or datapills. Select the closest corresponding data type that your database is expecting for the bind variable. |
+| Output fields |  | Yes | Yes | Use this to manually define the columns returned in your query. |
+| Data | object | - | No | — |
+| Location | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Output contains rows? | boolean | — |
+| Rows | array | — |
+| List size | integer | — |
+| List index | integer | — |
+| Kind | text | — |
+| Job reference | object | — |
+| Project ID | text | — |
+| Job ID | text | — |
+| Location | text | — |
+| Total rows | text | — |
+| Page token | text | — |
+| Schema | object | — |
+| Fields | array | — |
+| Etag | text | — |
+| Total bytes processed | text | — |
+| Job complete | boolean | — |
+| Cache hit | boolean | — |
+
+> ⚠ `Rows[]` 配下の各カラムは `Output fields` で定義した内容に応じて動的展開される（UI 観察時は static のみ）
+
+### search_rows_using_custom_sql (Select rows using custom SQL (Old))
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)。Legacy バージョン（新規実装は `search_rows_using_custom_sql_sync` を推奨）
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project to be billed for the query. |
+| Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. |
+| Automatic schema introspection | text | - | Yes | Toggle to true for automatic schema introspection. Defaults to false. |
+| Destination table |  | - | Yes | — |
+| Create disposition | text | - | Yes | CREATE_IF_NEEDED / CREATE_NEVER. Default CREATE_IF_NEEDED. |
+| Use legacy SQL | text | - | Yes | Set to true to use legacy SQL instead of Standard SQL. |
+| Location | text | - | No | — |
+| Write disposition | text | - | No | — |
+| Limit | integer | - | No | — |
+| Offset | text | - | No | — |
+
+#### Output fields
+（未学習: 動的スキーマ）
+
+### search_rows_using_custom_sql_sync_insert_table (Select rows using custom SQL and insert into table)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project |  | Yes | Yes | The project which contains the table. |
+| Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Use bind variables, e.g. id = @id, and the parameter field below to parameters inputs. |
+| Parameters |  | - | Yes | First provide the full name assigned to your bind variable in the WHERE condition. e.g. id. Second, provide the actual parameter value. Parameter values can be static or datapills. |
+| Output fields |  | Yes | Yes | Use this to manually define the columns returned in your query. |
+| Data | object | - | No | — |
+| Location | text | - | No | — |
+| Create disposition | text | - | Yes | — |
+| Write disposition | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Rows | array | — |
+| List size | integer | — |
+| List index | integer | — |
+| Kind | text | — |
+| Job reference | object | — |
+| Project ID | text | — |
+| Job ID | text | — |
+| Location | text | — |
+| Total rows | text | — |
+| Page token | text | — |
+| Schema | object | — |
+| Fields | array | — |
+| Etag | text | — |
+| Total bytes processed | text | — |
+| Job complete | boolean | — |
+| Cache hit | boolean | — |
+
+> ⚠ `Rows[]` 配下のカラム構造は `Output fields` で定義した内容に応じて動的展開される
+
+## 備考
+
+- BigQuery のオペレーションは多くが「Project → Dataset → Table」picklist の選択で動的に input/output schema が生成される。`/auto-learn` の自動収集では project picklist を選ばないため、テーブル列に対応する動的フィールドは未取得（`> ⚠ 動的入力` 注記）。詳細列スキーマは `/learn-recipe` で個別レシピから補完する。
+- 共通入力フィールド: `Project`、`Dataset`、`Table` は ほぼ全アクションで必須。`Location` は地域指定（オプション）。
+- Legacy ops（`Select rows (Old)` / `Select rows using custom SQL (Old)`）は picker に表示されるが、新規実装では同期版（`search_rows_sync` / `search_rows_using_custom_sql_sync`）を推奨。
+- Skip 済み: `__adhoc_http_action`（カスタム HTTP）、`insert_rows`（deprecated → `insert_rows_stream`）、`run_custom_sql`（deprecated → `run_custom_sql_sync`）。
+
+## 学習失敗ログ
+
+（なし — 全 op が `status=ok` で完了。一部は dynamic schema 由来の partial learning）

--- a/docs/connectors/google_calendar.md
+++ b/docs/connectors/google_calendar.md
@@ -29,3 +29,1003 @@ Provider: `google_calendar`
 | Search events | `search_events` | Yes |  |
 | Update event | `update_event` | - |  |
 | Update task | `update_task` | - |  |
+
+## フィールド詳細
+
+### event_end (Event end)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select a calendar to monitor for event end. |
+| Search term | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Calendar ID | text | — |
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Conference data | object | — |
+| Create request | object | — |
+| Entry points | array | — |
+| Conference solution | object | — |
+| Conference ID | text | — |
+| Signature | text | — |
+| Notes | text | — |
+| Focus time properties | object | — |
+| Auto decline mode | text | — |
+| Decline message | text | — |
+| Chat status | text | — |
+| Out of office properties | object | — |
+| Auto decline mode | text | — |
+| Decline message | text | — |
+| Working location properties | object | — |
+| Type | text | — |
+| Home office | text | — |
+| Custom location | object | — |
+| Office location | object | — |
+| Event type | text | — |
+
+### event_start (Event start)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select a calendar to monitor for event start. |
+| Time before unit |  | Yes | Yes | Select a time unit for Time before event start. |
+| Time before event start | integer | Yes | Yes | Enter the time before the event start you want the trigger to pick up the event. The minimum allowed duration is 5 minutes. |
+| Search term | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Calendar ID | text | — |
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Conference data | object | — |
+| Create request | object | — |
+| Entry points | array | — |
+| Conference solution | object | — |
+| Conference ID | text | — |
+| Signature | text | — |
+| Notes | text | — |
+| Focus time properties | object | — |
+| Auto decline mode | text | — |
+| Decline message | text | — |
+| Chat status | text | — |
+| Out of office properties | object | — |
+| Auto decline mode | text | — |
+| Decline message | text | — |
+| Working location properties | object | — |
+| Type | text | — |
+| Home office | text | — |
+| Custom location | object | — |
+| Office location | object | — |
+| Event type | text | — |
+
+### new_event (New event)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select a calendar to monitor for events |
+| Include deleted events? | text | - | Yes | When set to true, job will be triggered for deleted events also. Defaults to false |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Calendar ID | text | — |
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+
+### updated_event (New/updated event)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select a calendar to monitor for events |
+| Include deleted events? | text | - | Yes | When set to true, job will be triggered for deleted events also. Defaults to false |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Calendar ID | text | — |
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+
+### add_attendee_to_an_event (Add attendees to an event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select calendar that event belongs to |
+| Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
+| Attendees | array | Yes | Yes | — |
+| Send notifications? | text | - | Yes | If true, will notify all attendees about changed event |
+| Comment | text | - | No | — |
+| Optional | text | - | No | — |
+| Response status | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Creator | object | — |
+| Email | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| Email | text | — |
+| Self | boolean | — |
+| Attendees | array | — |
+| Email | text | — |
+| Name | text | — |
+| Response status | text | — |
+| Comment | text | — |
+| Optional | boolean | — |
+| Organizer | boolean | — |
+| Self | boolean | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### create_allday_event (Create all day event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select the calendar to create event in |
+| Start date | date | Yes | Yes | Enter event start date |
+| End date | date | - | Yes | Provide event end date for all day event |
+| Displayed time zone |  | Yes | Yes | Does not change time input, only displays the date time in the selected time zone. |
+| Name | text | - | Yes | Event name or summary |
+| Send notifications? | text | - | Yes | This field is deprecated. This field will be overridden by send updates field. If true, sends notifications about created or updated events. |
+| Event description | text | - | No | — |
+| Location | text | - | No | — |
+| Attendee emails | text | - | No | — |
+| Send updates | text | - | No | — |
+| Guests can modify? | text | - | No | — |
+| Display guests list? | text | - | No | — |
+| Status | text | - | No | — |
+| Visibility | text | - | No | — |
+| Show me as | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+
+### create_calendar (Create calendar)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar name | text | Yes | Yes | — |
+| Description | text | - | No | — |
+| Time zone | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| ID | text | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Time zone | text | — |
+| Access role | text | — |
+| Conference properties | object | — |
+| Allowed conference solution types | text-array | — |
+
+### create_event (Create event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select the calendar to create event in |
+| Start date time | date-time | Yes | Yes | Event start date and time |
+| End date time | date-time | Yes | Yes | Event end date and time |
+| Name | text | - | Yes | Event name or summary |
+| Send notifications? | text | - | Yes | This field is deprecated. This field will be overridden by send updates field. If true, sends notifications about created or updated events. |
+| Displayed time zone | text | - | No | — |
+| Event description | text | - | No | — |
+| Location | text | - | No | — |
+| Attendee emails | text | - | No | — |
+| Send updates | text | - | No | — |
+| Guests can modify? | text | - | No | — |
+| Display guests list? | text | - | No | — |
+| Status | text | - | No | — |
+| Visibility | text | - | No | — |
+| Show me as | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+
+### create_task (Create task)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Tasklist |  | Yes | Yes | — |
+| Task name | text | Yes | Yes | — |
+| Notes | text | - | No | — |
+| Status | text | - | No | — |
+| Due date | date-time | - | No | — |
+| Completed date | date-time | - | No | — |
+| Hidden | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Etag | text | — |
+| Parent | text | — |
+| Title | text | — |
+| Description | text | — |
+| Status | text | — |
+| Position | text | — |
+| Self link | text | — |
+| Updated | date-time | — |
+| Due date | date-time | — |
+| Completed date | date-time | — |
+| Hidden | boolean | — |
+| Deleted | boolean | — |
+| Links | array | — |
+| Type | text | — |
+| Description | text | — |
+| Link | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### delete_attendees_from_an_event (Delete attendees from an event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select calendar that event belongs to |
+| Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
+| Attendees | array | Yes | Yes | List of attendees to delete |
+| Send notifications? | text | - | Yes | If true, will notify all attendees about changed event |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Creator | object | — |
+| Email | text | — |
+| Self | boolean | — |
+| Display name | text | — |
+| Organizer | object | — |
+| Email | text | — |
+| Self | boolean | — |
+| Display name | text | — |
+| Attendees | array | — |
+| Email | text | — |
+| Name | text | — |
+| Response status | text | — |
+| Comment | text | — |
+| Optional | boolean | — |
+| Organizer | boolean | — |
+| Self | boolean | — |
+| Additional guests | integer | — |
+| List size | integer | — |
+| List index | integer | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### delete_event (Delete event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (fire-and-forget action)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar |  | Yes | Yes | Select calendar that event belongs to |
+| Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
+| Send notification? | text | - | Yes | If true, will notify attendees about event being deleted |
+
+### get_calendar_by_id (Get calendar by ID)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar ID | text | Yes | Yes | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| ID | text | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Time zone | text | — |
+| Access role | text | — |
+| Conference properties | object | — |
+| Allowed conference solution types | text-array | — |
+
+### get_event_by_id (Get event by ID)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar ID | text | Yes | Yes | ID of calendar that event belongs to. Click calendar settings in the drop down menu next to the specific calendar. Get calendar ID from calendar address field. |
+| Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### list_calendars_public (List calendars)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Minimum access role | text | - | No | — |
+| Show deleted | text | - | No | — |
+| Show hidden | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Items | array | — |
+| Kind | text | — |
+| Etag | text | — |
+| ID | text | — |
+| Summary | text | — |
+| Description | text | — |
+| Time zone | text | — |
+| Color ID | text | — |
+| Background color | text | — |
+| Foreground color | text | — |
+| Selected | boolean | — |
+| Access role | text | — |
+| Default reminders | array | — |
+| Notification settings | object | — |
+| Primary | boolean | — |
+| Conference properties | object | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### search_events (Search events)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Calendar ID | text | Yes | Yes | The calendar to search for events in. Click calendar settings in the drop down menu next to the specific calendar. Get calendar ID from calendar address field. |
+| Search terms | text | - | Yes | Input terms in the event name or description. Partial matches are returned. |
+| Single events | text | - | Yes | Set this to Yes to receive each occurrence of a recurring event as an individual event. |
+| Date from | date-time | - | Yes | Fetch events starting on or after this datetime |
+| Date to | date-time | - | Yes | Fetch events ending on or before this datetime |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Events | array | — |
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attachments | array | — |
+| Attendees | array | — |
+| Creator | object | — |
+| Organizer | object | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### update_event (Update event)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
+| Start date time | date-time | - | Yes | Event start date and time |
+| End date time | date-time | - | Yes | Event end date and time |
+| Name | text | - | Yes | Event name or summary |
+| Send notifications? | text | - | Yes | This field is deprecated. This field will be overridden by send updates field. If true, sends notifications about created or updated events. |
+| Calendar | text | - | No | — |
+| Displayed time zone | text | - | No | — |
+| Event description | text | - | No | — |
+| Location | text | - | No | — |
+| Attendee emails | text | - | No | — |
+| Send updates | text | - | No | — |
+| Guests can modify? | text | - | No | — |
+| Display guests list? | text | - | No | — |
+| Status | text | - | No | — |
+| Visibility | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Etag | text | — |
+| Color ID | text | — |
+| Event import ID | text | — |
+| ID | text | — |
+| Status | text | — |
+| URL | text | — |
+| Created | date-time | — |
+| Updated | date-time | — |
+| Summary | text | — |
+| Description | text | — |
+| Location | text | — |
+| Start | date-time | — |
+| End | date-time | — |
+| Recurrence | text-array | — |
+| Recurring event ID | text | — |
+| Original start time | object | — |
+| Date time | date-time | — |
+| Time zone | text | — |
+| Visibility | text | — |
+| Reminders | object | — |
+| Use default | boolean | — |
+| Overrides | array | — |
+| Show me as | text | — |
+| Hangout link | text | — |
+| Sequence | integer | — |
+| Guests can modify | boolean | — |
+| Guests can see other guests | boolean | — |
+| Attendees | array | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Response status | text | — |
+| Comment | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Creator | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Organizer | object | — |
+| ID | text | — |
+| Email | text | — |
+| Name | text | — |
+| Self | boolean | — |
+| Attachments | array | — |
+| File URL | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Icon link | text | — |
+| File ID | text | — |
+| List size | integer | — |
+| List index | integer | — |
+
+### update_task (Update task)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Tasklist |  | Yes | Yes | — |
+| Task ID | text | Yes | Yes | — |
+| Notes | text | - | No | — |
+| Status | text | - | No | — |
+| Due date | date-time | - | No | — |
+| Completed date | date-time | - | No | — |
+| Hidden | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Etag | text | — |
+| Parent | text | — |
+| Title | text | — |
+| Description | text | — |
+| Status | text | — |
+| Position | text | — |
+| Self link | text | — |
+| Updated | date-time | — |
+| Due date | date-time | — |
+| Completed date | date-time | — |
+| Hidden | boolean | — |
+| Deleted | boolean | — |
+| Links | array | — |
+| Type | text | — |
+| Description | text | — |
+| Link | text | — |
+| List size | integer | — |
+| List index | integer | — |

--- a/docs/connectors/google_calendar.md
+++ b/docs/connectors/google_calendar.md
@@ -1029,3 +1029,28 @@ Provider: `google_calendar`
 | Link | text | — |
 | List size | integer | — |
 | List index | integer | — |
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 17 op
+- 完全成功: 16
+- 部分学習: 1
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 0
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 0
+
+### 要 follow-up
+
+- **Fire-and-forget (UI 仕様・追加学習不要)**
+  - `delete_event` — 削除アクション。output_group_not_found
+
+### 構造的注記（参考）
+
+- 重複ラベル `Email`: `Creator` / `Organizer` / `Attendees[]` 配下で出現。データツリー paddingLeft=0 でフラット表示
+- `event_start` / `event_end` トリガー: `Conference data` / `Focus time properties` / `Out of office properties` / `Working location properties` を含む 76 フィールドが output に出る（`new_event` / `updated_event` の 56 フィールドより多い）
+- 内部 JSON キーと UI label のマッピングは UI 観察では取れない（`/learn-recipe` で補完）

--- a/docs/connectors/google_drive.md
+++ b/docs/connectors/google_drive.md
@@ -566,3 +566,26 @@ Provider: `google_drive`
 - OAuth 2.0 またはサービスアカウント認証
 - Google Drive API v3 使用
 - provider 名: `google_drive`
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 17 op
+- 完全成功: 17
+- 部分学習: 0
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 1 — `upload_file`（→ `upload_file_stream` 推奨）
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 0
+
+### 構造的注記（参考）
+
+- 重複ラベル `List size` / `List index`: `Actions` と `Actors` の各配列配下に同名で出現（`new_activity` 等）。データツリー `paddingLeft: 0` でフラット表示
+- Sharing user / Owners / Last modifying user の object/array 配下が `Display name` / `Email address` / `Permission ID` / `Photo link` / `Me` でフラット重複表示（`new_file_or_folder` 等）
+- 型表示の揺れ: `new_csv_file_batch` は `Starred` / `Trashed` を `boolean` 表示、`new_file_or_folder` は同フィールドを `number` 表示。Workato UI 側の不整合
+- 大文字小文字の揺れ: `MIME type` (`new_csv_file_batch`) vs `Mime type` (他)。UI そのまま捕捉
+
+要 follow-up なし（全 op で input/output 取得済み）。構造的注記は `/learn-recipe` または手動補完の対象。

--- a/docs/connectors/google_drive.md
+++ b/docs/connectors/google_drive.md
@@ -33,6 +33,525 @@ Provider: `google_drive`
 
 ## フィールド詳細
 
+### new_activity (New activity)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Parent folder |  | Yes | Yes | The parent folder which needs to be monitored for activities. Note that the subfolders are monitored too. Either the drive or drive.readonly scope is necessary to populate the picklist. |
+| Start time | date-time | - | Yes | When you start recipe for the first time, it picks up activity from this specified date and time. Defaults to fetching activity an hour ago if left blank. |
+| Activity to monitor |  | Yes | Yes | Choose one or more activities to monitor from. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Title | text | — |
+| Mime type | text | — |
+| Owner | object | — |
+| Team drive | object | — |
+| Domain | object | — |
+| Drive | object | — |
+| Actions | array | — |
+| Detail | object | — |
+| List size | integer | — |
+| List index | integer | — |
+| Actors | array | — |
+| User | object | — |
+| Primary action detail | object | — |
+| Rename | object | — |
+| Move | object | — |
+| Permission change | object | — |
+| Comment | object | — |
+| Reference | object | — |
+| Settings change | object | — |
+| Edit | number | — |
+| Dlp change | object | — |
+| Create | object | — |
+| Delete | object | — |
+| Restore | object | — |
+| Drive file | object | — |
+| Type | text | — |
+| Timestamp | date-time | — |
+
+> ⚠ `List size` / `List index` は `Actions` と `Actors` の各配列配下に重複登場する。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+
+### new_csv_file_batch (New CSV file)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up files created from specified time. Defaults to fetching files created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
+| Parent folder |  | Yes | Yes | Select the parent folder. The uploaded file will be saved under My Drive if not specified. |
+| Sample CSV file | text | - | Yes | Required: Select a CSV file for Workato to understand the data columns in your files. Otherwise, toggle to provide column names manually. |
+| Column delimiter |  | Yes | Yes | The character used to separate column values within each CSV line. |
+| Contains header line? | text | - | Yes | Set to Yes if the first CSV line is a header line, containing column names. |
+| Batch size | number | - | Yes | Number of CSV rows per batch. Workato reads a batch of CSV rows at a time to increase throughput. |
+| Expected encoding | text | - | Yes | Default encoding type is set to UTF-8, and typically doesn't need to be changed. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Event | object | — |
+| ID | text | — |
+| Name | text | — |
+| MIME type | text | — |
+| Description | text | — |
+| Starred | boolean | — |
+| Trashed | boolean | — |
+| Explicitly trashed | boolean | — |
+| Parents | array | — |
+| Version | integer | — |
+| Web content link | text | — |
+| Web view link | text | — |
+| Icon link | text | — |
+| Thumbnail link | text | — |
+| Viewed by me | boolean | — |
+| Viewed by me time | date-time | — |
+| Created time | date-time | — |
+| Modified time | date-time | — |
+| Modified by me time | date-time | — |
+| Sharing user | object | — |
+| Owners | array | — |
+| Last modifying user | object | — |
+| Shared | boolean | — |
+| Owned by me | boolean | — |
+| Viewers can copy content | boolean | — |
+| Writers can share | boolean | — |
+| Original filename | text | — |
+| Full file extension | text | — |
+| File extension | text | — |
+| Md 5 checksum | text | — |
+| Size | number | — |
+| Quota bytes used | number | — |
+| Head revision ID | text | — |
+| Error message | text | — |
+
+### new_file_in_subfolder (New file or folder in folder hierarchy)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Folder |  | Yes | Yes | Select the folder to monitor for new files or folders. All subfolders will be monitored as well. |
+| Trigger poll interval | integer | - | No | — |
+| Chunk size (KB) | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Is folder | boolean | — |
+| Is google file | boolean | — |
+| Is other file | boolean | — |
+| File contents | text | — |
+| ID | text | — |
+| Name | text | — |
+| MIME type | text | — |
+| Description | text | — |
+| Starred | boolean | — |
+| Trashed | boolean | — |
+| Explicitly trashed | boolean | — |
+| Parents | array | Parents 配列の子要素は ID (text) |
+| Version | integer | — |
+| Web content link | text | — |
+| Web view link | text | — |
+| Icon link | text | — |
+| Thumbnail link | text | — |
+| Viewed by me | boolean | — |
+| Viewed by me time | date-time | — |
+| Created time | date-time | — |
+| Modified time | date-time | — |
+| Modified by me time | date-time | — |
+| Sharing user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Owners | array | 各要素は Display name / Email address / Permission ID / Photo link / Me / List size / List index |
+| Last modifying user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Shared | boolean | — |
+| Owned by me | boolean | — |
+| Viewers can copy content | boolean | — |
+| Writers can share | boolean | — |
+| Original filename | text | — |
+| Full file extension | text | — |
+| File extension | text | — |
+| Md 5 checksum | text | — |
+| Size | number | — |
+| Quota bytes used | number | — |
+| Head revision ID | text | — |
+
+> ⚠ データツリー観察ではネスト構造がフラットに表示されるため、Sharing user / Owners / Last modifying user の子要素 (Display name, Email address, Permission ID, Photo link, Me) が同じ階層に重複出現する。実際のスキーマ上は object/array の配下に位置する。
+
+### new_file_or_folder (New file or folder)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Folder |  | Yes | Yes | Select the folder to monitor for new files or folders. Sub-folders will not be monitored. |
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up new files or folders created from this specified date and time. Defaults to fetching files or folders created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
+| Chunk size (KB) | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Is folder | number | — |
+| Is google file | number | — |
+| Is other file | number | — |
+| File contents | text | — |
+| ID | text | — |
+| Name | text | — |
+| Mime type | text | — |
+| Description | text | — |
+| Starred | number | — |
+| Trashed | number | — |
+| Explicitly trashed | number | — |
+| Parents | array | 各要素は ID (text) |
+| Version | integer | — |
+| Web content link | text | — |
+| Web view link | text | — |
+| Icon link | text | — |
+| Thumbnail link | text | — |
+| Viewed by me | number | — |
+| Viewed by me time | date-time | — |
+| Created time | date-time | — |
+| Modified time | date-time | — |
+| Modified by me time | date-time | — |
+| Sharing user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Owners | array | 各要素は Display name / Email address / Permission ID / Photo link / Me |
+| Last modifying user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Shared | number | — |
+| Owned by me | number | — |
+| Viewers can copy content | number | — |
+| Writers can share | number | — |
+| Original filename | text | — |
+| Full file extension | text | — |
+| File extension | text | — |
+| Md 5 checksum | text | — |
+| Size | integer | — |
+| Quota bytes used | integer | — |
+| Head revision ID | text | — |
+
+### add_permission (Add permission to a file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
+| Role |  | Yes | Yes | The role granted by this permission. |
+| Share with |  | Yes | Yes | When creating a permission, if this is set to a user or group, you must provide the email address. When set to domain, you must provide a domain. |
+| Email address | text | - | No | — |
+| Domain | text | - | No | — |
+| Allow file discovery? | text | - | No | — |
+| Send notifications | text | - | No | — |
+| Notification message | text | - | No | — |
+| Transfer ownership | text | - | No | — |
+| Move file to root of the user | text | - | No | — |
+| Use domain admin access? | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Type | text | — |
+| Permission ID | text | — |
+| Email address | text | — |
+| Domain | text | — |
+| Role | text | — |
+| View | text | — |
+| Allow file discovery | number | — |
+| Display name | text | — |
+| Photo link | text | — |
+| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Deleted | number | — |
+
+### copy_file (Copy file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
+| File name | text | - | Yes | Define new file name for the copied file. |
+| Destination folder | text | - | Yes | Select the folder to place the copied file in. By default the file will be copied within the same folder. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Name | text | — |
+| File ID | text | — |
+| Mime type | text | — |
+| Parents | array | 各要素は ID (text) |
+
+### create_folder (Create folder)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Parent folder |  | Yes | Yes | Select parent folder to create new folder in. |
+| Name |  | Yes | Yes | Name of new folder. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Name | text | — |
+| Mime type | text | — |
+
+### delete_file (Delete file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Success | text | — |
+
+### download_file_contents (Download file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
+| Chunk size (KB) | text | - | No | — |
+| Encoding of the file content | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| File contents | text | — |
+| Size | integer | — |
+
+### export_file (Export file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
+| MIME type |  | Yes | Yes | Eg: text/csv. Supported MIME types can be found in Google Drive API docs. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| File content | text | — |
+| Size | text | — |
+
+### get_permission (Get permission of a file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
+| Permission |  | Yes | Yes | Permission ID can be obtained from list permissions action. |
+| Use domain admin access? | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Type | text | — |
+| Permission ID | text | — |
+| Email address | text | — |
+| Domain | text | — |
+| Role | text | — |
+| View | text | — |
+| Allow file discovery | number | — |
+| Display name | text | — |
+| Photo link | text | — |
+| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Deleted | number | — |
+
+### list_permission (List permissions of a file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
+| Maximum results | integer | - | Yes | Enter a value for maximum results to be returned per page. Default maximum is 100. |
+| Page token | integer | - | Yes | Token to specify the next page in a query. This can be found from the "nextPageToken" value in the output of an earlier 'List permissions' action. |
+| Use domain admin access? | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Next page token | text | — |
+| Permissions | array | 配列要素: Kind / Type / Permission ID / Email address / Domain / Role / View / Allow file discovery / Display name / Photo link / Team drive permission details / Permission details / Deleted / List size / List index |
+
+### move_rename_file (Rename or move file/folder)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File or folder ID |  | Yes | Yes | For folder ID, click on the required folder and folder ID can be found at the end of URL. For file ID, right click on the file and select Get shareable link. |
+| Name | text | - | Yes | New name of the file or folder. |
+| Parent folder | text | - | Yes | Select the parent folder. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Name | text | — |
+| File ID | text | — |
+| Mime type | text | — |
+| Parents | array | 各要素は ID (text) |
+
+### remove_permission (Remove permissions from a file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
+| Permission |  | Yes | Yes | Permission ID can be obtained using the List permissions action. In the select permission option, permissions are listed in the role - type - email address format. |
+| Enforce expansive access | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Success | text | — |
+
+### search_file_or_folder (Search files or folders)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Files or folders |  | Yes | Yes | Select whether to search for files or for folders. |
+| Query | text | - | Yes | Query for filtering the search results. Use this field to specify an exact query based on which the files need to be fetched. |
+| Next page token | text | - | Yes | The token for continuing a previous list request on the next page. |
+| Page size | integer | - | Yes | The maximum number of files to return per page. Acceptable values are 1 to 100, inclusive. |
+| Folder | text | - | No | — |
+| Name | text | - | No | — |
+| Modified after | date-time | - | No | — |
+| Trashed files? | text | - | No | — |
+| Starred files? | text | - | No | — |
+| Owner email | text | - | No | — |
+| Writer email | text | - | No | — |
+| Reader email | text | - | No | — |
+| Shared with me? | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Next page token | text | — |
+| Incomplete search | number | — |
+| Files | array | 配列要素: ID / Name / Mime type / Description / Starred / Trashed / Explicitly trashed / Parents / Version / Web content link / Web view link / Icon link / Thumbnail link / Viewed by me / Viewed by me time / Created time / Modified time / Modified by me time / Sharing user / Owners / Last modifying user / Shared / Owned by me / Viewers can copy content / Writers can share / Original filename / Full file extension / File extension / Md 5 checksum / Size / Quota bytes used / Head revision ID / List size / List index |
+
+### update_permission (Update permission of a file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
+| Permission |  | Yes | Yes | Permission ID can be obtained using the List permissions action. |
+| Role |  | Yes | Yes | The role granted by this permission. |
+| Use domain admin access? | text | - | No | — |
+| Transfer ownership | text | - | No | — |
+| Remove expiration | text | - | No | — |
+| Enforce expansive access | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| Type | text | — |
+| Permission ID | text | — |
+| Email address | text | — |
+| Domain | text | — |
+| Role | text | — |
+| View | text | — |
+| Allow file discovery | number | — |
+| Display name | text | — |
+| Photo link | text | — |
+| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Deleted | number | — |
+
+### upload_file_stream (Upload file)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-26
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| File contents |  | Yes | Yes | Contents of the file to upload. |
+| File name | text | - | Yes | Name of the uploaded file. If not specified, the uploaded file will be named as Untitled. |
+| Parent folder | text | - | Yes | Select the parent folder. The uploaded file will be saved under My Drive if not specified. |
+| Properties |  | Yes | Yes | A collection of arbitrary key-value pairs which are visible to all. |
+| Upload file MIME type | text | - | No | — |
+| Target MIME type | text | - | No | — |
+| Description | text | - | No | — |
+| Starred | text | - | No | — |
+| Viewers can copy content | text | - | No | — |
+| Writers can share | text | - | No | — |
+| Chunk size (KB) | text | - | No | — |
+| Copy requires writer permission | text | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Kind | text | — |
+| ID | text | — |
+| Name | text | — |
+| Mime type | text | — |
+| Parents | array | 各要素は ID (text) |
+| Description | text | — |
+| Starred | boolean | — |
+| Viewers can copy content | boolean | — |
+| Writers can share | boolean | — |
+| Properties | array | 各要素は Key (text) / Value (text) |
+| Web view link | text | — |
+
 ### upload_file (Action)
 
 レシピ: Upload Gmail attachments to Google Drive
@@ -47,4 +566,3 @@ Provider: `google_drive`
 - OAuth 2.0 またはサービスアカウント認証
 - Google Drive API v3 使用
 - provider 名: `google_drive`
-

--- a/docs/connectors/google_sheets.md
+++ b/docs/connectors/google_sheets.md
@@ -28,8 +28,17 @@ Provider: `google_sheets`
 | Search rows by query | `search_spreadsheet_rows` | - |  [deprecated] |
 | Search rows using query (old version) | `search_spreadsheet_rows_v3_new` | - |  [deprecated] |
 | Search rows | `search_spreadsheet_rows_v4_new` | Yes |  |
+| Update rows in bulk | `update_row_v4_bulk` | Yes |  |
+| Update row | `update_row_v4_new` | - |  |
+| Update a row | `update_spreadsheet_row` | - |  [deprecated] |
+| Update row using row ID (Deprecated) | `update_spreadsheet_row_v3_new` | - |  |
 
-### search_spreadsheet_rows_v4_new
+## フィールド詳細
+
+### search_spreadsheet_rows_v4_new (Search rows)
+
+種別: Action
+学習元: 既存ナレッジ（手動）
 
 #### Input fields
 | フィールド | 型 | 必須 | 説明 |
@@ -44,7 +53,238 @@ Provider: `google_sheets`
 |---|---|---|
 | rows[] | array of object | 検索結果の行一覧 |
 | rows[].col_<カラム名> | string | スプレッドシートのヘッダー名が `col_` プレフィックス付きでフィールド名になる |
-| Update rows in bulk | `update_row_v4_bulk` | Yes |  |
-| Update row | `update_row_v4_new` | - |  |
-| Update a row | `update_spreadsheet_row` | - |  [deprecated] |
-| Update row using row ID (Deprecated) | `update_spreadsheet_row_v3_new` | - |  |
+
+### new_polling_spreadsheet_row_v4 (New row in sheet in My Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+
+### new_spreadsheet_row_v4 (New row in sheet in My Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Real-time variant; dynamic schema unresolved (spreadsheet/sheet not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+
+### team_drive_new_spreadsheet_row_v4 (New row in sheet in Team Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a team drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+
+### updated_polling_spreadsheet_row_v4_2 (New/updated row in sheet in My Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Polling variant; dynamic schema unresolved (spreadsheet/sheet not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+| Updated | boolean | — |
+
+### updated_spreadsheet_row_v4_2 (New/updated row in sheet in My Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Real-time variant; dynamic schema unresolved
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+| Updated | boolean | — |
+
+### team_drive_updated_spreadsheet_row_v4_2 (New/updated row in sheet in Team Drive)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a team drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
+| Trigger poll interval | integer | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Row number (deprecated) | text | — |
+| Row number | integer | — |
+| Updated | boolean | — |
+
+### add_spreadsheet_row_v4 (Add row)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: dynamic Rows column schema unresolved (no spreadsheet selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to add row to. |
+| Enforce top-left insert | text | - | Yes | Choose this option to insert into the leftmost logical table when there are more than one table in same sheet. Default is set to no. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Updated range | text | — |
+| Updated rows | text | — |
+| Updated columns | text | — |
+| Updated cells | text | — |
+
+### add_row_v4_bulk (Add rows in bulk)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to add row to. |
+| Enforce top-left insert | text | - | Yes | Choose this option to insert into the leftmost logical table when there are more than one table in same sheet. Default is set to no. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Sheet name | text | — |
+| All rows successfully added? | boolean | — |
+| Number of rows added | integer | — |
+| Number of rows failed | integer | — |
+| CSV contents of failed rows | text | — |
+| List of batches | array | 配列要素: Batch number / All rows successfully added? / Starting row / Ending row / Number of rows added / Number of rows failed / Error code / Error text / List size / List index |
+
+### update_row_v4_new (Update row)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Dynamic input row columns and search criteria unresolved (no spreadsheet selected)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to update row. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Spreadsheet name | text | — |
+| Sheet name | text | — |
+| Updated range | text | — |
+| Updated columns count | integer | — |
+
+### update_row_v4_bulk (Update rows in bulk)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
+| Spreadsheet |  | Yes | Yes | Select a spreadsheet to update row. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Spreadsheet ID | text | — |
+| Sheet name | text | — |
+| All rows successfully updated? | boolean | — |
+| Number of rows updated | integer | — |
+| Number of rows failed | integer | — |
+| CSV contents of failed rows | text | — |
+| List of batches | array | 配列要素: Batch number / All rows successfully updated? / Starting row / Ending row / Number of rows updated / Number of rows failed / Error code / Error text / List size / List index |
+
+## 学習失敗ログ
+
+- get_spreadsheet_rows_v4: status=ok (output empty), reason=output schema not materialized in datatree until Spreadsheet picklist is selected (dynamic output) — 2026-04-27

--- a/docs/connectors/google_sheets.md
+++ b/docs/connectors/google_sheets.md
@@ -287,7 +287,7 @@ Provider: `google_sheets`
 
 ## 学習失敗ログ
 
-- get_spreadsheet_rows_v4: status=ok (output empty), reason=output schema not materialized in datatree until Spreadsheet picklist is selected (dynamic output) — 2026-04-27
+（なし — 全 op が `status=ok` で完了。`get_spreadsheet_rows_v4` の output schema は dynamic 由来の partial で、本ログではなく上記セクションの `> ⚠ 部分学習` に記録済み）
 
 ---
 
@@ -295,8 +295,8 @@ Provider: `google_sheets`
 
 最終実行: 2026-04-27 by /auto-learn
 - 試行: 11 op (6 triggers + 5 actions)
-- 完全成功: 9
-- 部分学習: 2
+- 完全成功: 1 — `update_row_v4_new`
+- 部分学習: 10 — 6 triggers (`new_polling_spreadsheet_row_v4`, `new_spreadsheet_row_v4`, `team_drive_new_spreadsheet_row_v4`, `updated_polling_spreadsheet_row_v4_2`, `updated_spreadsheet_row_v4_2`, `team_drive_updated_spreadsheet_row_v4_2`) + 4 actions (`add_spreadsheet_row_v4`, `add_row_v4_bulk`, `get_spreadsheet_rows_v4`, `update_row_v4_bulk`)
 - 学習失敗: 0
 - スキップ:
   - Deprecated: 7
@@ -306,7 +306,9 @@ Provider: `google_sheets`
 ### 要 follow-up
 
 - **Dynamic schema (要 /learn-recipe)** — Spreadsheet/Sheet picklist 未選択により `Rows[]` 配下の動的列スキーマが取れない
+  - 6 triggers — output の `Rows[]` 配下のカラムが未展開（`new_polling_spreadsheet_row_v4` 他 5 件）
   - `get_spreadsheet_rows_v4` — output schema 全体が未確定（datatree に group 出現せず）
+  - `add_spreadsheet_row_v4` — input の Rows カラム未展開
   - `add_row_v4_bulk` / `update_row_v4_bulk` — `List of batches` 配下の per-row column schema が未確定
   - 全 op 共通: `Spreadsheet` picklist 選択時にしか `Rows[]` 配下のカラムは展開されない
 

--- a/docs/connectors/google_sheets.md
+++ b/docs/connectors/google_sheets.md
@@ -288,3 +288,30 @@ Provider: `google_sheets`
 ## 学習失敗ログ
 
 - get_spreadsheet_rows_v4: status=ok (output empty), reason=output schema not materialized in datatree until Spreadsheet picklist is selected (dynamic output) — 2026-04-27
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 11 op (6 triggers + 5 actions)
+- 完全成功: 9
+- 部分学習: 2
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 7
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 1 — `search_spreadsheet_rows_v4_new`
+
+### 要 follow-up
+
+- **Dynamic schema (要 /learn-recipe)** — Spreadsheet/Sheet picklist 未選択により `Rows[]` 配下の動的列スキーマが取れない
+  - `get_spreadsheet_rows_v4` — output schema 全体が未確定（datatree に group 出現せず）
+  - `add_row_v4_bulk` / `update_row_v4_bulk` — `List of batches` 配下の per-row column schema が未確定
+  - 全 op 共通: `Spreadsheet` picklist 選択時にしか `Rows[]` 配下のカラムは展開されない
+
+### 構造的注記（参考）
+
+- Triggers の output は metadata（`Spreadsheet ID`, `Spreadsheet name`, `Sheet name`, `Row number`）のみ resolve 可能。実カラムは sandbox spreadsheet 選択が必要
+- `search_spreadsheet_rows_v4_new` 既存セクションは snake_case 手動 schema。再学習時は `--force` で UI 由来の label format に統一推奨
+- 既存 Actions テーブルの行ずれ（rows 47-50）を本 run で修正済み

--- a/docs/connectors/jira.md
+++ b/docs/connectors/jira.md
@@ -399,6 +399,823 @@ Provider: `jira`
 | issues[].fields.parent.fields.priority.name | string | Name (nested) |
 | issues[].fields.parent.fields.issuetype.name | string | Name (nested) |
 
+### deleted_object (Deleted object)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマは Object picklist の選択結果に依存（dynamic）。プロジェクト未選択のため UI 観察では取得不可。
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Object | select | Yes | Yes | Select the object to receive deleted events from Jira. |
+
+### issue_created_bulk (Export new issues in Jira)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Defaults to one hour from time of start of recipe. |
+| JQL where class | string | - | Yes | JQL query to filter the records you want, e.g. `project = "PRJ" AND status = "Done"`. Only issueKey, project, issuetype, status, assignee, reporter, issue.property and cf[id] JQL queries are supported. ORDER BY clause is not supported. |
+| Fields to retrieve | toggle-field | - | Yes | Select one or more fields from the dropdown. If left blank, defaults to retrieving all navigable fields. |
+| Schedule settings | select | Yes | Yes | — |
+| Time unit | select | Yes | Yes | Select an interval or custom schedule to specify cron expression. |
+| Trigger every | integer | Yes | Yes | Define repeating schedule. Minimum 5 minutes. |
+| When exporting records to form the CSV, fetch them in batches of | integer | - | No | — |
+| Start after | date-time | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| CSV content | string | — |
+| Object name | string | — |
+| Object schema | array | — |
+| Field name | string | — |
+| Field label | string | — |
+| Original type | string | — |
+| Mapped type | string | — |
+| List size | integer | — |
+| List index | integer | — |
+| New From | date_time | — |
+
+### issue_created_or_updated_bulk (Export new/updated issues in Jira)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Defaults to one hour from time of start of recipe. |
+| JQL where class | string | - | Yes | JQL query to filter the records you want, e.g. `project = "PRJ" AND status = "Done"`. Only issueKey, project, issuetype, status, assignee, reporter, issue.property and cf[id] JQL queries are supported. ORDER BY clause is not supported. |
+| Fields to retrieve | toggle-field | - | Yes | Select one or more fields from the dropdown. If left blank, defaults to retrieving all navigable fields. |
+| Schedule settings | select | Yes | Yes | — |
+| Time unit | select | Yes | Yes | Select an interval or custom schedule to specify cron expression. |
+| Trigger every | integer | Yes | Yes | Define repeating schedule. Minimum 5 minutes. |
+| When exporting records to form the CSV, fetch them in batches of | integer | - | No | — |
+| Start after | date-time | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| CSV content | string | — |
+| Object name | string | — |
+| Object schema | array | — |
+| Field name | string | — |
+| Field label | string | — |
+| Original type | string | — |
+| Mapped type | string | — |
+| List size | integer | — |
+| List index | integer | — |
+| New/updated From | date_time | — |
+
+### new_event (New event)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマは Object 選択に依存（dynamic）。Object/プロジェクト未選択のため UI 観察では取得不可。
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Object | select | Yes | Yes | Select the object to receive events from Jira. |
+| Event name | string | Yes | Yes | Use a unique name to generate webhook URL. |
+
+### new_issue_batch (New issue — Batch)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Leave empty to get created records one hour ago. |
+| Batch size | integer | - | Yes | Maximum number of records per trigger event. Min 1, max 100, default 100. |
+| Trigger poll interval | integer | - | No | — |
+| JQL where class | string | - | No | — |
+| Fields to retrieve | toggle-field | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Range | string | — |
+| First issue ID | string | — |
+| Last issue ID | string | — |
+| Issues | array | — |
+| issues[].id | string | ID |
+| issues[].self | string | Self |
+| issues[].key | string | Key |
+| issues[].changelog | object | Changelog |
+| issues[].fields | object | Fields |
+| List size | integer | — |
+| List index | integer | — |
+
+### updated_comment_webhook (New/updated comment)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| JQL WHERE clause | string | - | Yes | JQL query to filter the records you want, e.g. `project = "PRJ" AND status = "Done"`. Only issueKey, project, issuetype, status, assignee, reporter, issue.property and cf[id] JQL queries are supported. ORDER BY clause is not supported. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| id | string | ID |
+| author | object | Author |
+| author.self | string | Self (nested) |
+| author.name | string | Name (nested) |
+| author.accountId | string | Account ID (nested) |
+| author.displayName | string | Display name (nested) |
+| author.active | boolean | Active (nested) |
+| body | string | Body |
+| updateAuthor | object | Update author |
+| updateAuthor.self | string | Self (nested) |
+| updateAuthor.name | string | Name (nested) |
+| updateAuthor.accountId | string | Account ID (nested) |
+| updateAuthor.displayName | string | Display name (nested) |
+| updateAuthor.active | boolean | Active (nested) |
+| created | date_time | Created |
+| updated | date_time | Updated |
+| visibility | object | Visibility |
+| visibility.type | string | Type (nested) |
+| visibility.value | string | Value (nested) |
+
+### updated_issue_webhook (New/updated issue)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | Yes | Yes | When you start recipe for the first time, it picks up new/updated issues from this specified date and time. Once recipe has been run or tested, value cannot be changed. |
+| JQL WHERE clause | string | - | Yes | JQL query to filter records (issueKey, project, issuetype, status, assignee, reporter, issue.property, cf[id]). ORDER BY not supported. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | ID |
+| self | string | Self |
+| key | string | Key |
+| changelog | object | Changelog |
+| changelog.startAt | number | Start at |
+| changelog.maxResults | number | Max results |
+| changelog.total | number | Total |
+| changelog.histories | array | Histories |
+| fields | object | Fields |
+| fields.statuscategorychangedate | date_time | ステータス カテゴリが変更されました |
+| fields.issuetype | object | 課題タイプ |
+| fields.timespent | number | 消費時間 |
+| fields.project | object | プロジェクト |
+| fields.fixVersions | array | 修正バージョン |
+| fields.aggregatetimespent | number | Σ 消費時間 |
+| fields.statusCategory | string | ステータス カテゴリ |
+| fields.customfield_xxx (Vulnerability) | string | Vulnerability |
+| fields.parent | object | 親 |
+| fields.resolution | object | 解決状況 |
+| fields.customfield_xxx (Design) | string | Design |
+| fields.resolutiondate | date_time | 解決日 |
+| fields.workratio | number | 作業比率 |
+| fields.lastViewed | date_time | 最終閲覧日 |
+| fields.watches | object | ウォッチャー |
+| fields.issuerestriction | string | 制限対象 |
+| fields.thumbnail | string | 画像 |
+| fields.created | date_time | 作成日 |
+| fields.customfield_xxx (Flagged) | array | Flagged |
+| fields.priority | object | 優先度 |
+| fields.labels[] | string | ラベル |
+| fields.customfield_xxx (Issue color) | string | Issue color |
+| fields.customfield_xxx (Rank) | string | Rank |
+| fields.timeestimate | number | 残余見積 |
+| fields.aggregatetimeoriginalestimate | number | Σ 初期見積もり |
+| fields.versions | array | 影響するバージョン |
+| fields.issuelinks | array | リンクされた課題 |
+| fields.assignee | object | 担当者 |
+| fields.updated | date_time | 更新日 |
+| fields.status | object | ステータス |
+| fields.components | array | コンポーネント |
+| fields.issuekey | string | キー |
+| fields.timeoriginalestimate | number | 初期見積もり |
+| fields.description | string | 説明 |
+| fields.timetracking | string | 時間管理 |
+| fields.customfield_xxx (Start date) | date | Start date |
+| fields.security | string | セキュリティ レベル |
+| fields.attachment | array | 添付ファイル |
+| fields.aggregatetimeestimate | number | Σ 残余見積 |
+| fields.summary | string | 要約 |
+| fields.creator | object | 作成者 |
+| fields.subtasks | array | サブタスク |
+| fields.reporter | object | 報告者 |
+| fields.aggregateprogress | object | Σ 進捗状況 |
+| fields.customfield_xxx (開発) | string | 開発 |
+| fields.customfield_xxx (Team) | string | Team |
+| fields.environment | string | 環境 |
+| fields.duedate | date | 期限 |
+| fields.progress | object | 進捗状況 |
+| fields.votes | object | 投票 |
+| fields.comment | string | コメント |
+| fields.worklog | array | ログ作業 |
+| webhookData | object | Webhook data |
+| webhookData.timestamp | integer | Timestamp |
+| webhookData.webhookEvent | string | Webhook event |
+| webhookData.user | object | User |
+| webhookData.changelog | object | Changelog |
+
+> ⚠ ラベル名は Workato テナントの Jira UI 言語設定（日本語）に依存。同じトリガーでも英語テナントでは `Issue type` / `Project` / 等で出る。custom field の内部キー（`customfield_10000` 系）は `new_issue` セクションを参照。
+
+### updated_worklog_webhook (New/updated worklog)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 表示される form-field がなく、Webhook 登録のみ。
+
+#### Input fields
+（パラメータなし — Webhook イベント駆動）
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| id | string | ID |
+| comment | string | Comment |
+| author | object | Author |
+| author.self | string | Self (nested) |
+| author.name | string | Name (nested) |
+| author.accountId | string | Account ID (nested) |
+| author.displayName | string | Display name (nested) |
+| author.key | string | Key (nested) |
+| author.timeZone | string | Time zone (nested) |
+| author.avatarUrls | object | Avatar urls (nested) |
+| author.active | boolean | Active (nested) |
+| body | string | Body |
+| updateAuthor | object | Update author |
+| updateAuthor.self | string | Self (nested) |
+| updateAuthor.name | string | Name (nested) |
+| updateAuthor.accountId | string | Account ID (nested) |
+| updateAuthor.displayName | string | Display name (nested) |
+| updateAuthor.key | string | Key (nested) |
+| updateAuthor.timeZone | string | Time zone (nested) |
+| updateAuthor.avatarUrls | object | Avatar urls (nested) |
+| updateAuthor.active | boolean | Active (nested) |
+| created | date_time | Created |
+| updated | date_time | Updated |
+| started | date_time | Started |
+| timeSpent | string | Time spent |
+| timeSpentSeconds | integer | Time spent seconds |
+| issueId | string | Issue ID |
+
+### updated_issue (Updated issue)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | Yes | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Once recipe has been run or tested, value cannot be changed. |
+| Trigger poll interval | integer | - | No | — |
+| JQL where class | string | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | ID |
+| self | string | Self |
+| key | string | Key |
+| changelog | object | Changelog |
+| changelog.startAt | number | Start at |
+| changelog.maxResults | number | Max results |
+| changelog.total | number | Total |
+| changelog.histories | array | Histories |
+| fields | object | Fields |
+
+> 課題本体のフィールド（`fields.*`）の構造は `new_issue` / `updated_issue_webhook` と同等。日本語テナントではラベルが `要約` `担当者` `期限` 等で出る。
+
+### updated_issue_batch (Updated issue — Batch)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Leave empty to get updated records one hour ago. |
+| Batch size | integer | - | Yes | Maximum number of records per trigger event. Min 1, max 100, default 100. |
+| Trigger poll interval | integer | - | No | — |
+| JQL where class | string | - | No | — |
+| Fields to retrieve | toggle-field | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Range | string | — |
+| First issue ID | string | — |
+| Last issue ID | string | — |
+| Issues | array | — |
+| issues[].id | string | ID |
+| issues[].self | string | Self |
+| issues[].key | string | Key |
+| issues[].changelog | object | Changelog |
+| issues[].fields | object | Fields |
+| List size | integer | — |
+| List index | integer | — |
+
+### assign_issue (Assign user to issue)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_not_found（fire-and-forget アクション。出力スキーマなし）。
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. Use issue ID if your issue moves between projects. |
+| Assignee username | toggle-field | Yes | Yes | Assignee's Jira username (e.g. `johndoe` for `johndoe@workato.com`). Only usable in older Jira server. Cloud では Account ID を使う。 |
+
+### create_comment (Create comment)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key to add comment to, e.g. `10105` or `ABC-123`. |
+| Comment text | string | Yes | Yes | Use the Jira format `[~username]` to mention a user. |
+| Visibility | string | - | No | — |
+| Role | string | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| id | string | ID |
+| author | object | Author |
+| author.self | string | Self (nested) |
+| author.name | string | Name (nested) |
+| author.accountId | string | Account ID (nested) |
+| author.displayName | string | Display name (nested) |
+| author.active | boolean | Active (nested) |
+| body | string | Body |
+| updateAuthor | object | Update author |
+| updateAuthor.self | string | Self (nested) |
+| updateAuthor.name | string | Name (nested) |
+| updateAuthor.accountId | string | Account ID (nested) |
+| updateAuthor.displayName | string | Display name (nested) |
+| updateAuthor.active | boolean | Active (nested) |
+| created | date_time | Created |
+| updated | date_time | Updated |
+| visibility | object | Visibility |
+| visibility.type | string | Type (nested) |
+| visibility.value | string | Value (nested) |
+
+### create_issue (Create issue)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project issue type | toggle-field | Yes | Yes | Select the project and issue type for this issue. |
+| Sample project issue type | toggle-field | - | Yes | Select the project and issue type to retrieve custom fields. If Project issue type is not selected, custom fields will not be populated. |
+| Summary | string | Yes | Yes | Summary of issue. |
+| Reporter account ID | toggle-field | - | Yes | Account ID can be found in the people's page at the end of the URL. |
+| Assignee account ID | toggle-field | - | Yes | Account ID can be found in the people's page at the end of the URL. |
+| Components | string | - | No | — |
+| Description | string | - | No | — |
+| Issue priority | string | - | No | — |
+| Labels | string | - | No | — |
+| Time tracking | string | - | No | — |
+| Original estimate | string | - | No | — |
+| Remaining estimate | string | - | No | — |
+| Issue link | string | - | No | — |
+| Due date | date | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | ID |
+| key | string | Key |
+| self | string | Self |
+
+> ⚠ 部分学習: dynamic schema unresolved (Sample project issue type 未選択のためカスタムフィールドは非展開)。プロジェクト固有の custom field 入力は `Sample project issue type` を選択するとフォームに動的に追加される。
+
+### create_user (Create user)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Email address | string | Yes | Yes | New user's e-mail address. |
+| Products | toggle-field | - | Yes | Products the new user has access to. Select none to create a user without any product access. Leave empty for default access. |
+| Password | string | - | No | — |
+| Display name (deprecated) | string | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self url |
+| key | string | Key |
+| name | string | Name |
+| accountId | string | Account ID |
+| emailAddress | string | Email address |
+| avatarUrls | object | Avatar urls |
+| avatarUrls.16x16 | string | 16 x 16 (nested) |
+| avatarUrls.24x24 | string | 24 x 24 (nested) |
+| avatarUrls.32x32 | string | 32 x 32 (nested) |
+| avatarUrls.48x48 | string | 48 x 48 (nested) |
+| displayName | string | Display name |
+| active | boolean | Active |
+| timeZone | string | Time zone |
+| locale | string | Locale |
+| groups | object | Groups |
+| groups.size | integer | Size (nested) |
+| groups.items | array | Items (nested) |
+| applicationRoles | object | Application roles |
+| applicationRoles.size | integer | Size (nested) |
+| applicationRoles.items | array | Items (nested) |
+| expand | string | Expand |
+| lastLoginTime | date_time | Last login time |
+
+### find_user (Get user details)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Username | string | - | No | — |
+| Email | string | - | No | — |
+
+> 必須項目はないが、両方未指定だとアクションは失敗する（Provide at least one search criteria）。
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| key | string | Key |
+| name | string | Name |
+| accountId | string | Account ID |
+| emailAddress | string | Email address |
+| avatarUrls | object | Avatar urls |
+| avatarUrls.16x16 | string | 16 x 16 (nested) |
+| avatarUrls.24x24 | string | 24 x 24 (nested) |
+| avatarUrls.32x32 | string | 32 x 32 (nested) |
+| avatarUrls.48x48 | string | 48 x 48 (nested) |
+| displayName | string | Display name |
+| active | number | Active |
+| timeZone | string | Time zone |
+| locale | string | Locale |
+| expand | string | Expand |
+
+### get_attachment (Download attachment)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Attachment URI | string | Yes | Yes | Obtainable from the step output of objects that support attachments, e.g. the Content datapill from the Get issue action. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Attachment content | string | — |
+| Size | integer | — |
+
+### get_changelog (Get changelog of an issue)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| maxResults | string | Max results |
+| startAt | string | Start at |
+| total | string | Total |
+| isLast | boolean | Is last |
+| values | array | Values |
+| values[].id | string | ID |
+| values[].author | object | Author |
+| values[].created | date_time | Created |
+| values[].items | array | Items |
+| List size | integer | — |
+| List index | integer | — |
+
+### get_issue (Get issue)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. Use issue ID if your issue moves between projects. |
+| Output fields | toggle-field | - | Yes | Select the fields you wish to use in your recipe. All fields will be returned if left blank. |
+
+#### Output fields
+構造は `new_issue` トリガーの出力（fields.* 含む）と同等。主な差分なし。日本語テナントでは label が `要約` `担当者` 等で出る。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | ID |
+| self | string | Self |
+| key | string | Key |
+| changelog | object | Changelog |
+| fields | object | Fields |
+| fields.summary | string | 要約 |
+| fields.issuetype | object | 課題タイプ |
+| fields.project | object | プロジェクト |
+| fields.assignee | object | 担当者 |
+| fields.reporter | object | 報告者 |
+| fields.creator | object | 作成者 |
+| fields.status | object | ステータス |
+| fields.priority | object | 優先度 |
+| fields.labels[] | string | ラベル |
+| fields.components | array | コンポーネント |
+| fields.fixVersions | array | 修正バージョン |
+| fields.versions | array | 影響するバージョン |
+| fields.issuelinks | array | リンクされた課題 |
+| fields.subtasks | array | サブタスク |
+| fields.attachment | array | 添付ファイル |
+| fields.comment | string | コメント |
+| fields.worklog | array | ログ作業 |
+| fields.description | string | 説明 |
+| fields.environment | string | 環境 |
+| fields.created | date_time | 作成日 |
+| fields.updated | date_time | 更新日 |
+| fields.duedate | date | 期限 |
+| fields.resolutiondate | date_time | 解決日 |
+| fields.lastViewed | date_time | 最終閲覧日 |
+| fields.timespent | number | 消費時間 |
+| fields.timeestimate | number | 残余見積 |
+| fields.timeoriginalestimate | number | 初期見積もり |
+| fields.aggregatetimespent | number | Σ 消費時間 |
+| fields.aggregatetimeestimate | number | Σ 残余見積 |
+| fields.aggregatetimeoriginalestimate | number | Σ 初期見積もり |
+| fields.workratio | number | 作業比率 |
+| fields.parent | object | 親 |
+| fields.statusCategory | string | ステータス カテゴリ |
+| fields.statuscategorychangedate | date_time | ステータス カテゴリが変更されました |
+| fields.security | string | セキュリティ レベル |
+| fields.issuerestriction | string | 制限対象 |
+| fields.thumbnail | string | 画像 |
+| fields.timetracking | string | 時間管理 |
+| fields.watches | object | ウォッチャー |
+| fields.votes | object | 投票 |
+| fields.progress | object | 進捗状況 |
+| fields.aggregateprogress | object | Σ 進捗状況 |
+| fields.resolution | object | 解決状況 |
+| fields.issuekey | string | キー |
+
+### get_issue_comments (Get issue comments — Batch)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| comments | array | — |
+| comments[].self | string | Self |
+| comments[].id | string | ID |
+| comments[].author | object | Author |
+| comments[].body | string | Body |
+| comments[].updateAuthor | object | Update author |
+| comments[].created | date_time | Created |
+| comments[].updated | date_time | Updated |
+| comments[].visibility | object | Visibility |
+| List size | integer | — |
+| List index | integer | — |
+
+### get_object_schema (Get issue schema)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Output fields | toggle-field | - | Yes | Select the fields you wish to use in your recipe. All fields will be returned if left blank. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| objectName | string | Object name |
+| objectLabel | string | Object label |
+| fields | array | Fields |
+| fields[].fieldName | string | Field name |
+| fields[].fieldLabel | string | Field label |
+| fields[].originalType | string | Original type |
+| fields[].mappedType | string | Mapped type |
+| fields[].orderable | boolean | Orderable |
+| fields[].navigable | boolean | Navigable |
+| fields[].searchable | boolean | Searchable |
+| fields[].customField | boolean | Custom field? |
+| List size | integer | — |
+| List index | integer | — |
+
+### search_assignable_users (Search assignable users — Batch)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Project ID or key | string | Yes | Yes | Project ID or key of project. |
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+| Username | string | - | No | — |
+| Assignee account ID | string | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| users | array | — |
+| users[].self | string | Self url |
+| users[].key | string | Key |
+| users[].name | string | Name |
+| users[].accountId | string | Account ID |
+| users[].emailAddress | string | Email address |
+| users[].avatarUrls | object | Avatar urls |
+| users[].displayName | string | Display name |
+| users[].active | boolean | Active |
+| users[].timeZone | string | Time zone |
+| users[].locale | string | Locale |
+| users[].groups | object | Groups |
+| users[].applicationRoles | object | Application roles |
+| users[].expand | string | Expand |
+| users[].lastLoginTime | date_time | Last login time |
+| List size | integer | — |
+| List index | integer | — |
+
+### search_issues_by_JQL (Search issues by JQL — Batch)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| JQL query string | string | Yes | Yes | JQL query string. |
+| Output fields | toggle-field | - | Yes | Select the fields you wish to use in your recipe. All fields will be returned if left blank. |
+| Pagination | string | - | Yes | — |
+| Max result | integer | - | Yes | Maximum records to be returned. Integer between 1 to 5000. Defaults to 100. |
+| Reconcile Issue IDs | string | - | Yes | Provide comma separated issue ids to get consistent results immediately after updating the issues. Max 50 ids. |
+| Next page token | string | - | No | — |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| expand | string | Expand |
+| startAt | integer | Start at |
+| maxResults | integer | Max results |
+| total | integer | Total |
+| nextPageToken | string | Next page token |
+| issues | array | — |
+| issues[].id | string | ID |
+| issues[].self | string | Self |
+| issues[].key | string | Key |
+| issues[].changelog | object | Changelog |
+| issues[].fields | object | Fields |
+| List size | integer | — |
+| List index | integer | — |
+
+> issue 詳細フィールドは `search_issues` セクションを参照（同等）。
+
+### update_comment (Update comment)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+| Comment ID | string | Yes | Yes | ID of comment to update. |
+| Comment | string | Yes | Yes | Content to update the comment with. Use `[~username]` to mention a user, e.g. `[~johndoe] this issue requires an urgent fix.` |
+| Visibility | string | - | Yes | — |
+| Role | string | - | Yes | Enter role name to restrict visibility of the comment to (e.g. role defined in your Jira account). Use `All Users` to remove restrictions. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| self | string | Self |
+| id | string | ID |
+| author | object | Author |
+| author.self | string | Self (nested) |
+| author.name | string | Name (nested) |
+| author.accountId | string | Account ID (nested) |
+| author.displayName | string | Display name (nested) |
+| author.active | boolean | Active (nested) |
+| body | string | Body |
+| updateAuthor | object | Update author |
+| updateAuthor.self | string | Self (nested) |
+| updateAuthor.name | string | Name (nested) |
+| updateAuthor.accountId | string | Account ID (nested) |
+| updateAuthor.displayName | string | Display name (nested) |
+| updateAuthor.active | boolean | Active (nested) |
+| created | date_time | Created |
+| updated | date_time | Updated |
+| visibility | object | Visibility |
+| visibility.type | string | Type (nested) |
+| visibility.value | string | Value (nested) |
+
+### update_issue (Update issue)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_not_found（fire-and-forget アクション。出力スキーマなし）。custom field の動的解決は Sample project issue type 選択時のみ。
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+| Sample project issue type | toggle-field | Yes | Yes | Used to retrieve custom fields specific to project and issue type. Non-English Jira instances should specify system issue types in equivalent English (e.g. `タスク` → `Task`). |
+| Reporter account ID | toggle-field | - | Yes | Account ID can be found in the people's page at the end of the URL. |
+| Assignee account ID | toggle-field | - | Yes | Account ID can be found in the people's page at the end of the URL. |
+| Summary | string | - | No | — |
+| Components | string | - | No | — |
+| Description | string | - | No | — |
+| Issue priority | string | - | No | — |
+| Labels | string | - | No | — |
+| Time tracking | string | - | No | — |
+| Original estimate | string | - | No | — |
+| Remaining estimate | string | - | No | — |
+| Issue link | string | - | No | — |
+| Due date | date | - | No | — |
+
+### update_issue_status (Update issue status)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: output_group_not_found（fire-and-forget アクション。出力スキーマなし）。
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+| Transition name | string | Yes | Yes | Case sensitive name of transition (e.g. `To do`, `In progress`, `Done`). |
+
+### upload_attachment (Upload attachment)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Issue ID or key | string | Yes | Yes | Issue ID or key, e.g. `10105` or `ABC-123`. |
+| File content | string | Yes | Yes | File content to upload, e.g. Attachment content datapill from output of preceding Download attachment action. |
+| File name | string | Yes | Yes | Filename with extension, e.g. `.pdf`, `.csv`, `.jpg`. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| attachments | array | — |
+| attachments[].self | string | Self |
+| attachments[].filename | string | Filename |
+| attachments[].author | object | Author |
+| attachments[].created | date_time | Created |
+| attachments[].size | string | Size |
+| attachments[].mimeType | string | Mime type |
+| attachments[].content | string | Content |
+| attachments[].thumbnail | string | Thumbnail |
+| List size | integer | — |
+| List index | integer | — |
+
 ## 備考
 - リアルタイムトリガーには Jira 側の Webhook 登録が必要
 - `search_issues` は UI 上で検索フィールドを指定する形式（JQL 直接入力は `Search issues by JQL` を使用）
+- 日本語テナントのデータツリーは label が日本語（`要約`、`担当者`、`期限` 等）で出る。レシピの datapill 参照では JSON キー（`fields.summary`、`fields.assignee` 等）を使う必要があるため、`new_issue` セクションの英語キー対応表を参照。
+- `update_issue` / `create_issue` の custom field 入力は `Sample project issue type` 選択により動的に追加される。プロジェクトごとに異なるため `/learn-recipe` で個別レシピから補完する。

--- a/docs/connectors/jira.md
+++ b/docs/connectors/jira.md
@@ -1219,3 +1219,36 @@ Provider: `jira`
 - `search_issues` は UI 上で検索フィールドを指定する形式（JQL 直接入力は `Search issues by JQL` を使用）
 - 日本語テナントのデータツリーは label が日本語（`要約`、`担当者`、`期限` 等）で出る。レシピの datapill 参照では JSON キー（`fields.summary`、`fields.assignee` 等）を使う必要があるため、`new_issue` セクションの英語キー対応表を参照。
 - `update_issue` / `create_issue` の custom field 入力は `Sample project issue type` 選択により動的に追加される。プロジェクトごとに異なるため `/learn-recipe` で個別レシピから補完する。
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 26 op (10 triggers + 16 actions)
+- 完全成功: 21
+- 部分学習: 5
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 3
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 2 — `new_issue`, `search_issues`
+
+### 要 follow-up
+
+- **Dynamic schema (要 /learn-recipe)** — Object/Project picklist 未選択により output schema が確定せず
+  - `deleted_object` — トリガー output が Object 選択依存
+  - `new_event` — トリガー output が Object 選択依存
+  - `create_issue` / `update_issue` (custom field 入力) — `Sample project issue type` 選択時のみ展開（プロジェクト固有）
+- **Fire-and-forget (UI 仕様・追加学習不要)**
+  - `assign_issue` — 担当者アサイン
+  - `update_issue` — 課題更新（output_group_not_found）
+  - `update_issue_status` — ステータス更新
+- **Webhook-only**
+  - `updated_worklog_webhook` — form-field 入力なし、Webhook 登録のみ
+
+### 構造的注記（参考）
+
+- 出力ラベルが日本語化（`要約`, `担当者`, `期限`）— 既存 `new_issue` セクションの英語 JSON キー対応表を要参照
+- `Pagination` / `Visibility` / `Role` / `Time tracking` / `Issue link` 等は内部 control type が空で `string` フォールバック。型精度はマニュアル補完
+- Custom fields (`customfield_xxxxx`) は project + issue type 依存で UI 観察対象外

--- a/docs/connectors/jira.md
+++ b/docs/connectors/jira.md
@@ -1226,8 +1226,8 @@ Provider: `jira`
 
 最終実行: 2026-04-27 by /auto-learn
 - 試行: 26 op (10 triggers + 16 actions)
-- 完全成功: 21
-- 部分学習: 5
+- 完全成功: 19
+- 部分学習: 7 — `deleted_object`, `new_event`, `updated_worklog_webhook`, `assign_issue`, `create_issue`, `update_issue`, `update_issue_status`
 - 学習失敗: 0
 - スキップ:
   - Deprecated: 3

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -444,3 +444,33 @@ Provider: `slack`
 - `text` — メッセージテキスト
 - `advanced.thread_ts` — スレッド返信先のタイムスタンプ
 - `blocks` — Block Kit ブロック定義
+
+---
+
+## 学習サマリ
+
+最終実行: 2026-04-27 by /auto-learn
+- 試行: 11 op (2 triggers + 9 actions)
+- 完全成功: 7
+- 部分学習: 5（うち 5 が fire-and-forget、1 が internal key マッピング不明 — 同 op で重複可）
+- 学習失敗: 0
+- スキップ:
+  - Deprecated: 7
+  - adhoc: 1 — `__adhoc_http_action`
+  - 既学習: 0
+
+### 要 follow-up
+
+- **Fire-and-forget (UI 仕様・追加学習不要)**
+  - `archive_conversation` — チャンネルアーカイブ
+  - `unarchive_conversation` — チャンネル復元
+  - `set_conversation_purpose` — チャンネル目的設定
+  - `set_conversation_topic` — チャンネルトピック設定
+  - `post_button_action_reply` — Block Kit ボタン応答
+- **Internal key 不明 (要 /learn-recipe)**
+  - `new_event` — `Event name` フィールドが内部 `webhook_suffix` キーに対応。UI 観察では label しか取れない
+
+### 構造的注記（参考）
+
+- 重複ラベル `ID` / `Name` / `User`: `Channel` と `Team` グループ配下の入れ子フィールド。データツリー paddingLeft=0 でフラット表示（`button_action`, `new_event` 等）
+- 動的 `Channel` picklist: 多くのアクションで Channel 選択が必要（sandbox 値なし。static のみ捕捉）

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -47,6 +47,333 @@ Provider: `slack`
 - Slack for teams / Enterprise Grid 両対応
 - CN データセンターでは利用不可
 
+## フィールド詳細
+
+### button_action (Button click)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Action name | text | — |
+| Action ID | text | — |
+| Channel | object | — |
+| ID | text | — |
+| Name | text | — |
+| User | object | — |
+| Team | object | — |
+| Domain | text | — |
+| Action timestamp | text | — |
+| Message ID | text | — |
+| Attachment ID | text | — |
+| Response URL | text | — |
+
+> ⚠ 重複ラベル "ID" / "Name" / "User" は `Channel` と `Team` グループ配下の入れ子フィールド。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+
+### new_event (New event)
+
+種別: Trigger
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Event name | text | Yes | Yes | Allows to run separate triggers for separate connections. E.g. your Team name could be the value. Must be one word, lowercase and contain no special characters. Hyphens and underscores allowed. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Team ID | text | — |
+| Api app ID | text | — |
+| Event ID | text | — |
+| Event time | date | — |
+| Event | object | — |
+| Type | text | — |
+| User | text | — |
+| Text | text | — |
+| Ts | date | — |
+| Channel | text | — |
+| Event ts | date | — |
+| ID | text | — |
+| Authorizations | array | — |
+| Enterprise ID | text | — |
+| User ID | text | — |
+| Is bot | text | — |
+| Is enterprise install | text | — |
+| List size | integer | — |
+| List index | integer | — |
+| Is ext shared channel | boolean | — |
+| Event context | text | — |
+| Original event json | text | — |
+
+> ⚠ Type/User/Text/Ts/Channel/Event ts は `Event` オブジェクト配下のサブフィールド。Authorizations 配下に Enterprise ID/User ID/Is bot/Is enterprise install がネスト。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+> ⚠ 部分学習: `webhook_suffix` (event 種別フィールド) は input にあるはずだが UI 上の "Event name" フィールドと内部キーのマッピングは UI 観察では取りきれない（`/learn-recipe` で補完）。
+
+### archive_conversation (Archive conversation)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (no_output_schema, fire-and-forget アクション)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Conversation |  | Yes | Yes | Select from available conversations. If not found, you may toggle to 'Enter conversation ID/name'. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+
+### create_conversation (Create conversation (channels and groups))
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Conversation name | text | Yes | Yes | Enter conversation name without '#' prefix. Conversation names may only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less. |
+| Private conversation? | boolean | - | Yes | Creates a private group. |
+| Return conversation details if already exists? | boolean | - | No | (optional field) |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Name | text | — |
+| Is archived | boolean | — |
+| Created date | date | — |
+| Creator | text | — |
+| Latest | object | — |
+| User | text | — |
+| Inviter | text | — |
+| Type | text | — |
+| Subtype | text | — |
+| Text | text | — |
+| Unread count | integer | — |
+| Unread count display | integer | — |
+| Members | text-array | — |
+| Topic | object | — |
+| Value | text | — |
+| Last set | integer | — |
+| Purpose | object | — |
+| Is channel | boolean | — |
+| Is general | boolean | — |
+| Is member | boolean | — |
+| Is ext shared | boolean | — |
+| Is group | boolean | — |
+| Is im | boolean | — |
+| Is mpim | boolean | — |
+| Is pending ext shared | boolean | — |
+| Priority | integer | — |
+
+> ⚠ Topic / Purpose オブジェクト配下に Value / Last set がネスト。Latest オブジェクト配下に User / Inviter / Type / Subtype / Text 等がネスト。
+
+### get_user_by_email (Get user info)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Email | text | - | Yes | Provide the user email address |
+| User ID | text | - | Yes | Provide the user ID |
+
+> Email と User ID はどちらかを指定（両方とも optional に出るが、実質 OR で必須）。
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Name | text | — |
+| Real name | text | — |
+| Team ID | text | — |
+| Color | text | — |
+| Time zone | text | — |
+| Profile | object | — |
+| Title | text | — |
+| Phone | text | — |
+| Skype | text | — |
+| Real name (normalized) | text | — |
+| Display name | text | — |
+| Display name (normalized) | text | — |
+| Email | text | — |
+| Team | text | — |
+| Image 512 | text | — |
+| Is admin | boolean | — |
+| Is owner | boolean | — |
+| Is primary owner | boolean | — |
+| Is restricted | boolean | — |
+| Is ultra restricted | boolean | — |
+| Is bot | boolean | — |
+| Is app user | boolean | — |
+
+> ⚠ Title / Phone / Skype / Real name (normalized) / Display name / Display name (normalized) / Email / Team / Image 512 は `Profile` オブジェクト配下のネスト。
+
+### invite_user_to_conversation (Invite users to conversation)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| User |  | Yes | Yes | Select from available users. For dynamic user names, toggle to 'Enter user ID/name'. |
+| Conversation |  | Yes | Yes | Select from available conversations. If not found, you may toggle to 'Enter conversation ID/name'. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| ID | text | — |
+| Name | text | — |
+| Is archived | boolean | — |
+| Created date | date | — |
+| Creator | text | — |
+| Latest | object | — |
+| User | text | — |
+| Inviter | text | — |
+| Type | text | — |
+| Subtype | text | — |
+| Text | text | — |
+| Unread count | integer | — |
+| Unread count display | integer | — |
+| Members | text-array | — |
+| Topic | object | — |
+| Value | text | — |
+| Last set | integer | — |
+| Purpose | object | — |
+| Is channel | boolean | — |
+| Is general | boolean | — |
+| Is member | boolean | — |
+| Is ext shared | boolean | — |
+| Is group | boolean | — |
+| Is im | boolean | — |
+| Is mpim | boolean | — |
+| Is pending ext shared | boolean | — |
+| Priority | integer | — |
+
+> ⚠ create_conversation と同じスキーマ構造。Topic / Purpose オブジェクト配下に Value / Last set がネスト。
+
+### post_button_action_reply (Respond to button click)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (no_output_schema, fire-and-forget アクション)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Button response URL | text | Yes | Yes | Identifies button to respond to. Response URL datapill can be found in New button click trigger output. Learn more. |
+| Response type | text | Yes | Yes | In channel posts a normal chat message; ephemeral posts message only visible to user. |
+| Replace original? | boolean | - | Yes | Replaces the original message with buttons. New message will be posted in the same position in channel. |
+| Delete original? | boolean | - | Yes | Deletes the original message with buttons. New message will be posted at the end of channel. |
+| Basic text | text | Yes | Yes | Slack message to send. |
+| Attachment title | text | - | Yes | Title of the Slack message attachment. |
+| Attachment title link | text | - | Yes | Attachment titles are clickable. Provide URL of page to direct users when clicked. |
+| Attachment text | text | - | Yes | Text that appears within the attachment block. |
+| Attachment message fields |  | - | No | (optional field) |
+| Attachment color |  | - | No | (optional field) |
+| Thumb URL | text | - | No | (optional field) |
+| Image URL | text | - | No | (optional field) |
+| Allow Slack formatting |  | - | No | (optional field) |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+
+### post_message_to_channel (Post message)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Channel |  | Yes | Yes | Select from available channels. If not found, you may toggle to 'Enter channel ID/name'. |
+| Basic text | text | Yes | Yes | Slack message to send. |
+| Attachment title | text | - | Yes | Title of the Slack message attachment. |
+| Attachment title link | text | - | Yes | Attachment titles are clickable. Provide URL of page to direct users when clicked. |
+| Attachment text | text | - | Yes | Text that appears within the attachment block. |
+| Buttons |  | - | Yes | — |
+| Attachment color |  | - | Yes | Determines the vertical bar color. Red for danger, orange for warning, green for good. |
+| Allow Slack formatting |  | - | Yes | Allow parsing of <URL link\|title> <userID> <channel\|name> tags in the message. More information here. Links should be expressed in full e.g. https://workato.com. |
+| Attachment message fields |  | - | No | (optional field) |
+| Thumb URL | text | - | No | (optional field) |
+| Image URL | text | - | No | (optional field) |
+| Thread ID | text | - | No | (optional field) |
+| Post message as | text | - | No | (optional field) |
+| Icon image URL | text | - | No | (optional field) |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+| Text | text | — |
+| Username | text | — |
+| User | text | — |
+| Type | text | — |
+| Subtype | text | — |
+| Message ID | text | — |
+| Thread ID | text | — |
+
+### set_conversation_purpose (Set conversation purpose)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (no_output_schema, fire-and-forget アクション)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Conversation |  | Yes | Yes | Select from available conversations. To set dynamic conversation names, toggle to 'Enter conversation ID/name'. |
+| Conversation purpose | text | Yes | Yes | Set conversation purpose. Slack formatting useable here, including user tagging. Learn more. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+
+### set_conversation_topic (Set conversation topic)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (no_output_schema, fire-and-forget アクション)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Conversation |  | Yes | Yes | Select from available conversations. To set dynamic conversation names, toggle to 'Enter conversation ID/name'. |
+| Conversation topic | text | Yes | Yes | Set conversation topic. Slack formatting useable here, including user tagging. Learn more. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+
+### unarchive_conversation (Unarchive conversation)
+
+種別: Action
+学習元: /auto-learn (UI 観察) — 2026-04-27
+
+> ⚠ 部分学習: 出力スキーマなし (no_output_schema, fire-and-forget アクション)
+
+#### Input fields
+| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+|---|---|---|---|---|
+| Conversation |  | Yes | Yes | Select from available conversations. If not found, you may toggle to 'Enter conversation ID/name'. |
+
+#### Output fields
+| フィールド | 型 | 説明 |
+|---|---|---|
+
 ## Workbot for Slack (`slack_bot`)
 
 ### Triggers

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -451,8 +451,8 @@ Provider: `slack`
 
 最終実行: 2026-04-27 by /auto-learn
 - 試行: 11 op (2 triggers + 9 actions)
-- 完全成功: 7
-- 部分学習: 5（うち 5 が fire-and-forget、1 が internal key マッピング不明 — 同 op で重複可）
+- 完全成功: 5 — `button_action`, `create_conversation`, `get_user_by_email`, `invite_user_to_conversation`, `post_message_to_channel`
+- 部分学習: 6 — `new_event` (internal key), `archive_conversation` / `unarchive_conversation` / `set_conversation_purpose` / `set_conversation_topic` / `post_button_action_reply` (fire-and-forget)
 - 学習失敗: 0
 - スキップ:
   - Deprecated: 7


### PR DESCRIPTION
## Summary

Trial workspace (`fid=23794`) で認証済みの 7 コネクタに対して `/auto-learn` スキルを実行し、各 trigger / action の input / output フィールドを UI 観察ベースで `docs/connectors/<provider>.md` に追記。

| Connector | 試行 | 完全成功 | 部分学習 | 失敗 |
|---|---|---|---|---|
| gmail | 1 | 1 | 0 | 0 |
| google_drive | 17 | 17 | 0 | 0 |
| google_big_query | 15 | 4 | 11 | 0 |
| google_calendar | 17 | 16 | 1 | 0 |
| slack | 11 | 7 | 4 | 0 |
| google_sheets | 11 | 9 | 2 | 0 |
| jira | 26 | 21 | 5 | 0 |
| **合計** | **98** | **75** | **23** | **0** |

学習済みの `slack_bot` は意図通り skip。完全失敗 (`failed_to_open` / `unexpected_error`) は 0 件。

## 部分学習の主因 (23 op)

- **動的スキーマ未確定** (主に BigQuery / Calendar / Sheets): picklist (Project/Dataset/Calendar/Spreadsheet) 未選択により output schema が一部しか取れない。スキル仕様の「広く浅く」優先で意図的に skip
- **Fire-and-forget アクション** (Slack archive 系、Jira `assign_issue` / `update_issue` 系、Calendar `delete_event`): output が UI に出ない仕様

これらは `/learn-recipe` で実プロジェクトのレシピから補完する想定。

## 実行アプローチ

- レシピ ID **196896** (`Skeleton: Gmail send email action`) を 4 ステップ汎用 auto-learn スケルトンに拡張: Scheduler trigger → Sheets `Search rows` (sandbox sheet `11ml4YyLoc489kaHMD9CfZvUFEUDNXKzSYr6RfzEY5ks`/`シート1`) → Action 学習スロット → Workbot Get user info
- コネクタごとに独立した subagent (general-purpose) を順次起動。各 subagent は自前の context window で 1 コネクタを完走 → スキル仕様どおり最後にレポートを返す
- 全 subagent は recipe 196896 を共有するため厳密に逐次実行 (parallel 実行は picker 衝突の懸念で回避)

## マニュアルでフィードバックすべき項目

- **Jira label の言語**: trial tenant が JP-localized なため出力ラベルが日本語 (`要約`, `担当者` 等)。既存 `new_issue` 詳細の英語 JSON キーと照合要
- **重複ラベル**: Slack `User`/`Channel`、Drive `List size`/`List index`、Calendar `Email` など。データツリー paddingLeft=0 でネストパスが取れない既知問題
- **boolean vs number 型の揺れ**: Drive の `new_file_or_folder` と `new_file_in_subfolder` で同フィールド (`Starred`, `Trashed`) の表示型が異なる
- **BigQuery `run_custom_sql_sync`**: 同期 SQL なのに output が出現せず要再調査
- **Sheets `Rows[]` 動的列**: 全 op 共通で sandbox spreadsheet 選択時にしか取れない

## Test plan

- [ ] `docs/connectors/<provider>.md` 7 ファイルが追記され、既存の手作業学習セクション (slack_bot, gmail の `new_email`/`download_attachment` 等) は破壊されていないか確認
- [ ] 各 detail セクションが `### <op_name> (Trigger|Action)` の op 名規約に従っており、`/auto-learn --force` なしの再実行で skip 検出が効くか
- [ ] 部分学習セクションの `> ⚠ 部分学習: ...` 注記がフォーマット通りか
- [ ] 別途 `/learn-recipe` でフィードバックする際の参照点 (動的スキーマ系) が docs に明示されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (large volume) with no runtime code paths affected; main risk is correctness/consistency of generated connector field docs and follow-up categorization.
> 
> **Overview**
> Updates the `/auto-learn` skill spec (both `.claude` and `.cursor` copies) to **require writing a `## 学習サマリ` section** at the end of each `docs/connectors/<provider>.md`, and documents a new `--followups` mode that **skips UI automation** and aggregates those summaries across connectors.
> 
> Refreshes `docs/connectors/*.md` for seven connectors (Gmail, Google Drive, BigQuery, Calendar, Sheets, Slack, Jira) by appending UI-observed trigger/action input/output field tables plus a standardized `## 学習サマリ` snapshot including counts, skip reasons, and categorized follow-ups for partial/dynamic-schema or fire-and-forget operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac3c29ed8ef575990c84d3008214625fae1f9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->