### PR TITLE
docs(connectors): clarify _index.md role and the learning cycle

### DIFF
--- a/docs/connectors/_index.md
+++ b/docs/connectors/_index.md
@@ -1,5 +1,21 @@
 # Workato コネクタ一覧
 
+## このリストの位置づけ
+
+本ファイルは Workato Pre-built コネクタ **316 件のインベントリ**（コネクタ名・provider key・トリガー数・アクション数）です。`/sync-connectors` が Workato API から自動生成・更新します。
+
+各コネクタの詳細（個別トリガー/アクションの一覧、フィールド仕様）は **`docs/connectors/<provider>.md`** に分離されています。これらの個別ファイルも `/sync-connectors` がスケルトン（`## Triggers` / `## Actions` テーブル + `## フィールド詳細` 空セクション）を作成しますが、**説明文・フィールド詳細は API から取得できないため空欄**で初期化されます。
+
+### ドキュメントの育て方
+
+説明文・フィールド詳細は以下のサイクルで段階的に充実させていく設計です:
+
+1. **`/learn-recipe <project>`** — 既存レシピの JSON からフィールド使用例を抽出し、該当 `<provider>.md` の `## フィールド詳細` に追記
+2. **`/auto-learn <provider>`** — Workato UI を Claude in Chrome で操作し、全 op の input/output フィールドを自律収集して追記（Claude Code 限定）
+3. **手動補正** — 公式ドキュメントや実機検証で得た知見を `org/docs/connectors/<provider>.md`（組織ナレッジ層）または PR で kit に還元
+
+そのため Triggers / Actions テーブルの「説明」列が空欄でも**仕様外ではなく未学習**の意味です。コミュニティ PR でのナレッジ還元は [CONTRIBUTING.md](../../CONTRIBUTING.md) と [connector_doc_update](../../.github/ISSUE_TEMPLATE/connector_doc_update.yml) issue テンプレートを参照してください。
+
 ## コネクタの分類
 
 ### Pre-built Connectors（標準コネクタ）


### PR DESCRIPTION
## Summary

レビューで「[docs/connectors/_index.md](docs/connectors/_index.md) と各 `<provider>.md` の **説明列がほぼ空欄**で、現状は『コネクタ名・op 名のリスト』止まり」と指摘された件への応答。

実装上、説明文・フィールド詳細は Workato API から取得できないため、`/sync-connectors` はスケルトンのみを生成し、`/learn-recipe` → `/auto-learn` → 手動補正/PR の **学習サイクル**で段階的に充実させる設計です。これは「未完成」ではなく「ナレッジを育てる仕組み」ですが、ドキュメント上で明示されていなかったため誤解を招きやすい状態でした。

機械的に説明列を埋める案 (#104 オプション A/B) は別途長期作業として残し、本 PR では **設計意図の明示**による期待値リセット (オプション C) のみ実施します。

## Changes

[docs/connectors/_index.md](docs/connectors/_index.md) 冒頭に「## このリストの位置づけ」セクションを追加 (16 lines):

- 本ファイルが 316 件の **インベントリ**（counts のみ）であることを明示
- 個別 `<provider>.md` がスケルトンで空欄の **理由**（API から説明文が取れない）を説明
- 育て方サイクル 3 段階を提示:
  1. `/learn-recipe <project>` — 既存レシピから抽出
  2. `/auto-learn <provider>` — Claude in Chrome で UI 操作
  3. 手動/PR — 公式ドキュメントや実機検証から
- [CONTRIBUTING.md](CONTRIBUTING.md) と [connector_doc_update](.github/ISSUE_TEMPLATE/connector_doc_update.yml) issue テンプレートへの導線

## Test plan

- [x] 既存の「## コネクタの分類」以下のセクションが影響を受けていないことを確認 (head の追記のみ)
- [x] 内部リンク (CONTRIBUTING.md, ISSUE_TEMPLATE) が _index.md の階層 (`docs/connectors/`) から `../../` で正しく解決することを確認

## Closes

- #104 (本 PR は設計意図の明示で対応。個別フィールド充実は引き続き `/learn-recipe` 等で蓄積)

🤖 Generated with [Claude Code](https://claude.com/claude-code)