### PR TITLE
docs(readme): add CI / license / Python / editor badges

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,12 @@
 
 English | [日本語](README.md)
 
+[![tests](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/tests.yml)
+[![sync-check](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/sync-check.yml/badge.svg?branch=main)](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/sync-check.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
+[![editors](https://img.shields.io/badge/editors-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20CLI%20%7C%20Gemini%20CLI-orange.svg)](#features)
+
 A toolkit for building Workato (enterprise iPaaS) automations with AI coding agents.
 Supports [Claude Code](https://claude.com/claude-code), [Cursor](https://cursor.com), [Codex CLI](https://github.com/openai/codex), and [Gemini CLI](https://github.com/google-gemini/gemini-cli).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [English](README.en.md) | 日本語
 
+[![tests](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/tests.yml)
+[![sync-check](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/sync-check.yml/badge.svg?branch=main)](https://github.com/rkawaishi/workato-dev-kit/actions/workflows/sync-check.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
+[![editors](https://img.shields.io/badge/editors-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20CLI%20%7C%20Gemini%20CLI-orange.svg)](#特徴)
+
 Workato (エンタープライズ iPaaS) の自動化開発を AI コーディングエージェントで行うためのツールキット。
 [Claude Code](https://claude.com/claude-code) / [Cursor](https://cursor.com) / [Codex CLI](https://github.com/openai/codex) / [Gemini CLI](https://github.com/google-gemini/gemini-cli) に対応。
 


### PR DESCRIPTION
## Summary

OSS 公開時の第一印象を底上げするため、`README.md` (日本語版) と `README.en.md` (英語版) の冒頭にバッジを 5 つ追加。

| バッジ | 用途 |
|---|---|
| tests | [tests workflow](.github/workflows/tests.yml) の状態 (#101 で追加) |
| sync-check | [sync-check workflow](.github/workflows/sync-check.yml) の状態 |
| License | MIT |
| Python | 3.8+ |
| editors | Claude Code / Cursor / Codex CLI / Gemini CLI 対応の明示 |

## Notes

スクリーンショット・GIF は別途撮影が必要なので本 PR ではスコープ外。今回はバッジのみ。

## Test plan

- [x] バッジの URL を `https://github.com/rkawaishi/workato-dev-kit/...` で実 URL 化
- [x] 英語版・日本語版で同じバッジ群、リンクアンカーは各言語の見出しへ (`#features` / `#特徴`)
- [ ] マージ後、main 上の workflow 実行で badge が正しく緑表示されることを確認

## Closes

- #105 (バッジ追加分のみ。GIF / スクリーンショットは follow-up issue にする想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)