### PR TITLE
fix(setup): pass paths to python via env to avoid shell-escape breakage

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -166,38 +166,53 @@ USER_SETTINGS="$WORKSPACE_ROOT/.claude/settings.json"
 
 if [ ! -f "$USER_SETTINGS" ]; then
   # 初回: kit の settings.json をコピー（hook パスを書き換え）
-  python3 -c "
-import json, sys
+  #
+  # 値は env 経由で Python に渡す。`python3 -c "..."` 内にシェル変数を直接展開すると、
+  # パスにクォート・改行・バックスラッシュが含まれた場合に Python コードが破綻する
+  # （あるいは任意コード実行に近い挙動になる）。ヒアドキュメントは <<'PY' でクォート
+  # しておけば変数展開も完全に防げる。
+  KIT_SETTINGS="$KIT_SETTINGS" USER_SETTINGS="$USER_SETTINGS" KIT_REL="$KIT_REL" \
+    python3 <<'PY'
+import json
+import os
 
-with open('$KIT_SETTINGS') as f:
+kit_settings = os.environ['KIT_SETTINGS']
+user_settings = os.environ['USER_SETTINGS']
+kit_rel = os.environ['KIT_REL']
+
+with open(kit_settings) as f:
     s = json.load(f)
 
 # Hook のコマンドパスを kit/framework/claude/ 配下に書き換え
-# テンプレート上は \".claude/hooks/<name>\" と書かれているが、実体は
-# kit/framework/claude/hooks/<name>。利用者の \".claude/settings.json\" には
+# テンプレート上は ".claude/hooks/<name>" と書かれているが、実体は
+# kit/framework/claude/hooks/<name>。利用者の ".claude/settings.json" には
 # 実体パスを直接埋め込む（symlink を経由しない）。
 for event in s.get('hooks', {}).values():
     for group in event:
         for hook in group.get('hooks', []):
             cmd = hook.get('command', '')
             if cmd.startswith('.claude/hooks/'):
-                hook['command'] = '$KIT_REL/framework/claude/hooks/' + cmd[len('.claude/hooks/'):]
+                hook['command'] = kit_rel + '/framework/claude/hooks/' + cmd[len('.claude/hooks/'):]
 
-with open('$USER_SETTINGS', 'w') as f:
+with open(user_settings, 'w') as f:
     json.dump(s, f, indent=2, ensure_ascii=False)
     f.write('\n')
-  "
+PY
   echo "  ✓ Created .claude/settings.json (from kit template)"
 else
   # 既存設定: 旧版 setup.sh が書いた hook パスを framework/claude/ 配下に書き換える。
   # 利用者が追加した hook（kit 由来でないもの）には手を付けない。
-  python3 -c "
+  USER_SETTINGS="$USER_SETTINGS" KIT_REL="$KIT_REL" \
+    python3 <<'PY'
 import json
+import os
 
-old_prefix = '$KIT_REL/.claude/hooks/'
-new_prefix = '$KIT_REL/framework/claude/hooks/'
+user_settings = os.environ['USER_SETTINGS']
+kit_rel = os.environ['KIT_REL']
+old_prefix = kit_rel + '/.claude/hooks/'
+new_prefix = kit_rel + '/framework/claude/hooks/'
 
-with open('$USER_SETTINGS') as f:
+with open(user_settings) as f:
     s = json.load(f)
 
 migrated = 0
@@ -210,13 +225,13 @@ for event in s.get('hooks', {}).values():
                 migrated += 1
 
 if migrated:
-    with open('$USER_SETTINGS', 'w') as f:
+    with open(user_settings, 'w') as f:
         json.dump(s, f, indent=2, ensure_ascii=False)
         f.write('\n')
     print(f'  ✓ Migrated {migrated} kit hook path(s) in .claude/settings.json (.claude/hooks/ → framework/claude/hooks/)')
 else:
     print('  EXISTS .claude/settings.json (no kit hook paths needed migrating — merge manually if other changes are needed)')
-  "
+PY
 fi
 
 # ── 6. CLAUDE.md の生成 ──────────────────────────────────


### PR DESCRIPTION
## Summary

[setup.sh:169-219](setup.sh) の `python3 -c "..."` ブロック 2 箇所で、シェル変数 `$KIT_REL` / `$KIT_SETTINGS` / `$USER_SETTINGS` を Python の文字列リテラル内に**直接展開**していた。利用者リポジトリのパスにシングルクォート、改行、バックスラッシュ等が含まれる場合に Python コードが構文エラーで破綻するか、最悪は意図しないコード実行に近い挙動となる脆弱性。

OSS 公開後は異常パス（macOS の \"My Apple ID's Workspace/\" 等）を踏む利用者が必ず出るため、公開ブロッカー扱い。

## Changes

両ブロックとも以下のパターンに統一:
- ヒアドキュメント \`<<'PY'\` でクォートし、シェルによる変数展開を完全停止
- 値は呼び出し直前の環境変数として渡し、Python 側は \`os.environ\` 経由で取得

```sh
KIT_SETTINGS=\"\$KIT_SETTINGS\" USER_SETTINGS=\"\$USER_SETTINGS\" KIT_REL=\"\$KIT_REL\" \\
  python3 <<'PY'
import json, os
kit_settings = os.environ['KIT_SETTINGS']
...
PY
```

## Test plan

- [x] \`bash -n setup.sh\` で構文 OK
- [x] 通常パス (\`/tmp/kit-normal-XXXXXX\`) で setup 完走、settings.json の hook パスが正しく書き換えられることを確認
- [x] **アポストロフィ + スペースを含むパス** (\`/tmp/kit-test-with 'apostrophe' and spaces-XXX\`) で setup 完走、hook commands が正しく書き込まれることを確認 — 旧コードならここで Python 側が SyntaxError で破綻

```
\$ ls /tmp/kit-test-with\\ \\'apostrophe\\'\\ and\\ spaces-*/.claude/settings.json
... '/tmp/kit-test-with '\\''apostrophe'\\'' and spaces-29412/.claude/settings.json'

\$ grep '\"command\"' .claude/settings.json
  \"command\": \"kit/framework/claude/hooks/validate-before-push.sh\"
  \"command\": \"kit/framework/claude/hooks/sync-docs-after-sdk-push.sh\"
```

## Closes

- #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)