### PR TITLE
fix(ci): detect untracked drift in sync-check workflow

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -30,8 +30,18 @@ jobs:
 
       - name: Detect drift
         run: |
-          if ! git diff --exit-code; then
+          # `git diff` だけでは tracked ファイルの変更しか検出できず、
+          # 新規スキル追加で sync が untracked ファイルを生成したケース
+          # （例: framework/cursor/skills/<new-skill>/SKILL.md）を見落とす。
+          # `git status --porcelain` で tracked / untracked 両方を検査する。
+          if [ -n "$(git status --porcelain)" ]; then
             echo "::error::framework/{cursor,codex,gemini}/ or framework/AGENTS.md is out of sync with framework/claude/."
             echo "::error::Run 'python3 scripts/sync_agents.py' locally and commit the regenerated files."
+            echo ""
+            echo "Drift detected (modified or untracked):"
+            git status --short
+            echo ""
+            echo "--- Diff of tracked changes ---"
+            git diff
             exit 1
           fi


### PR DESCRIPTION
## Summary

[.github/workflows/sync-check.yml:33](.github/workflows/sync-check.yml) の `git diff --exit-code` は **tracked ファイルの未ステージ変更しか見ない**ため、新規スキル追加時に `sync_agents.py` が生成した untracked ファイル（`framework/{cursor,codex,gemini}/skills/<new-skill>/SKILL.md`）を見落として CI を素通りさせていた。

`git status --porcelain` に切り替え、tracked 変更と untracked ファイルの両方を検出する。CI ログには `git status --short` と `git diff` 両方を出力し、修正方法を判断しやすくする。

## Verification (再現テスト)

```sh
# 1. 新規スキルを追加（untracked）
mkdir -p framework/claude/skills/_test-drift
cat > framework/claude/skills/_test-drift/SKILL.md <<EOSKILL
---
description: Test drift detection skill.
allowed-tools: Read
---
# /_test-drift
EOSKILL

# 2. sync 実行 → 各エディタ用の untracked ファイルも生成される
python3 scripts/sync_agents.py

# 3. 旧ロジック (git diff --exit-code) → exit 0、CI を素通り
git diff --exit-code; echo "exit=\$?"
# exit=0  ← バグ

# 4. 新ロジック (git status --porcelain) → 4 件 detected
[ -n "\$(git status --porcelain)" ] && echo "DRIFT DETECTED"
# DRIFT DETECTED
git status --short
# ?? framework/claude/skills/_test-drift/
# ?? framework/codex/skills/_test-drift/
# ?? framework/cursor/skills/_test-drift/
# ?? framework/gemini/skills/_test-drift/
```

## Test plan

- [x] 新規スキル追加 → sync 実行 → untracked 4 件が新ロジックで全て検出されることを確認
- [x] 既存トラック対象の変更（このPR自身の sync-check.yml 編集）も合わせて検出されることを確認

## Closes

- #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)