### PR TITLE
ci: framework/ ドリフト検出のための sync-check workflow を追加

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -1,0 +1,37 @@
+name: sync-check
+
+# scripts/sync_agents.py が生成する framework/{cursor,codex,gemini}/ と
+# framework/AGENTS.md が、framework/claude/ の正本とドリフトしていないか検証する。
+#
+# framework/claude/ を編集したのに sync_agents.py を回し忘れた PR を検出する。
+
+on:
+  pull_request:
+    paths:
+      - 'framework/claude/**'
+      - 'framework/cursor/**'
+      - 'framework/codex/**'
+      - 'framework/gemini/**'
+      - 'framework/AGENTS.md'
+      - 'scripts/sync_agents.py'
+      - '.github/workflows/sync-check.yml'
+  push:
+    branches: [main]
+
+jobs:
+  sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run sync_agents.py
+        run: python3 scripts/sync_agents.py
+
+      - name: Detect drift
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::framework/{cursor,codex,gemini}/ or framework/AGENTS.md is out of sync with framework/claude/."
+            echo "::error::Run 'python3 scripts/sync_agents.py' locally and commit the regenerated files."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- `.github/workflows/sync-check.yml` を追加
- `framework/claude/` を編集したのに `python3 scripts/sync_agents.py` を回し忘れた PR を CI で検出する

## なぜ

`framework/claude/CLAUDE.md` には以下のように書かれていた:

> 編集後、必ず `python3 scripts/sync_agents.py` を実行する。これで `framework/{cursor,codex,gemini}/` と `framework/AGENTS.md` が再生成される。コミットには `framework/claude/` 側の編集と再生成された配布物を両方含めること（**CI で同期チェックあり**）

しかし実際には `.github/workflows/` ディレクトリも workflow ファイルも存在せず、ドキュメントが現実を上回っていた。手動運用に依存しているため、リネーム・新規スキル追加などで再生成漏れが発生するリスクがあった（直前の PR #87 でも、ローカルで sync 漏れに気づかなければ Cursor/Codex/Gemini 配布物にドリフトが残るところだった）。

## 変更内容

`.github/workflows/sync-check.yml`:
- トリガー: PR で `framework/**` または `scripts/sync_agents.py` が触られた時、および `main` への push 時
- ステップ:
  1. `actions/checkout@v4`
  2. `python3 scripts/sync_agents.py` を実行
  3. `git diff --exit-code` でドリフトを検出 → 差分があればエラーメッセージ付きで fail

`sync_agents.py` は標準ライブラリのみ (`re`, `pathlib`, `sys`) を使うので `setup-python` step は不要（ubuntu-latest 同梱の python3 で十分）。

## 動作確認（ローカル）

クリーンな main checkout で:
1. `python3 scripts/sync_agents.py && git diff --exit-code` → pass（ドリフトなし）
2. 故意に `framework/claude/CLAUDE.md` を編集 → sync 実行後 `git diff` で変更検知 → CI なら fail する流れを確認

## Test plan

- [ ] この PR 自体で sync-check ジョブが pass することを確認（`framework/` を触っていないので path filter でスキップされる可能性あり → push トリガーで main 入り後の動作も観察）
- [ ] 後続の `framework/claude/` を触る PR で sync 忘れシミュレーションを試す（必要なら）

🤖 Generated with [Claude Code](https://claude.com/claude-code)