### PR TITLE
fix(create-workflow-app): remove (※要確認) markers consistent with rule

### DIFF
--- a/framework/claude/skills/create-workflow-app/SKILL.md
+++ b/framework/claude/skills/create-workflow-app/SKILL.md
@@ -87,8 +87,8 @@ Workato UI で Workflow App を有効化してください:
 - 連絡先: `"type": "input"` + `"style": "email"` / `"phone"` / `"url"`（自動バリデーション付き）
 - 日付系: **`"type": "date"`**（`"input"` + `"style": "date"` は NG — エディタが壊れる）
 - 選択式: `"type": "dropdown"` + `"options"` で固定選択肢を定義。`"multiValue": true` で複数選択
-- チェックボックス: `"type": "checkbox"`（※JSON type 要確認）→ Data Table の `boolean` 型
-- ファイル: `"type": "file"`（※JSON type 要確認）→ Data Table の `file` 型
+- チェックボックス: `"type": "checkbox"` → Data Table の `boolean` 型
+- ファイル: `"type": "file"` → Data Table の `file` 型
 - button コンポーネント（`handlers.click.type`: `"save-data"` / `"complete-task"` / `"open-url"` / `"run-recipe"` / `"reset-reload"`）
 - `dataSource` は **Data Table カラムへの保存先**を指定する。`dataSource.id` には Data Table フィールドの **title**（UUID ではない）を指定。`dataSource` が `null` だと送信時に値が保存されない
 
@@ -104,8 +104,8 @@ Workato UI で Workflow App を有効化してください:
 | date / date-time | **`"date"`** | 不要 |
 | 選択式（単一） | **`"dropdown"`** | 不要 |
 | 選択式（複数） | **`"dropdown"`** + `multiValue: true` | 不要 |
-| チェックボックス | **`"checkbox"`** (※要確認) | 不要 |
-| ファイル | **`"file"`** (※要確認) | 不要 |
+| チェックボックス | **`"checkbox"`** | 不要 |
+| ファイル | **`"file"`** | 不要 |
 
 **レビューページ** (`Pages/review_<name>.lcap_page.json`):
 - input / date コンポーネント（`editable: false`）でリクエスト内容を読み取り表示

--- a/framework/codex/skills/create-workflow-app/SKILL.md
+++ b/framework/codex/skills/create-workflow-app/SKILL.md
@@ -87,8 +87,8 @@ Workato UI で Workflow App を有効化してください:
 - 連絡先: `"type": "input"` + `"style": "email"` / `"phone"` / `"url"`（自動バリデーション付き）
 - 日付系: **`"type": "date"`**（`"input"` + `"style": "date"` は NG — エディタが壊れる）
 - 選択式: `"type": "dropdown"` + `"options"` で固定選択肢を定義。`"multiValue": true` で複数選択
-- チェックボックス: `"type": "checkbox"`（※JSON type 要確認）→ Data Table の `boolean` 型
-- ファイル: `"type": "file"`（※JSON type 要確認）→ Data Table の `file` 型
+- チェックボックス: `"type": "checkbox"` → Data Table の `boolean` 型
+- ファイル: `"type": "file"` → Data Table の `file` 型
 - button コンポーネント（`handlers.click.type`: `"save-data"` / `"complete-task"` / `"open-url"` / `"run-recipe"` / `"reset-reload"`）
 - `dataSource` は **Data Table カラムへの保存先**を指定する。`dataSource.id` には Data Table フィールドの **title**（UUID ではない）を指定。`dataSource` が `null` だと送信時に値が保存されない
 
@@ -104,8 +104,8 @@ Workato UI で Workflow App を有効化してください:
 | date / date-time | **`"date"`** | 不要 |
 | 選択式（単一） | **`"dropdown"`** | 不要 |
 | 選択式（複数） | **`"dropdown"`** + `multiValue: true` | 不要 |
-| チェックボックス | **`"checkbox"`** (※要確認) | 不要 |
-| ファイル | **`"file"`** (※要確認) | 不要 |
+| チェックボックス | **`"checkbox"`** | 不要 |
+| ファイル | **`"file"`** | 不要 |
 
 **レビューページ** (`Pages/review_<name>.lcap_page.json`):
 - input / date コンポーネント（`editable: false`）でリクエスト内容を読み取り表示

--- a/framework/cursor/skills/create-workflow-app/SKILL.md
+++ b/framework/cursor/skills/create-workflow-app/SKILL.md
@@ -87,8 +87,8 @@ Workato UI で Workflow App を有効化してください:
 - 連絡先: `"type": "input"` + `"style": "email"` / `"phone"` / `"url"`（自動バリデーション付き）
 - 日付系: **`"type": "date"`**（`"input"` + `"style": "date"` は NG — エディタが壊れる）
 - 選択式: `"type": "dropdown"` + `"options"` で固定選択肢を定義。`"multiValue": true` で複数選択
