### PR TITLE
docs: add CONTRIBUTING / CODE_OF_CONDUCT / SECURITY for OSS publication

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at kantannano@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,172 @@
+# Contributing to workato-dev-kit
+
+workato-dev-kit へのコントリビューションをご検討いただきありがとうございます。
+このドキュメントは、開発・PR 提出・新スキル追加の流れをまとめたものです。
+英語話者の方は GitHub Issues で英語で起票していただいて構いません（メンテナーは日本語/英語両対応します）。
+
+---
+
+## 開発のセットアップ
+
+このリポジトリは **kit 単体でも開発可能**です（利用者ワークスペースのように `submodule` として追加する必要はありません）。
+
+```bash
+git clone https://github.com/rkawaishi/workato-dev-kit.git
+cd workato-dev-kit
+```
+
+開発に必要なのは:
+
+- `bash` (macOS の zsh 環境でも `bash` が必要)
+- `python3` (3.8+ — 標準ライブラリのみ使用)
+- `git`
+
+Workato CLI 本体は kit 自体の開発には不要です（利用者ワークスペース側で必要）。
+
+詳しいリポジトリ構造とディレクトリの役割は [.claude/CLAUDE.md](.claude/CLAUDE.md) を参照してください。
+
+---
+
+## 配布物 (`framework/`) の編集ルール
+
+**正本は `framework/claude/`** です。スキル・ルール・hooks はここを編集します。
+
+```
+framework/
+├── claude/        ← canonical source（編集対象）
+├── cursor/        ← scripts/sync_agents.py で生成（直接編集禁止）
+├── codex/         ← 同上
+├── gemini/        ← 同上
+└── AGENTS.md      ← 同上
+```
+
+> **重要**: `framework/claude/` を編集したら、必ず `python3 scripts/sync_agents.py` を実行して
+> Cursor / Codex / Gemini / AGENTS.md を再生成してください。
+> CI ([sync-check workflow](.github/workflows/sync-check.yml)) がドリフトを自動検出し、PR を block します。
+
+Cursor 専用の手書きファイル（sync 対象外）:
+
+- `framework/cursor/rules/workato-project.mdc` — `alwaysApply: true` のプロジェクト全体ルール
+- `framework/cursor/hooks.json` — Cursor の hook 設定
+
+これら以外の Cursor ファイルは sync が上書きするため直接編集しないでください。
+
+---
+
+## ブランチ命名規則
+
+`<type>/<slug>` の形式を使ってください。`<type>` は Conventional Commits に揃えます:
+
+| Type | 用途 |
+|---|---|
+| `fix/` | バグ修正 |
+| `feat/` | 新機能 |
+| `docs/` | ドキュメントのみの変更 |
+| `chore/` | ビルド・補助ツール・雑務 |
+| `refactor/` | 機能変更を伴わないリファクタ |
+| `ci/` | CI 設定変更 |
+| `test/` | テスト追加・修正 |
+
+例: `fix/setup-python-shell-escape`, `docs/governance-files`, `feat/add-pull-recipe-skill`
+
+---
+
+## コミットメッセージ
+
+[Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) に従ってください。
+
+```
+<type>(<scope>): <subject>
+
+<body — 何故その変更が必要か>
+
+Closes #<issue-number>
+```
+
+例:
+
+```
+fix(setup): pass paths to python via env to avoid shell-escape breakage
+
+setup.sh の python3 -c がシェル変数を直接展開していたため、
+パスにクォートが含まれると Python コードが破綻していた。
+ヒアドキュメント + os.environ パターンに切り替えて隔離。
+
+Closes #92
+```
+
+---
+
+## Pull Request の流れ
+
+1. **Issue を確認/作成**: 既存 issue がない場合は先に立ててください（小さな typo 修正は除く）
+2. **ブランチ作成**: `git checkout -b <type>/<slug>`
+3. **実装 + ローカル検証**:
+   - `framework/claude/` を編集したら `python3 scripts/sync_agents.py` 実行
+   - テストがある領域は `python3 -m unittest scripts/tests/test_*.py` で実行
+4. **コミット**: Conventional Commits 準拠
+5. **Push + PR 作成**: `gh pr create --base main` または GitHub Web UI
+6. **CI チェック確認**: `sync-check` workflow が green になること
+7. **レビュー対応**: マージは原則メンテナーが行います
+
+PR 本文には「Summary」「Test plan」「Closes #N」を含めてください。
+
+---
+
+## テスト
+
+現状のテスト:
+
+```bash
+python3 -m unittest scripts/tests/test_sdk_push_frontmatter.py
+```
+
+新しい機能を追加したら、可能な範囲でテストも追加してください。
+特に [scripts/sync_agents.py](scripts/sync_agents.py) のリライト規則周りはテストカバレッジ拡充を歓迎します（[#101](https://github.com/rkawaishi/workato-dev-kit/issues/101) 参照）。
+
+---
+
+## 新規スキル追加時のチェックリスト
+
+`framework/claude/skills/<new-skill>/SKILL.md` を追加する際:
+
+- [ ] frontmatter の `description` が「いつこのスキルを起動すべきか」を機械可読な形で書かれているか
+- [ ] `allowed-tools` に必要なツールを全て宣言したか（Chrome MCP 等の外部ツールも含む）
+- [ ] スキル本文中の `@.claude/...` 参照が利用者ビュー（symlink 後の相対パス）になっているか
+- [ ] スキル間で重複している責務がないか
+- [ ] `python3 scripts/sync_agents.py` を実行し、`framework/{cursor,codex,gemini}/skills/<new-skill>/` が生成されたか
+- [ ] `framework/AGENTS.md` への影響を確認したか（必要に応じて）
+- [ ] [docs/skills-reference.md](guides/skills-reference.md) と README のスキル一覧表に追記したか
+
+---
+
+## ドキュメント (`docs/`) の編集ルール
+
+`docs/` 配下のナレッジベース（コネクタ情報・ロジック・プラットフォーム機能）は、
+利用者が `@docs/<path>` で参照することを前提に書かれています。
+リンク先を kit 内部パスに書き換えないでください。
+
+組織独自の補正・追記は利用者リポジトリ側の `org/docs/` に置く設計のため、
+kit の `docs/` には Workato 公式ドキュメント由来の汎用情報のみを記載してください。
+
+---
+
+## バグ報告 / 機能要望
+
+[GitHub Issues](https://github.com/rkawaishi/workato-dev-kit/issues) からどうぞ。
+（イシューテンプレートは [#95](https://github.com/rkawaishi/workato-dev-kit/issues/95) で整備中です）
+
+セキュリティ脆弱性については [SECURITY.md](SECURITY.md) を参照してください。
+
+---
+
+## 行動規範
+
+このプロジェクトは [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md) を採用しています。
+コントリビュートする際は遵守をお願いします。
+
+---
+
+## ライセンス
+
+このリポジトリへのコントリビューションは [MIT License](LICENSE) の元で公開されることに同意したものとみなされます。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Supported Versions
+
+workato-dev-kit はまだ正式なバージョンタグを切っていません。
+セキュリティ修正は **`main` ブランチの最新コミット** に対してのみ適用されます。
+利用者は `git submodule update --remote kit` で最新を取り込んでください。
+
+| Version | Supported |
+|---|---|
+| `main` (latest) | ✅ |
+| それ以前のコミット | ❌ |
+
+## 脆弱性の報告 / Reporting a Vulnerability
+
+セキュリティ脆弱性を発見した場合は、**公開イシューを立てずに**以下の方法で報告してください。
+
+### 推奨: GitHub Security Advisories
+
+1. リポジトリの [Security タブ](https://github.com/rkawaishi/workato-dev-kit/security/advisories/new) を開く
+2. 「Report a vulnerability」を選択
+3. 詳細を記入
+
+GitHub の Private Vulnerability Reporting 機能でメンテナーと安全に連絡できます。
+
+### フォールバック: メール
+
+GitHub Security Advisories が利用できない場合は、以下に直接メールしてください。
+
+- **Email**: kantannano@gmail.com
+- **件名プレフィックス**: `[SECURITY] workato-dev-kit:` を付けてください
+
+## 報告に含めると助かる情報
+
+- 影響を受けるファイル/コンポーネント（例: `setup.sh`, `scripts/sync_agents.py`, 特定のスキル）
+- 再現手順（最小限の PoC）
+- 想定される影響範囲（情報漏洩 / 任意コード実行 / 権限昇格 など）
+- 報告者のクレジット表記の希望（不要な場合はその旨）
+
+## 対応プロセス
+
+メンテナーは可能な限り迅速に対応しますが、本プロジェクトはボランティアベースで運営されているため、対応時期について保証はできません。目安として:
+
+| ステップ | 目標時間 |
+|---|---|
+| 受領確認 | 7 日以内 |
+| 影響評価 | 14 日以内 |
+| 修正リリース | 重大度に応じて調整 |
+
+## スコープ
+
+このリポジトリのコードベースに含まれる脆弱性が対象です。
+
+**スコープ外**:
+
+- Workato プラットフォーム本体の脆弱性（[Workato 公式](https://www.workato.com/legal/security) に報告してください）
+- 利用者リポジトリの設定不備（`.workatoenv` の漏洩など、利用者責任の領域）
+- Workato Platform CLI 本体の脆弱性（[workato-platform-cli](https://github.com/workato-devs/workato-platform-cli) に報告してください）
+- 依存している外部サービス（Claude Code, Cursor, Codex CLI, Gemini CLI など）の脆弱性
+
+## 開示ポリシー
+
+- 修正リリース完了後、GitHub Security Advisories を通じて公開
+- 報告者の協力に対し、希望に応じてクレジットを記載
+- CVE 番号の取得は重大度に応じて検討


### PR DESCRIPTION
## Summary

OSS 公開準備として、リポジトリルートに 3 つのガバナンス文書を追加します。
README で「ツールキットへの還元」を呼びかけているのに受け皿が無い状態を解消します。

| ファイル | 内容 |
|---|---|
| [CONTRIBUTING.md](CONTRIBUTING.md) | 開発セットアップ、`framework/claude/` 編集後の `python3 scripts/sync_agents.py` 実行義務、Conventional Commits、ブランチ命名規則、PR 手順、テスト方法、新規スキル追加チェックリスト |
| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) を採用。公式 [EthicalSource](https://github.com/EthicalSource/contributor_covenant) リポジトリから本文を取得し、TOML front matter を除去、enforcement 連絡先を `kantannano@gmail.com` に置換 |
| [SECURITY.md](SECURITY.md) | 脆弱性報告フロー（GitHub Security Advisories を主、メールをフォールバック）、サポート対象バージョン、対応プロセスの目安、スコープ（Workato 本体や利用者責任領域はスコープ外を明記） |

## Notes

- イシューテンプレート / PR テンプレートは別途 #95 で整備予定（同じ `.github/` 周辺だが文脈が異なるため分離）
- CODE_OF_CONDUCT.md は公式テキストを変更せず採用（連絡先プレースホルダのみ置換）
- SECURITY.md は GitHub の Private Vulnerability Reporting (PVR) を前提。リポジトリ Settings → Security → 「Private vulnerability reporting」を有効化していない場合は、マージ後に有効化してください

## Test plan

- [x] 3 ファイルとも GitHub のコミュニティスタンダード判定で「Found」になることを期待（マージ後に確認）
- [x] CONTRIBUTING.md 内のリンク（CODE_OF_CONDUCT.md, SECURITY.md, .github/workflows/sync-check.yml, scripts/sync_agents.py 等）が全て解決可能なパスであることを確認
- [x] CODE_OF_CONDUCT.md に `[INSERT CONTACT METHOD]` プレースホルダが残っていないことを確認

## Closes

- #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)