### PR TITLE
ci(sync-check): add AGENTS.md size budget guard

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -45,3 +45,27 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: Check AGENTS.md size budget
+        run: |
+          # AGENTS.md は CLAUDE.md + 全ルールをフラット連結する性質上、
+          # ルール追加で線形に膨張する。Codex / Aider 等のフラット読み込み
+          # エージェントは毎回これを context に取り込むため、肥大化はそのまま
+          # 利用者のトークンコストに跳ね返る。
+          #
+          # ルール 1 つ追加で +200〜400 行を想定し、現状 +12% の余裕を持たせた
+          # 上限を設定。budget を超えたら以下のいずれかで対応:
+          #   1) ルールを統合して総量を減らす
+          #   2) AGENTS.md の構造をインデックス型に再設計 (issue #102)
+          #   3) 議論の上で本ファイルの上限値を引き上げる
+          MAX_LINES=1500
+          MAX_BYTES=65000
+          lines=$(wc -l < framework/AGENTS.md)
+          bytes=$(wc -c < framework/AGENTS.md)
+          echo "framework/AGENTS.md: $lines lines, $bytes bytes (budget: $MAX_LINES lines, $MAX_BYTES bytes)"
+          if [ "$lines" -gt "$MAX_LINES" ] || [ "$bytes" -gt "$MAX_BYTES" ]; then
+            echo "::error::framework/AGENTS.md exceeds the size budget."
+            echo "::error::Lines: $lines / $MAX_LINES, Bytes: $bytes / $MAX_BYTES"
+            echo "::error::See issue #102 for refactor options (index-based structure, rule consolidation)."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

[framework/AGENTS.md](framework/AGENTS.md) は CLAUDE.md + 全ルールをフラット連結する性質上、ルール追加で線形に膨張する。Codex / Aider 等のフラット読み込みエージェントは毎回これを context に取り込むため、肥大化はそのまま**利用者のトークンコスト**に跳ね返る。

Issue #102 では構造的な再設計（インデックス型）も挙げられているが、現状サイズ (1342 lines / 55KB) は許容範囲なので、まずは CI で **サイズバジェットを守る**シンプルな対策を入れる。バジェットを超えたら以下のいずれかを意識的に選ぶよう強制する:

1. ルール統合 (#103 のような小規模対応)
2. 構造再設計 (#102 のインデックス化)
3. バジェット引き上げの議論

## Changes

- [.github/workflows/sync-check.yml](.github/workflows/sync-check.yml) に「Check AGENTS.md size budget」ステップを追加
- `MAX_LINES=1500` / `MAX_BYTES=65000` (現状 +12% の余裕。ルール 1 つ追加で +200〜400 行を想定し、即座にトリップしない値を設定)
- バジェット超過時は明示的なエラーメッセージで対応オプションを案内

## Test plan

- [x] ローカルで budget check を実行: `framework/AGENTS.md: 1342 lines, 56334 bytes (budget: 1500 / 65000)` → PASS
- [ ] CI 上で sync-check workflow が通ることをマージ前に確認

## Refs

- #102 (本 PR は size guard のみ。構造再設計は別途議論)

🤖 Generated with [Claude Code](https://claude.com/claude-code)