### PR TITLE
fix(push-project): make hook reference editor-agnostic

### DIFF
--- a/framework/claude/skills/push-project/SKILL.md
+++ b/framework/claude/skills/push-project/SKILL.md
@@ -66,7 +66,9 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
 
 #### 1d. Workato CLI recipes validate（ブロッキング）
 
-`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+**Claude Code 環境**: `kit/framework/claude/hooks/validate-before-push.sh` が PreToolUse フック経由で `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+**他エディタ (Cursor / Codex / Gemini)**: 自動フックは未整備。push 前に `/validate-recipe` を明示的に実行してフォーマットを確認すること。
 
 - **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
 - **失敗時**: エラー詳細を表示して push を中断（exit 2）

--- a/framework/codex/skills/push-project/SKILL.md
+++ b/framework/codex/skills/push-project/SKILL.md
@@ -65,7 +65,9 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
 
 #### 1d. Workato CLI recipes validate（ブロッキング）
 
-`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+**Claude Code 環境**: `kit/framework/claude/hooks/validate-before-push.sh` が PreToolUse フック経由で `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+**他エディタ (Cursor / Codex / Gemini)**: 自動フックは未整備。push 前に `$validate-recipe` を明示的に実行してフォーマットを確認すること。
 
 - **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
 - **失敗時**: エラー詳細を表示して push を中断（exit 2）

--- a/framework/cursor/skills/push-project/SKILL.md
+++ b/framework/cursor/skills/push-project/SKILL.md
@@ -66,7 +66,9 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
 
 #### 1d. Workato CLI recipes validate（ブロッキング）
 
-`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+**Claude Code 環境**: `kit/framework/claude/hooks/validate-before-push.sh` が PreToolUse フック経由で `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+**他エディタ (Cursor / Codex / Gemini)**: 自動フックは未整備。push 前に `/validate-recipe` を明示的に実行してフォーマットを確認すること。
 
 - **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
 - **失敗時**: エラー詳細を表示して push を中断（exit 2）

--- a/framework/gemini/skills/push-project/SKILL.md
+++ b/framework/gemini/skills/push-project/SKILL.md
@@ -65,7 +65,9 @@ WARNING: <page>.lcap_page.json のドロップダウン "<label>" の dataSource
 
 #### 1d. Workato CLI recipes validate（ブロッキング）
 
-`.claude/hooks/validate-before-push.sh` が `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+**Claude Code 環境**: `kit/framework/claude/hooks/validate-before-push.sh` が PreToolUse フック経由で `workato push` 検知時に自動実行する。全 `*.recipe.json` に対して `workato recipes validate --path <file>` を流し、フォーマット不備を push 前に検出する。
+
+**他エディタ (Cursor / Codex / Gemini)**: 自動フックは未整備。push 前に `/validate-recipe` を明示的に実行してフォーマットを確認すること。
 
 - **実行時間**: 約 2 秒/ファイル（直列実行）。大規模プロジェクトでは push 前の待ち時間になる点に留意
 - **失敗時**: エラー詳細を表示して push を中断（exit 2）


### PR DESCRIPTION
## Summary

[framework/claude/skills/push-project/SKILL.md:69](framework/claude/skills/push-project/SKILL.md) で \`.claude/hooks/validate-before-push.sh\` を直接参照していた。`sync_agents.py` は `.claude/` パスを Cursor / Codex / Gemini 向けに書き換えないため、他エディタ利用者には**誤情報**として配布されていた。

## Changes

L67-73 周辺を以下のように分岐:

- **Claude Code 環境**: PreToolUse フック経由で `kit/framework/claude/hooks/validate-before-push.sh` が自動実行される旨を、実体パスで明示
- **他エディタ (Cursor / Codex / Gemini)**: 自動フック未整備のため `/validate-recipe` を手動実行する案内を追加

## Test plan

- [x] `grep -rn '\\.claude/hooks/' framework/claude/skills/` が空であることを確認
- [x] `python3 scripts/sync_agents.py` 実行で 4 エディタ用 SKILL.md が同じ内容で再生成されることを確認

## Closes

- #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)