-- チェックボックス: `"type": "checkbox"`（※JSON type 要確認）→ Data Table の `boolean` 型
-- ファイル: `"type": "file"`（※JSON type 要確認）→ Data Table の `file` 型
+- チェックボックス: `"type": "checkbox"` → Data Table の `boolean` 型
+- ファイル: `"type": "file"` → Data Table の `file` 型
 - button コンポーネント（`handlers.click.type`: `"save-data"` / `"complete-task"` / `"open-url"` / `"run-recipe"` / `"reset-reload"`）
 - `dataSource` は **Data Table カラムへの保存先**を指定する。`dataSource.id` には Data Table フィールドの **title**（UUID ではない）を指定。`dataSource` が `null` だと送信時に値が保存されない
 
@@ -104,8 +104,8 @@ Workato UI で Workflow App を有効化してください:
 | date / date-time | **`"date"`** | 不要 |
 | 選択式（単一） | **`"dropdown"`** | 不要 |
 | 選択式（複数） | **`"dropdown"`** + `multiValue: true` | 不要 |
-| チェックボックス | **`"checkbox"`** (※要確認) | 不要 |
-| ファイル | **`"file"`** (※要確認) | 不要 |
+| チェックボックス | **`"checkbox"`** | 不要 |
+| ファイル | **`"file"`** | 不要 |
 
 **レビューページ** (`Pages/review_<name>.lcap_page.json`):
 - input / date コンポーネント（`editable: false`）でリクエスト内容を読み取り表示

--- a/framework/gemini/skills/create-workflow-app/SKILL.md
+++ b/framework/gemini/skills/create-workflow-app/SKILL.md
@@ -87,8 +87,8 @@ Workato UI で Workflow App を有効化してください:
 - 連絡先: `"type": "input"` + `"style": "email"` / `"phone"` / `"url"`（自動バリデーション付き）
 - 日付系: **`"type": "date"`**（`"input"` + `"style": "date"` は NG — エディタが壊れる）
 - 選択式: `"type": "dropdown"` + `"options"` で固定選択肢を定義。`"multiValue": true` で複数選択
-- チェックボックス: `"type": "checkbox"`（※JSON type 要確認）→ Data Table の `boolean` 型
-- ファイル: `"type": "file"`（※JSON type 要確認）→ Data Table の `file` 型
+- チェックボックス: `"type": "checkbox"` → Data Table の `boolean` 型
+- ファイル: `"type": "file"` → Data Table の `file` 型
 - button コンポーネント（`handlers.click.type`: `"save-data"` / `"complete-task"` / `"open-url"` / `"run-recipe"` / `"reset-reload"`）
 - `dataSource` は **Data Table カラムへの保存先**を指定する。`dataSource.id` には Data Table フィールドの **title**（UUID ではない）を指定。`dataSource` が `null` だと送信時に値が保存されない
 
@@ -104,8 +104,8 @@ Workato UI で Workflow App を有効化してください:
 | date / date-time | **`"date"`** | 不要 |
 | 選択式（単一） | **`"dropdown"`** | 不要 |
 | 選択式（複数） | **`"dropdown"`** + `multiValue: true` | 不要 |
-| チェックボックス | **`"checkbox"`** (※要確認) | 不要 |
-| ファイル | **`"file"`** (※要確認) | 不要 |
+| チェックボックス | **`"checkbox"`** | 不要 |
+| ファイル | **`"file"`** | 不要 |
 
 **レビューページ** (`Pages/review_<name>.lcap_page.json`):
 - input / date コンポーネント（`editable: false`）でリクエスト内容を読み取り表示


### PR DESCRIPTION
## Summary

[framework/claude/skills/create-workflow-app/SKILL.md](framework/claude/skills/create-workflow-app/SKILL.md) で チェックボックス (\`\"checkbox\"\`) とファイル (\`\"file\"\`) の type 値に対して **(※要確認)** マーカーが 4 箇所付いていた (L90-91, L107-108)。

[framework/claude/rules/workato-page-components.md:88-89](framework/claude/rules/workato-page-components.md) (canonical なページコンポーネント仕様) は同じ値をマーカー無しで確定値として記載しており、スキル側の確認待ち表記は不整合。ルールを唯一の正として、スキルからマーカーを削除する。

## Changes

| 行 | Before | After |
|---|---|---|
| L90 | \`\"type\": \"checkbox\"\`（※JSON type 要確認） | \`\"type\": \"checkbox\"\` |
| L91 | \`\"type\": \"file\"\`（※JSON type 要確認） | \`\"type\": \"file\"\` |
| L107 | \`**\"checkbox\"** (※要確認)\` | \`**\"checkbox\"**\` |
| L108 | \`**\"file\"** (※要確認)\` | \`**\"file\"**\` |

`python3 scripts/sync_agents.py` で 4 エディタ (claude / cursor / codex / gemini) 用 SKILL.md も再生成。

## Test plan

- [x] `grep -nE '要確認' framework/claude/skills/create-workflow-app/SKILL.md` が空であることを確認
- [x] [framework/claude/rules/workato-page-components.md:88-89](framework/claude/rules/workato-page-components.md) の確定値と一致することを確認
- [x] 4 エディタ用 SKILL.md が同じ変更で再生成されたことを確認

## Closes

- #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)