### PR TITLE
fix(auto-learn): declare Chrome MCP tools and document prerequisites

### DIFF
--- a/framework/claude/skills/auto-learn/SKILL.md
+++ b/framework/claude/skills/auto-learn/SKILL.md
@@ -1,11 +1,17 @@
 ---
-description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。Claude in Chrome 拡張が必須で Claude Code 限定。
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, mcp__Claude_in_Chrome__navigate, mcp__Claude_in_Chrome__find, mcp__Claude_in_Chrome__form_input, mcp__Claude_in_Chrome__javascript_tool, mcp__Claude_in_Chrome__read_page, mcp__Claude_in_Chrome__read_console_messages, mcp__Claude_in_Chrome__read_network_requests, mcp__Claude_in_Chrome__tabs_context_mcp, mcp__Claude_in_Chrome__tabs_create_mcp, mcp__Claude_in_Chrome__select_browser, mcp__Claude_in_Chrome__list_connected_browsers
 ---
 
 # /auto-learn
 
 Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+## 前提
+
+- **エディタ**: Claude Code 限定（Cursor / Codex CLI / Gemini CLI には Chrome MCP が無いため動作しない）
+- **拡張機能**: [Claude in Chrome](https://chrome.google.com/webstore) がインストール・接続されていること。未接続だと `tabs_context_mcp` や `navigate` などの呼び出しがエラーになる（接続状態は `mcp__Claude_in_Chrome__list_connected_browsers` で確認）
+- **Workato ログイン**: 対象ワークスペースに UI でログイン済みのタブがあること（自動ログインはしない）
 
 ## 設計原則（重要）
 

--- a/framework/codex/skills/auto-learn/SKILL.md
+++ b/framework/codex/skills/auto-learn/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: auto-learn
-description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。Claude in Chrome 拡張が必須で Claude Code 限定。
 ---
 
 # $auto-learn
 
 Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+## 前提
+
+- **エディタ**: Claude Code 限定（Cursor / Codex CLI / Gemini CLI には Chrome MCP が無いため動作しない）
+- **拡張機能**: [Claude in Chrome](https://chrome.google.com/webstore) がインストール・接続されていること。未接続だと `tabs_context_mcp` や `navigate` などの呼び出しがエラーになる（接続状態は `mcp__Claude_in_Chrome__list_connected_browsers` で確認）
+- **Workato ログイン**: 対象ワークスペースに UI でログイン済みのタブがあること（自動ログインはしない）
 
 ## 設計原則（重要）
 

--- a/framework/cursor/skills/auto-learn/SKILL.md
+++ b/framework/cursor/skills/auto-learn/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: auto-learn
-description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。Claude in Chrome 拡張が必須で Claude Code 限定。
 ---
 
 # /auto-learn
 
 Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+## 前提
+
+- **エディタ**: Claude Code 限定（Cursor / Codex CLI / Gemini CLI には Chrome MCP が無いため動作しない）
+- **拡張機能**: [Claude in Chrome](https://chrome.google.com/webstore) がインストール・接続されていること。未接続だと `tabs_context_mcp` や `navigate` などの呼び出しがエラーになる（接続状態は `mcp__Claude_in_Chrome__list_connected_browsers` で確認）
+- **Workato ログイン**: 対象ワークスペースに UI でログイン済みのタブがあること（自動ログインはしない）
 
 ## 設計原則（重要）
 

--- a/framework/gemini/skills/auto-learn/SKILL.md
+++ b/framework/gemini/skills/auto-learn/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: auto-learn
-description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。
+description: Workato UI を Claude in Chrome で操作し、1 コネクタ単位で全オペレーションのフィールド情報を自律的に収集して docs/connectors/<provider>.md に追記する。完全性より自律性を優先し、不確実なものは記録してスキップする（途中でユーザーに質問しない）。Claude in Chrome 拡張が必須で Claude Code 限定。
 ---
 
 # /auto-learn
 
 Workato UI を Claude in Chrome で操作し、対象コネクタの全オペレーション（trigger / action）の input / output フィールドを能動収集して `docs/connectors/<provider>.md` に追記するスキル。
+
+## 前提
+
+- **エディタ**: Claude Code 限定（Cursor / Codex CLI / Gemini CLI には Chrome MCP が無いため動作しない）
+- **拡張機能**: [Claude in Chrome](https://chrome.google.com/webstore) がインストール・接続されていること。未接続だと `tabs_context_mcp` や `navigate` などの呼び出しがエラーになる（接続状態は `mcp__Claude_in_Chrome__list_connected_browsers` で確認）
+- **Workato ログイン**: 対象ワークスペースに UI でログイン済みのタブがあること（自動ログインはしない）
 
 ## 設計原則（重要）
 


### PR DESCRIPTION
## Summary

[framework/claude/skills/auto-learn/SKILL.md](framework/claude/skills/auto-learn/SKILL.md) は本文で Chrome MCP 操作 (`tabs_context_mcp`, `navigate`, `find`, `javascript_tool`, `form_input` 等) を前提にしているのに、frontmatter の `allowed-tools` は `Read, Write, Edit, Glob, Grep, Bash, WebFetch` のみで Chrome MCP を**一切宣言していなかった**。Chrome MCP 未接続環境では black-box で失敗する。

## Changes

### `allowed-tools` に Chrome MCP 11 個を追加

```yaml
allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch,
  mcp__Claude_in_Chrome__navigate,
  mcp__Claude_in_Chrome__find,
  mcp__Claude_in_Chrome__form_input,
  mcp__Claude_in_Chrome__javascript_tool,
  mcp__Claude_in_Chrome__read_page,
  mcp__Claude_in_Chrome__read_console_messages,
  mcp__Claude_in_Chrome__read_network_requests,
  mcp__Claude_in_Chrome__tabs_context_mcp,
  mcp__Claude_in_Chrome__tabs_create_mcp,
  mcp__Claude_in_Chrome__select_browser,
  mcp__Claude_in_Chrome__list_connected_browsers
```

### description に Claude Code 限定の前提を追記

> ... Claude in Chrome 拡張が必須で Claude Code 限定。

`sync_agents.py` は `allowed-tools` を Cursor/Codex/Gemini から削るが description は保持するため、他エディタ利用者にも前提が伝わる。

### 本文冒頭に「## 前提」セクション新設

3 点を明示:
- エディタ: Claude Code 限定
- 拡張機能: Claude in Chrome がインストール・接続済み
- Workato ログイン: 対象ワークスペースに UI でログイン済みのタブ

## Test plan

- [x] `python3 scripts/sync_agents.py` 実行 → 4 エディタ用が再生成される
- [x] Cursor / Codex / Gemini の SKILL.md 先頭で `allowed-tools` 行が省かれていることを確認 (これらのフォーマットでは未対応キーのため)
- [x] 全エディタの description に「Claude Code 限定」が伝播していることを確認

## Closes

- #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)