### PR TITLE
docs: add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         バグ報告ありがとうございます。
-        セキュリティ脆弱性については [SECURITY.md](../blob/main/SECURITY.md) の手順に従って非公開で報告してください。
+        セキュリティ脆弱性については [SECURITY.md](https://github.com/rkawaishi/workato-dev-kit/blob/main/SECURITY.md) の手順に従って非公開で報告してください。
 
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: バグ報告 / Bug Report
+description: workato-dev-kit の不具合を報告
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。
+        セキュリティ脆弱性については [SECURITY.md](../blob/main/SECURITY.md) の手順に従って非公開で報告してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が起きているか、簡潔に教えてください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 最小限の再現手順を順番に書いてください。
+      placeholder: |
+        1. `bash kit/setup.sh` を実行
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待動作
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: エラーメッセージやログがあれば貼ってください。長い場合はコードブロックで囲ってください。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: editor
+    attributes:
+      label: エディタ
+      description: どのエディタで再現しますか？
+      multiple: true
+      options:
+        - Claude Code
+        - Cursor
+        - Codex CLI
+        - Gemini CLI
+        - その他 / 該当なし
+    validations:
+      required: true
+
+  - type: input
+    id: kit-version
+    attributes:
+      label: kit のバージョン
+      description: "`git -C kit rev-parse HEAD` の出力（コミットハッシュ）または submodule 取り込み日"
+      placeholder: "例: 20021ee または 2026-05-10 取り込み"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / 環境
+      placeholder: "例: macOS 14.5 (arm64), Ubuntu 22.04, Windows 11 + WSL2"
+    validations:
+      required: true
+
+  - type: input
+    id: workato-cli-version
+    attributes:
+      label: Workato Platform CLI バージョン
+      description: "`workato --version` の出力（CLI を使う再現の場合のみ）"
+      placeholder: "例: workato-platform-cli 0.5.x"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: その他補足
+      description: スクリーンショット、関連 issue、回避策など
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 質問・ディスカッション / Questions & Discussion
+    url: https://github.com/rkawaishi/workato-dev-kit/discussions
+    about: 使い方の質問、設計相談、アイデアの共有はこちらへ。
+  - name: セキュリティ脆弱性 / Security Vulnerability
+    url: https://github.com/rkawaishi/workato-dev-kit/security/advisories/new
+    about: 脆弱性は公開イシューではなく Private Vulnerability Reporting で報告してください（詳細は SECURITY.md）。
+  - name: Workato プラットフォーム本体
+    url: https://www.workato.com/legal/security
+    about: Workato 本体の不具合・脆弱性は本リポジトリではなく Workato 公式へ。

--- a/.github/ISSUE_TEMPLATE/connector_doc_update.yml
+++ b/.github/ISSUE_TEMPLATE/connector_doc_update.yml
@@ -1,0 +1,78 @@
+name: コネクタドキュメント追加・修正 / Connector Doc Update
+description: docs/connectors/<provider>.md の追加・修正提案
+title: "[docs] connector: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Workato コネクタのフィールド情報やトリガー/アクションのドキュメントを追加・修正する提案です。
+        `/learn-recipe` や `/auto-learn` で得た学習結果の還元 PR と組み合わせて使うと便利です。
+
+  - type: input
+    id: provider
+    attributes:
+      label: コネクタ名 (provider)
+      description: "docs/connectors/<provider>.md のファイル名と一致する名前"
+      placeholder: "例: salesforce, google_sheets, slack"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connector-type
+    attributes:
+      label: コネクタタイプ
+      options:
+        - Pre-built (Workato 公式)
+        - カスタム (Connector SDK)
+        - 不明 / 該当なし
+    validations:
+      required: true
+
+  - type: dropdown
+    id: change-type
+    attributes:
+      label: 変更タイプ
+      multiple: true
+      options:
+        - 新規コネクタ追加
+        - トリガー / アクションの追加
+        - 既存フィールドの修正
+        - 説明文の追加・改善
+        - 誤情報の修正
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 追加・修正したい情報
+      description: |
+        具体的にどのトリガー/アクション、どのフィールドを追加・修正したいか。
+        可能なら入力フィールドのスキーマ（type, required, options 等）まで書いてください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: source
+    attributes:
+      label: 情報源
+      description: |
+        - Workato 公式ドキュメントの URL
+        - 自分のレシピ JSON での確認結果
+        - `/learn-recipe` 実行結果
+        - `/auto-learn` の収集結果
+        などの根拠
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pr-intent
+    attributes:
+      label: PR 提出の意思
+      options:
+        - 自分で PR を出す予定
+        - 提案のみ（メンテナーに任せたい）
+        - 未定
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: 機能要望 / Feature Request
+description: 新機能・改善の提案
+title: "[enhancement] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        新しいスキル・ルール・コネクタドキュメントの提案などを歓迎します。
+        まず議論したい場合は [Discussions](https://github.com/rkawaishi/workato-dev-kit/discussions) も検討してください。
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 動機 / Why
+      description: 解決したい問題、現状の不便さ、ユースケース
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案 / What
+      description: どう変えたいか。具体的な API・スキル名・ファイル構成のスケッチがあると話が進めやすいです。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 検討した他のアプローチと、それを選ばなかった理由
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: スコープ
+      description: どの領域の変更ですか？
+      multiple: true
+      options:
+        - スキル (framework/claude/skills/)
+        - ルール (framework/claude/rules/)
+        - ナレッジベース (docs/)
+        - ビルド/同期スクリプト (scripts/)
+        - セットアップ (setup.sh)
+        - ドキュメント (guides/, README)
+        - CI / GitHub 関連
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: その他補足
+      description: 関連 issue、参考リンク、図など
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+Thanks for the PR!
+- Conventional Commits 準拠の commit message にしてください: https://www.conventionalcommits.org/ja/v1.0.0/
+- 関連 issue を必ず Closes/Fixes で参照してください
+-->
+
+## Summary
+
+<!-- 何を、なぜ変えたか。1-3 文 -->
+
+## Changes
+
+<!-- 主要な変更点を箇条書きで -->
+
+-
+-
+
+## Test plan
+
+<!-- 検証手順をチェックボックスで -->
+
+- [ ]
+- [ ]
+
+## Checklist
+
+- [ ] `framework/claude/` を編集した場合、`python3 scripts/sync_agents.py` を実行し再生成物もコミット済み
+- [ ] 既存テストが通る (`python3 -m unittest scripts/tests/test_*.py`)
+- [ ] 新機能/挙動変更の場合、ドキュメント (README / guides / framework/claude/CLAUDE.md) を更新済み
+- [ ] スキル追加・変更の場合、[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#新規スキル追加時のチェックリスト) のチェックリストを満たしている
+- [ ] [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) と [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) を読んだ
+
+## Related
+
+<!-- Closes #N / Fixes #N / Refs #N -->
+
+Closes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,8 +27,8 @@ Thanks for the PR!
 - [ ] `framework/claude/` を編集した場合、`python3 scripts/sync_agents.py` を実行し再生成物もコミット済み
 - [ ] 既存テストが通る (`python3 -m unittest scripts/tests/test_*.py`)
 - [ ] 新機能/挙動変更の場合、ドキュメント (README / guides / framework/claude/CLAUDE.md) を更新済み
-- [ ] スキル追加・変更の場合、[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#新規スキル追加時のチェックリスト) のチェックリストを満たしている
-- [ ] [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) と [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) を読んだ
+- [ ] スキル追加・変更の場合、[CONTRIBUTING.md](https://github.com/rkawaishi/workato-dev-kit/blob/main/CONTRIBUTING.md#新規スキル追加時のチェックリスト) のチェックリストを満たしている
+- [ ] [CONTRIBUTING.md](https://github.com/rkawaishi/workato-dev-kit/blob/main/CONTRIBUTING.md) と [Code of Conduct](https://github.com/rkawaishi/workato-dev-kit/blob/main/CODE_OF_CONDUCT.md) を読んだ
 
 ## Related
 


### PR DESCRIPTION
## Summary

OSS 公開準備として、`.github/ISSUE_TEMPLATE/` と `.github/PULL_REQUEST_TEMPLATE.md` を整備します。コントリビューターの入り口を構造化し、報告品質を底上げします。

## Changes

### Issue templates (YAML フォーム形式)

- **bug_report.yml** — エディタ (Claude Code/Cursor/Codex/Gemini) を multiple dropdown、kit バージョン (commit hash)、OS、Workato CLI バージョンを構造化収集
- **feature_request.yml** — 動機・提案・代替案、スコープ (skills/rules/docs/scripts/...) を分類
- **connector_doc_update.yml** — \`docs/connectors/<provider>.md\` の追加修正に特化。provider 名、Pre-built/カスタムの別、変更タイプ、PR 提出の意思を収集
- **config.yml** — blank issue 無効化、Discussions / SECURITY.md / Workato 公式 へ誘導

### Pull request template

- Summary / Changes / Test plan / Checklist 構成
- Checklist: \`sync_agents.py\` 実行確認、テスト通過、ドキュメント更新、[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) のスキル追加チェックリスト遵守を必須項目化

## Notes

- YAML 形式は GitHub の最新フォームベース UI に対応。Markdown 形式より構造化情報を収集できる
- マージ後、リポジトリ Settings → General → Features で「Issues」と「Discussions」が有効か確認推奨

## Test plan

- [x] 各 \`.yml\` ファイルが GitHub の Issue Form schema に沿った構造であることを確認
- [x] 必須/任意フィールド (\`validations.required\`) が適切に設定されていることを確認
- [x] PR テンプレートの内部リンクが解決可能なパスであることを確認
- [ ] マージ後、新規 issue 作成画面で 3 種のテンプレートが表示されることを確認

## Closes

- #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)