### PR TITLE
docs(connectors): translate A-G connector docs to English [P7a]

### DIFF
--- a/docs/connectors/active_directory.md
+++ b/docs/connectors/active_directory.md
@@ -1,10 +1,10 @@
-# Active Directory コネクタ
+# Active Directory connector
 
 Provider: `active_directory`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New entry | `new_entry` | - |  |
 | Scheduled entry search using search filter | `paged_search_entries` | Yes |  |
@@ -12,7 +12,7 @@ Provider: `active_directory`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Add entry | `add_entry` | - |  |
 | Add group | `add_group` | - |  |

--- a/docs/connectors/active_reg_online.md
+++ b/docs/connectors/active_reg_online.md
@@ -1,10 +1,10 @@
-# RegOnline® by Lanyon コネクタ
+# RegOnline® by Lanyon connector
 
 Provider: `active_reg_online`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New event | `on_new_event` | - |  |
 | New registration | `on_new_registration` | - |  |
@@ -12,7 +12,7 @@ Provider: `active_reg_online`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Get event details by ID | `lookup_event` | - |  |
 | Get registration details by ID | `lookup_registration` | - |  |

--- a/docs/connectors/adobe_experience_manager.md
+++ b/docs/connectors/adobe_experience_manager.md
@@ -1,17 +1,17 @@
-# Adobe Experience Manager コネクタ
+# Adobe Experience Manager connector
 
 Provider: `adobe_experience_manager`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New asset or folder | `new_asset_or_folder` | - |  |
 | New or updated asset | `new_or_updated_asset` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy folder/asset | `copy_folder_asset` | - |  |

--- a/docs/connectors/adp7.md
+++ b/docs/connectors/adp7.md
@@ -1,17 +1,17 @@
-# ADP Workforce Now コネクタ
+# ADP Workforce Now connector
 
 Provider: `adp7`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Scheduled worker search | `scheduled_worker` | - |  [deprecated] |
 | Scheduled worker search | `scheduled_worker_v2` | Yes |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Onboard applicant | `applicant_onboard` | - |  |

--- a/docs/connectors/air_regi.md
+++ b/docs/connectors/air_regi.md
@@ -1,14 +1,14 @@
-# AirREGI コネクタ
+# AirREGI connector
 
 Provider: `air_regi`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New refund | `new_refund` | - |  |
 | New sale | `new_sale` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/airbrake.md
+++ b/docs/connectors/airbrake.md
@@ -1,13 +1,13 @@
-# Airbrake コネクタ
+# Airbrake connector
 
 Provider: `airbrake`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Get project | `get_project` | - |  |

--- a/docs/connectors/airtable.md
+++ b/docs/connectors/airtable.md
@@ -1,17 +1,17 @@
-# Airtable コネクタ
+# Airtable connector
 
 Provider: `airtable`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New/updated record | `new_or_updated_record` | - |  |
 | New record | `new_record` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create record | `create_record` | - |  |

--- a/docs/connectors/amazon_lex_nlu.md
+++ b/docs/connectors/amazon_lex_nlu.md
@@ -1,11 +1,11 @@
-# Amazon Lex コネクタ
+# Amazon Lex connector
 
 Provider: `amazon_lex_nlu`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/amazon_s3.md
+++ b/docs/connectors/amazon_s3.md
@@ -1,10 +1,10 @@
-# Amazon S3 コネクタ
+# Amazon S3 connector
 
 Provider: `amazon_s3`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New CSV file | `new_CSV_file` | - |  |
 | New file | `new_file` | - |  |
@@ -13,7 +13,7 @@ Provider: `amazon_s3`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy file | `copy_object` | - |  |

--- a/docs/connectors/amazon_s3_secondary.md
+++ b/docs/connectors/amazon_s3_secondary.md
@@ -1,10 +1,10 @@
-# Amazon S3 secondary コネクタ
+# Amazon S3 secondary connector
 
 Provider: `amazon_s3_secondary`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New CSV file | `new_CSV_file` | - |  |
 | New file | `new_file` | - |  |
@@ -13,7 +13,7 @@ Provider: `amazon_s3_secondary`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy file | `copy_object` | - |  |

--- a/docs/connectors/amazon_ses.md
+++ b/docs/connectors/amazon_ses.md
@@ -1,14 +1,14 @@
-# Amazon SES コネクタ
+# Amazon SES connector
 
 Provider: `amazon_ses`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/amcards.md
+++ b/docs/connectors/amcards.md
@@ -1,13 +1,13 @@
-# AMcards コネクタ
+# AMcards connector
 
 Provider: `amcards`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Create card | `create_card` | - |  |

--- a/docs/connectors/anaplan.md
+++ b/docs/connectors/anaplan.md
@@ -1,14 +1,14 @@
-# Anaplan コネクタ
+# Anaplan connector
 
 Provider: `anaplan`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Download dump file | `download_dump_file` | - |  |

--- a/docs/connectors/api_ai_nlu.md
+++ b/docs/connectors/api_ai_nlu.md
@@ -1,11 +1,11 @@
-# Google Dialogflow コネクタ
+# Google Dialogflow connector
 
 Provider: `api_ai_nlu`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/apttus.md
+++ b/docs/connectors/apttus.md
@@ -1,10 +1,10 @@
-# Apttus コネクタ
+# Apttus connector
 
 Provider: `apttus`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Object created | `object_created` | - |  |
 | Daily object review | `object_review` | - |  |
@@ -12,7 +12,7 @@ Provider: `apttus`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/apttus_intelligent_cloud.md
+++ b/docs/connectors/apttus_intelligent_cloud.md
@@ -1,17 +1,17 @@
-# Apttus Intelligent Cloud コネクタ
+# Apttus Intelligent Cloud connector
 
 Provider: `apttus_intelligent_cloud`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New object | `new_object` | - |  |
 | New or updated object | `new_or_updated_object` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Create object | `create_object` | - |  |
 | Search object | `search_object` | Yes |  |

--- a/docs/connectors/ariba.md
+++ b/docs/connectors/ariba.md
@@ -1,16 +1,16 @@
-# Ariba コネクタ
+# Ariba connector
 
 Provider: `ariba`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New invoice | `new_invoice` | - |  |
 | New purchase order | `new_purchase_order` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Create new invoice | `add_invoice` | - |  |

--- a/docs/connectors/asana.md
+++ b/docs/connectors/asana.md
@@ -1,10 +1,10 @@
-# Asana コネクタ
+# Asana connector
 
 Provider: `asana`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New  event | `new_event` | - |  |
 | New or updated task | `new_or_updated_task` | - |  [deprecated] |
@@ -12,7 +12,7 @@ Provider: `asana`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add task to section | `add_task_to_section` | - |  |

--- a/docs/connectors/ascent_erp.md
+++ b/docs/connectors/ascent_erp.md
@@ -1,10 +1,10 @@
-# AscentERP コネクタ
+# AscentERP connector
 
 Provider: `ascent_erp`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Object created | `object_created` | - |  |
 | Daily object review | `object_review` | - |  |
@@ -12,7 +12,7 @@ Provider: `ascent_erp`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/aws_cognito.md
+++ b/docs/connectors/aws_cognito.md
@@ -1,14 +1,14 @@
-# Amazon Cognito コネクタ
+# Amazon Cognito connector
 
 Provider: `aws_cognito`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Authenticate user | `admin_initiate_auth_admin_no_srp_auth` | - |  |
 | Refresh auth token | `admin_initiate_auth_refresh_token_auth` | - |  |

--- a/docs/connectors/aws_lambda.md
+++ b/docs/connectors/aws_lambda.md
@@ -1,16 +1,16 @@
-# AWS Lambda コネクタ
+# AWS Lambda connector
 
 Provider: `aws_lambda`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New function created | `new_function` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Get function details | `get_function_by_name` | - |  |

--- a/docs/connectors/aws_sns.md
+++ b/docs/connectors/aws_sns.md
@@ -1,15 +1,15 @@
-# Amazon SNS コネクタ
+# Amazon SNS connector
 
 Provider: `aws_sns`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New message from a topic | `new_message` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Publish message to topic | `publish_to_topic` | - |  |

--- a/docs/connectors/aws_sqs.md
+++ b/docs/connectors/aws_sqs.md
@@ -1,17 +1,17 @@
-# Amazon SQS コネクタ
+# Amazon SQS connector
 
 Provider: `aws_sqs`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New message | `new_message` | - |  |
 | New messages | `new_messages_batch` | Yes |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Delete message | `delete_message` | - |  |
 | Delete messages | `delete_messages_batch` | Yes |  |

--- a/docs/connectors/azure_blob_storage.md
+++ b/docs/connectors/azure_blob_storage.md
@@ -1,17 +1,17 @@
-# Azure Blob Storage コネクタ
+# Azure Blob Storage connector
 
 Provider: `azure_blob_storage`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New blob | `new_blob` | - |  |
 | New event | `new_event_webhook` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create container | `create_container` | - |  |

--- a/docs/connectors/azure_blob_storage_secondary.md
+++ b/docs/connectors/azure_blob_storage_secondary.md
@@ -1,17 +1,17 @@
-# Azure Blob Storage secondary コネクタ
+# Azure Blob Storage secondary connector
 
 Provider: `azure_blob_storage_secondary`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New blob | `new_blob` | - |  |
 | New event | `new_event_webhook` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create container | `create_container` | - |  |

--- a/docs/connectors/azure_key_vault.md
+++ b/docs/connectors/azure_key_vault.md
@@ -1,11 +1,11 @@
-# Azure Key Vault コネクタ
+# Azure Key Vault connector
 
 Provider: `azure_key_vault`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/azure_monitor.md
+++ b/docs/connectors/azure_monitor.md
@@ -1,14 +1,14 @@
-# Azure Monitor コネクタ
+# Azure Monitor connector
 
 Provider: `azure_monitor`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Send custom log | `send_custom_log` | - |  |
 | Inject custom logs | `send_log_injection` | - |  |

--- a/docs/connectors/azure_open_ai.md
+++ b/docs/connectors/azure_open_ai.md
@@ -1,14 +1,14 @@
-# Azure OpenAI コネクタ
+# Azure OpenAI connector
 
 Provider: `azure_open_ai`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Analyse text | `analyse_document` | - |  |

--- a/docs/connectors/bamboohr.md
+++ b/docs/connectors/bamboohr.md
@@ -1,10 +1,10 @@
-# BambooHR コネクタ
+# BambooHR connector
 
 Provider: `bamboohr`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New employee | `new_employee` | - |  |
 | New employee | `new_employee_webhook` | - |  |
@@ -14,7 +14,7 @@ Provider: `bamboohr`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create employee | `create_employee` | - |  |

--- a/docs/connectors/basecamp.md
+++ b/docs/connectors/basecamp.md
@@ -1,10 +1,10 @@
-# Basecamp 2 コネクタ
+# Basecamp 2 connector
 
 Provider: `basecamp`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Access granted to calendar | `calendar_access_granted` | - |  |
 | New calendar event | `new_calendar_event` | - |  |
@@ -18,7 +18,7 @@ Provider: `basecamp`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create calendar event | `create_calendar_event` | - |  |

--- a/docs/connectors/bigtincan.md
+++ b/docs/connectors/bigtincan.md
@@ -1,17 +1,17 @@
-# Bigtincan コネクタ
+# Bigtincan connector
 
 Provider: `bigtincan`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New form submission | `new_form_submission` | - |  |
 | New story | `new_story` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create story | `create_story` | - |  |

--- a/docs/connectors/bill.md
+++ b/docs/connectors/bill.md
@@ -1,10 +1,10 @@
-# BILL コネクタ
+# BILL connector
 
 Provider: `bill`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New invoice payment received | `new_invoice_payment` | - |  [deprecated] |
 | New record | `new_record` | - |  |
@@ -13,7 +13,7 @@ Provider: `bill`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add line to invoice | `add_line_item_invoice` | - |  |

--- a/docs/connectors/bim360.md
+++ b/docs/connectors/bim360.md
@@ -1,10 +1,10 @@
-# BIM 360 コネクタ
+# BIM 360 connector
 
 Provider: `bim360`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New or updated document in a project folder | `new_updated_document_in_project` | - |  |
 | New or updated document in a project folder and subfolders | `new_updated_document_in_project_subfolders` | - |  |
@@ -14,7 +14,7 @@ Provider: `bim360`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create issue in a project | `create_issue_in_project` | - |  [deprecated] |

--- a/docs/connectors/bitbucket.md
+++ b/docs/connectors/bitbucket.md
@@ -1,10 +1,10 @@
-# Bitbucket コネクタ
+# Bitbucket connector
 
 Provider: `bitbucket`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Closed issue | `closed_issue` | - |  |
 | New issue | `new_issue` | - |  |
@@ -12,7 +12,7 @@ Provider: `bitbucket`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create comment in an issue | `create_comment_in_an_issue` | - |  |

--- a/docs/connectors/box.md
+++ b/docs/connectors/box.md
@@ -1,10 +1,10 @@
-# Box コネクタ
+# Box connector
 
 Provider: `box`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New upload/download event (beta) | `event_notification` | - |  [deprecated] |
 | Monitor sign requests | `monitor_sign_request` | - |  [deprecated] |
@@ -19,7 +19,7 @@ Provider: `box`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add comment to file | `add_comment_to_file` | - |  |

--- a/docs/connectors/brick_ftp.md
+++ b/docs/connectors/brick_ftp.md
@@ -1,13 +1,13 @@
-# BrickFTP コネクタ
+# BrickFTP connector
 
 Provider: `brick_ftp`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New file | `new_file` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/bynder.md
+++ b/docs/connectors/bynder.md
@@ -1,17 +1,17 @@
-# Bynder コネクタ
+# Bynder connector
 
 Provider: `bynder`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New asset | `new_asset` | - |  |
 | New/updated asset | `new_or_updated_asset` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add assets to collection | `add_assets_to_collection` | - |  |

--- a/docs/connectors/byollm.md
+++ b/docs/connectors/byollm.md
@@ -1,11 +1,11 @@
-# Custom LLM For Workato Genie コネクタ
+# Custom LLM For Workato Genie connector
 
 Provider: `byollm`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/capsulecrm.md
+++ b/docs/connectors/capsulecrm.md
@@ -1,10 +1,10 @@
-# Capsule CRM コネクタ
+# Capsule CRM connector
 
 Provider: `capsulecrm`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New opportunity | `new_opportunity` | - |  |
 | New organization | `new_organisation` | - |  |
@@ -13,7 +13,7 @@ Provider: `capsulecrm`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Add opportunity | `add_opportunity` | - |  |
 | Add organization | `add_organisation` | - |  |

--- a/docs/connectors/celonis.md
+++ b/docs/connectors/celonis.md
@@ -1,13 +1,13 @@
-# Celonis コネクタ
+# Celonis connector
 
 Provider: `celonis`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New Event in Celonis | `new_event` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/chargify.md
+++ b/docs/connectors/chargify.md
@@ -1,10 +1,10 @@
-# Maxio コネクタ
+# Maxio connector
 
 Provider: `chargify`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New customer | `new_customer` | - |  |
 | New site event | `new_event` | - |  |
@@ -12,7 +12,7 @@ Provider: `chargify`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create charge | `create_charge` | - |  |

--- a/docs/connectors/cisco_spark.md
+++ b/docs/connectors/cisco_spark.md
@@ -1,17 +1,17 @@
-# Cisco Webex Teams コネクタ
+# Cisco Webex Teams connector
 
 Provider: `cisco_spark`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New button submission | `new_attachment` | - |  |
 | New message | `new_message` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add person to room | `add_person_to_room` | - |  |

--- a/docs/connectors/clearbit.md
+++ b/docs/connectors/clearbit.md
@@ -1,14 +1,14 @@
-# Clearbit コネクタ
+# Clearbit connector
 
 Provider: `clearbit`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Company lookup | `company_lookup` | Yes |  |
 | Email lookup | `email_lookup` | - |  |

--- a/docs/connectors/clock.md
+++ b/docs/connectors/clock.md
@@ -1,10 +1,10 @@
-# Scheduler by Workato コネクタ
+# Scheduler by Workato connector
 
 Provider: `clock`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New scheduled event (advanced) | `daily_task` | - |  [deprecated] |
 | New recurring event | `scheduled_event` | - |  |
@@ -12,7 +12,7 @@ Provider: `clock`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Get current time | `get_time` | - |  |
 | Wait | `pause` | - |  [deprecated] |

--- a/docs/connectors/cloud_watch.md
+++ b/docs/connectors/cloud_watch.md
@@ -1,16 +1,16 @@
-# Cloud Watch コネクタ
+# Cloud Watch connector
 
 Provider: `cloud_watch`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New or updated alarm | `new_or_updated_alarm` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Disable alarm | `disable_alarm` | - |  |
 | Enable alarm | `enable_alarm` | - |  |

--- a/docs/connectors/coda.md
+++ b/docs/connectors/coda.md
@@ -1,14 +1,14 @@
-# Coda コネクタ
+# Coda connector
 
 Provider: `coda`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Begin page content export | `create_export` | - |  |

--- a/docs/connectors/codeship.md
+++ b/docs/connectors/codeship.md
@@ -1,14 +1,14 @@
-# Codeship コネクタ
+# Codeship connector
 
 Provider: `codeship`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | List builds | `list_builds` | Yes |  |
 | Restart build | `restart_build` | - |  |

--- a/docs/connectors/concur.md
+++ b/docs/connectors/concur.md
@@ -1,10 +1,10 @@
-# SAP Concur コネクタ
+# SAP Concur connector
 
 Provider: `concur`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New expense report | `new_expense_report` | - |  [deprecated] |
 | New expense report submission | `new_expense_report_submission` | - |  [deprecated] |
@@ -18,7 +18,7 @@ Provider: `concur`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Upload receipt image | `add_receipt_image` | - |  [deprecated] |

--- a/docs/connectors/confluence.md
+++ b/docs/connectors/confluence.md
@@ -1,14 +1,14 @@
-# Confluence コネクタ
+# Confluence connector
 
 Provider: `confluence`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create page | `create_page` | - |  [deprecated] |

--- a/docs/connectors/confluence_secondary.md
+++ b/docs/connectors/confluence_secondary.md
@@ -1,14 +1,14 @@
-# Confluence secondary コネクタ
+# Confluence secondary connector
 
 Provider: `confluence_secondary`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create page | `create_page` | - |  [deprecated] |

--- a/docs/connectors/confluent_cloud.md
+++ b/docs/connectors/confluent_cloud.md
@@ -1,17 +1,17 @@
-# Confluent Cloud コネクタ
+# Confluent Cloud connector
 
 Provider: `confluent_cloud`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New message in topic | `new_message` | - |  |
 | New messages in topic | `new_message_batch` | Yes |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Publish message | `publish_to_topic` | - |  |
 | Publish messages | `publish_to_topic_batch` | Yes |  |

--- a/docs/connectors/connector_4me.md
+++ b/docs/connectors/connector_4me.md
@@ -1,16 +1,16 @@
-# 4me コネクタ
+# 4me connector
 
 Provider: `connector_4me`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Webhook event | `new_event` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `custom_operation` | - |  |
 | Mutate records | `mutation` | - |  |

--- a/docs/connectors/cornerstone_ondemand.md
+++ b/docs/connectors/cornerstone_ondemand.md
@@ -1,11 +1,11 @@
-# Cornerstone OnDemand コネクタ
+# Cornerstone OnDemand connector
 
 Provider: `cornerstone_ondemand`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/coupa.md
+++ b/docs/connectors/coupa.md
@@ -1,16 +1,16 @@
-# Coupa コネクタ
+# Coupa connector
 
 Provider: `coupa`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New or updated object | `new_or_updated_object` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Cancel purchase order | `cancel_purchase_order` | - |  |

--- a/docs/connectors/csv_parser.md
+++ b/docs/connectors/csv_parser.md
@@ -1,14 +1,14 @@
-# CSV tools by Workato コネクタ
+# CSV tools by Workato connector
 
 Provider: `csv_parser`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Compose CSV | `create_csv_lines` | Yes |  |
 | Parse CSV | `parse_csv` | Yes |  |

--- a/docs/connectors/cxml.md
+++ b/docs/connectors/cxml.md
@@ -1,15 +1,15 @@
-# cXML コネクタ
+# cXML connector
 
 Provider: `cxml`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New purchase order | `new_purchase_order` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Create new invoice | `new_invoice` | - |  |

--- a/docs/connectors/cyberark_conjur.md
+++ b/docs/connectors/cyberark_conjur.md
@@ -1,11 +1,11 @@
-# Cyberark Conjur コネクタ
+# Cyberark Conjur connector
 
 Provider: `cyberark_conjur`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/data_pipelines.md
+++ b/docs/connectors/data_pipelines.md
@@ -1,13 +1,13 @@
-# PipelineOps by Workato コネクタ
+# PipelineOps by Workato connector
 
 Provider: `data_pipelines`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Sync completed | `sync_completed` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/databricks.md
+++ b/docs/connectors/databricks.md
@@ -1,10 +1,10 @@
-# Databricks コネクタ
+# Databricks connector
 
 Provider: `databricks`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New rows | `new_rows_batch` | Yes |  |
 | New rows via custom SQL | `new_rows_sql_batch` | Yes |  |
@@ -12,7 +12,7 @@ Provider: `databricks`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Delete rows | `delete_rows` | Yes |  |
 | Export query result | `export_csv_v2` | - |  |

--- a/docs/connectors/db2.md
+++ b/docs/connectors/db2.md
@@ -1,14 +1,14 @@
-# IBM Db2 コネクタ
+# IBM Db2 connector
 
 Provider: `db2`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Delete rows | `delete_rows` | Yes |  |
 | Export query result | `export_csv_v2` | - |  |

--- a/docs/connectors/deputy.md
+++ b/docs/connectors/deputy.md
@@ -1,10 +1,10 @@
-# Deputy コネクタ
+# Deputy connector
 
 Provider: `deputy`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New employee | `new_employee` | - |  |
 | New leave | `new_leave` | - |  |
@@ -12,7 +12,7 @@ Provider: `deputy`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Associate employee | `associate` | - |  |

--- a/docs/connectors/docparser.md
+++ b/docs/connectors/docparser.md
@@ -1,16 +1,16 @@
-# docparser コネクタ
+# docparser connector
 
 Provider: `docparser`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Parsed data | `parsed_data` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Fetch document from URL | `fetch_document_from_url` | - |  |

--- a/docs/connectors/docusign.md
+++ b/docs/connectors/docusign.md
@@ -1,10 +1,10 @@
-# DocuSign コネクタ
+# DocuSign connector
 
 Provider: `docusign`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New document received | `new_document_received` | - |  |
 | New document event | `new_event` | - |  |
@@ -13,7 +13,7 @@ Provider: `docusign`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create/send document | `create_envelope` | - |  |

--- a/docs/connectors/docusign_secondary.md
+++ b/docs/connectors/docusign_secondary.md
@@ -1,10 +1,10 @@
-# DocuSign secondary コネクタ
+# DocuSign secondary connector
 
 Provider: `docusign_secondary`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New document received | `new_document_received` | - |  |
 | New document event | `new_event` | - |  |
@@ -13,7 +13,7 @@ Provider: `docusign_secondary`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create/send document | `create_envelope` | - |  |

--- a/docs/connectors/dropbox.md
+++ b/docs/connectors/dropbox.md
@@ -1,10 +1,10 @@
-# Dropbox コネクタ
+# Dropbox connector
 
 Provider: `dropbox`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New file revision | `file_revision` | - |  |
 | New lines in CSV file | `new_batch_csv_file_lines` | Yes |  |
@@ -15,7 +15,7 @@ Provider: `dropbox`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy file or folder | `copy_file` | - |  |

--- a/docs/connectors/edi_parser.md
+++ b/docs/connectors/edi_parser.md
@@ -1,14 +1,14 @@
-# EDI tools by Workato コネクタ
+# EDI tools by Workato connector
 
 Provider: `edi_parser`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Generate EDI | `generate_edi` | - |  [deprecated] |
 | Generate EDI message | `generate_edi_v2` | - |  |

--- a/docs/connectors/egnyte.md
+++ b/docs/connectors/egnyte.md
@@ -1,16 +1,16 @@
-# Egnyte コネクタ
+# Egnyte connector
 
 Provider: `egnyte`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New/updated/deleted events | `new_events` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy or move file | `copy_or_move_file` | - |  |

--- a/docs/connectors/ellucian_banner.md
+++ b/docs/connectors/ellucian_banner.md
@@ -1,11 +1,11 @@
-# Ellucian Banner コネクタ
+# Ellucian Banner connector
 
 Provider: `ellucian_banner`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/eloqua.md
+++ b/docs/connectors/eloqua.md
@@ -1,17 +1,17 @@
-# Eloqua コネクタ
+# Eloqua connector
 
 Provider: `eloqua`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New record | `new_objects` | - |  |
 | New or updated record | `new_or_updated_objects` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create record | `create_object` | - |  |

--- a/docs/connectors/email.md
+++ b/docs/connectors/email.md
@@ -1,13 +1,13 @@
-# Email by Workato コネクタ
+# Email by Workato connector
 
 Provider: `email`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Send email | `send_mail` | - |  |

--- a/docs/connectors/etapestry.md
+++ b/docs/connectors/etapestry.md
@@ -1,17 +1,17 @@
-# eTapestry コネクタ
+# eTapestry connector
 
 Provider: `etapestry`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Account created | `account_created` | - |  |
 | Account updated | `account_updated` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Add account | `add_account` | - |  |
 | Add contact | `add_contact` | - |  |

--- a/docs/connectors/event_brite.md
+++ b/docs/connectors/event_brite.md
@@ -1,10 +1,10 @@
-# Eventbrite コネクタ
+# Eventbrite connector
 
 Provider: `event_brite`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New contact created | `new_contact` | - |  |
 | New event created | `new_user_event` | - |  |
@@ -16,7 +16,7 @@ Provider: `event_brite`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create/update contact | `create_contact` | - |  |

--- a/docs/connectors/everydayhero.md
+++ b/docs/connectors/everydayhero.md
@@ -1,14 +1,14 @@
-# everydayhero コネクタ
+# everydayhero connector
 
 Provider: `everydayhero`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New page | `new_page` | - |  |
 | New team | `new_team` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/excel.md
+++ b/docs/connectors/excel.md
@@ -1,14 +1,14 @@
-# Excel コネクタ
+# Excel connector
 
 Provider: `excel`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add rows in batch | `add_rows_batch` | Yes |  |

--- a/docs/connectors/expensify.md
+++ b/docs/connectors/expensify.md
@@ -1,16 +1,16 @@
-# Expensify コネクタ
+# Expensify connector
 
 Provider: `expensify`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Expense report created | `expense_report_created` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create expense | `create_expense` | - |  |

--- a/docs/connectors/facebook.md
+++ b/docs/connectors/facebook.md
@@ -1,14 +1,14 @@
-# Facebook コネクタ
+# Facebook connector
 
 Provider: `facebook`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Get Adset Insights | `get_adset_insights` | Yes |  |

--- a/docs/connectors/facebook_lead_ads.md
+++ b/docs/connectors/facebook_lead_ads.md
@@ -1,15 +1,15 @@
-# Facebook Lead Ads コネクタ
+# Facebook Lead Ads connector
 
 Provider: `facebook_lead_ads`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New lead | `new_lead` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |

--- a/docs/connectors/fairsail.md
+++ b/docs/connectors/fairsail.md
@@ -1,10 +1,10 @@
-# Fairsail コネクタ
+# Fairsail connector
 
 Provider: `fairsail`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Object created | `object_created` | - |  |
 | Daily object review | `object_review` | - |  |
@@ -12,7 +12,7 @@ Provider: `fairsail`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/feedly.md
+++ b/docs/connectors/feedly.md
@@ -1,13 +1,13 @@
-# Feedly コネクタ
+# Feedly connector
 
 Provider: `feedly`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New item | `new_item` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/file_connector.md
+++ b/docs/connectors/file_connector.md
@@ -1,14 +1,14 @@
-# File tools by Workato コネクタ
+# File tools by Workato connector
 
 Provider: `file_connector`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Compress files | `compress_file` | - |  |
 | Get file from URL | `read_file` | - |  |

--- a/docs/connectors/financialforce.md
+++ b/docs/connectors/financialforce.md
@@ -1,10 +1,10 @@
-# FinancialForce コネクタ
+# FinancialForce connector
 
 Provider: `financialforce`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Object created | `object_created` | - |  |
 | Daily object review | `object_review` | - |  |
@@ -12,7 +12,7 @@ Provider: `financialforce`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/forcecom.md
+++ b/docs/connectors/forcecom.md
@@ -1,10 +1,10 @@
-# Force.com コネクタ
+# Force.com connector
 
 Provider: `forcecom`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Object created | `object_created` | - |  |
 | Daily object review | `object_review` | - |  |
@@ -12,7 +12,7 @@ Provider: `forcecom`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create object | `create_object` | - |  |

--- a/docs/connectors/fresh_books.md
+++ b/docs/connectors/fresh_books.md
@@ -1,10 +1,10 @@
-# FreshBooks コネクタ
+# FreshBooks connector
 
 Provider: `fresh_books`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New/updated client | `new_or_updated_client` | - |  |
 | New/updated estimate | `new_or_updated_estimate` | - |  |
@@ -13,7 +13,7 @@ Provider: `fresh_books`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Add line item to invoice | `add_line_item_to_invoice` | - |  |
 | Create client | `create_client` | - |  |

--- a/docs/connectors/fresh_desk.md
+++ b/docs/connectors/fresh_desk.md
@@ -1,10 +1,10 @@
-# Freshdesk コネクタ
+# Freshdesk connector
 
 Provider: `fresh_desk`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Closed ticket | `closed_ticket` | - |  |
 | Company created | `company_created` | - |  |
@@ -15,7 +15,7 @@ Provider: `fresh_desk`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add note to ticket | `add_note_to_ticket` | - |  |

--- a/docs/connectors/ftps.md
+++ b/docs/connectors/ftps.md
@@ -1,17 +1,17 @@
-# FTP/FTPS コネクタ
+# FTP/FTPS connector
 
 Provider: `ftps`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New CSV file | `new_csv_file` | Yes |  |
 | New/updated file in directory | `new_file_in_dir` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Download file | `get_file_content` | - |  |
 | List files and directories | `list_directories_files` | Yes |  |

--- a/docs/connectors/ftps_secondary.md
+++ b/docs/connectors/ftps_secondary.md
@@ -1,17 +1,17 @@
-# FTP/FTPS secondary コネクタ
+# FTP/FTPS secondary connector
 
 Provider: `ftps_secondary`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New CSV file | `new_csv_file` | Yes |  |
 | New/updated file in directory | `new_file_in_dir` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Download file | `get_file_content` | - |  |
 | List files and directories | `list_directories_files` | Yes |  |

--- a/docs/connectors/fullcontact.md
+++ b/docs/connectors/fullcontact.md
@@ -1,14 +1,14 @@
-# FullContact コネクタ
+# FullContact connector
 
 Provider: `fullcontact`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Get contact details | `get_contact_info` | - |  |
 | Verify email | `verify_email` | - |  |

--- a/docs/connectors/funraise.md
+++ b/docs/connectors/funraise.md
@@ -1,13 +1,13 @@
-# Funraise コネクタ
+# Funraise connector
 
 Provider: `funraise`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New transaction | `new_event` | - |  |
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -1,10 +1,10 @@
-# GitHub コネクタ
+# GitHub connector
 
 Provider: `github`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Closed issue | `new_closed_issue` | - |  |
 | New issue | `new_issue` | - |  |
@@ -16,7 +16,7 @@ Provider: `github`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create comment in an issue | `create_comment_in_an_issue` | - |  |

--- a/docs/connectors/gmail.md
+++ b/docs/connectors/gmail.md
@@ -1,74 +1,74 @@
-# Gmail コネクタ
+# Gmail connector
 
 Provider: `gmail`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New email | `new_email` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Download attachment | `download_attachment` | - |  |
 | Send email | `send_mail` | - |  |
 
-## フィールド詳細
+## Field details
 
 ### new_email (Trigger)
 
-レシピ: Upload Gmail attachments to Google Drive
+Recipe: Upload Gmail attachments to Google Drive
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| label_ids | string | Yes | Gmail ラベル（例: INBOX） |
+| label_ids | string | Yes | Gmail label (e.g. INBOX) |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| id | string | メール ID |
-| subject | string | メール件名 |
-| attachments | array | 添付ファイル一覧 |
-| attachments[].filename | string | 添付ファイル名 |
-| attachments[].attachmentId | string | 添付ファイル ID |
+| id | string | Email ID |
+| subject | string | Email subject |
+| attachments | array | List of attachments |
+| attachments[].filename | string | Attachment filename |
+| attachments[].attachmentId | string | Attachment ID |
 
-#### Job Report カラム
-| カラム | ラベル | マッピング |
+#### Job Report columns
+| Column | Label | Mapping |
 |---|---|---|
 | custom_column_3 | Email subject | `data.gmail.new_email.subject` |
-| custom_column_1 | Number of files | `data.gmail.new_email.attachments` (リストサイズ) |
-| custom_column_2 | File names | `data.gmail.new_email.attachments` の `filename` を結合 |
+| custom_column_1 | Number of files | `data.gmail.new_email.attachments` (list size) |
+| custom_column_2 | File names | Concatenated `filename` values from `data.gmail.new_email.attachments` |
 
 ---
 
 ### download_attachment (Action)
 
-レシピ: Upload Gmail attachments to Google Drive
+Recipe: Upload Gmail attachments to Google Drive
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| id | string | Yes | メール ID（datapill: new_email.id） |
-| attachmentId | string | Yes | 添付ファイル ID（datapill: foreach.attachmentId） |
+| id | string | Yes | Email ID (datapill: new_email.id) |
+| attachmentId | string | Yes | Attachment ID (datapill: foreach.attachmentId) |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| content_bytes | string | 添付ファイルのバイナリコンテンツ |
+| content_bytes | string | Binary content of the attachment |
 
 ---
 
 ### send_mail (Action)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | To | string | Yes | Yes | Provide the recipient email address(es) separated by comma. |
 | Subject | string | Yes | Yes | — |
@@ -78,41 +78,41 @@ Provider: `gmail`
 | Bcc | string | - | No | — |
 | Cc | string | - | No | — |
 | Reply to | string | - | No | — |
-| Attachments[].File binary content | string | - | No | リスト型のグループフィールド |
-| Attachments[].File name | string | - | No | リスト型のグループフィールド |
+| Attachments[].File binary content | string | - | No | List-type group field |
+| Attachments[].File name | string | - | No | List-type group field |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| id | string | 送信メールの ID |
-| thread_id | string | スレッド ID |
-| label_ids | string | 適用ラベル（例: `UNREAD`） |
+| id | string | ID of the sent email |
+| thread_id | string | Thread ID |
+| label_ids | string | Applied labels (e.g. `UNREAD`) |
 
-## Custom Action パターン
+## Custom Action pattern
 
-Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gmail API を直接呼び出せる。
-- パス例: `me/messages/{messageId}?format=full`
+For Gmail, the `gmail` provider lets you call the Gmail API directly via `__adhoc_http_action`.
+- Example path: `me/messages/{messageId}?format=full`
 - base URI: `https://gmail.googleapis.com/gmail/v1/users/`
 
-## 備考
-- OAuth 2.0 認証
-- provider 名: `gmail`
-- スコープ: メールの読み取り、作成、送信
+## Notes
+- OAuth 2.0 authentication
+- provider name: `gmail`
+- Scopes: read, compose, and send email
 
 ---
 
 ## MCP Skills (Gmail MCP Server)
 
-プロジェクト `MCP | Gmail` で定義された Genie スキル群。各スキルは `workato_genie` / `start_workflow` トリガーで実装。
+Genie skills defined in the project `MCP | Gmail`. Each skill is implemented with the `workato_genie` / `start_workflow` trigger.
 
 ---
 
 ### search_messages
 
-メッセージを検索する。構造化パラメータ優先、`raw_query` は Gmail 検索構文を直接使う場合のみ。
+Search messages. Prefer structured parameters; use `raw_query` only when you need native Gmail search syntax directly.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | keywords | string | - | Free-text keywords to search for across subject and message content. |
 | from | string | - | Filter messages sent by this email address. |
@@ -128,7 +128,7 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | includeSpamTrash | boolean | - | Include threads from SPAM and TRASH in the results. Default false. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | messages[].bcc | string | Bcc |
@@ -146,10 +146,10 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### search_threads
 
-スレッドを検索する。パラメータは search_messages と同一。
+Search threads. Parameters are identical to search_messages.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | keywords | string | - | Free-text keywords to search for across subject and message content. |
 | from | string | - | Filter messages sent by this email address. |
@@ -165,7 +165,7 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | includeSpamTrash | boolean | - | Include threads from SPAM and TRASH in the results. Default false. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | threads[].bcc | string | Bcc |
@@ -183,15 +183,15 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### get_message
 
-メッセージ ID を指定して単一メッセージの全内容を取得する。
+Fetch the full content of a single message by message ID.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | messageId | string | Yes | ID of the message to retrieve. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Message ID |
@@ -219,15 +219,15 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### get_thread
 
-スレッド ID を指定してスレッド全体を取得する。
+Fetch an entire thread by thread ID.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | threadId | string | Yes | ID of the thread to retrieve. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Thread ID |
@@ -244,15 +244,15 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### get_draft
 
-下書き ID を指定して下書きの詳細を取得する。
+Fetch draft details by draft ID.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | draftId | string | Yes | ID of the draft to fetch |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Draft ID |
@@ -276,17 +276,17 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### list_drafts
 
-下書き一覧を取得する。
+List drafts.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| query | string | - | Gmail search box と同じクエリ形式でフィルタ |
+| query | string | - | Filter using the same query format as the Gmail search box |
 | pageToken | string | - | Page token to retrieve a specific page of results in the list. |
 | maxResults | integer | - | Maximum number of drafts to return. Default 30, max 50. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | drafts[].id | string | Draft ID |
@@ -296,7 +296,7 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | drafts[].message.historyId | number | History ID |
 | drafts[].message.internalDate | number | Internal date |
 | drafts[].message.sizeEstimate | number | Size estimate |
-| drafts[].message.payload | object | Payload (body, headers, parts -- 再帰構造) |
+| drafts[].message.payload | object | Payload (body, headers, parts — recursive structure) |
 | nextPageToken | string | Next page token |
 | has_more | boolean | Has more |
 
@@ -304,14 +304,14 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### list_labels
 
-認証ユーザーが利用可能なシステム/ユーザー定義ラベル一覧を取得する。
+List system and user-defined labels available to the authenticated user.
 
 #### Parameters
 
-パラメータなし。
+No parameters.
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | labels[].type | string | Label type (system / user) |
@@ -322,15 +322,15 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### list_attachments
 
-メッセージ ID を指定して添付ファイル一覧を取得する。
+List attachments by message ID.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | messageId | string | Yes | ID of the message to retrieve. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Message ID |
@@ -341,23 +341,23 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### create_draft
 
-新規下書きを作成する。返信の場合は threadId / inReplyTo / references が必須。
+Create a new draft. For replies, threadId / inReplyTo / references are required.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| to | array of string | - | 宛先。新規 or reply-to 時に指定。スレッド返信では省略可。 |
-| cc | array of string | - | CC recipients。ユーザーが明示した場合のみ。 |
-| bcc | array of string | - | BCC recipients。ユーザーが明示した場合のみ。 |
-| subject | string | - | 件名。返信時は元メールと同一必須。 |
-| body | string | Yes | メール本文。署名・免責・引用は明示指示がない限り不要。 |
-| bodyFormat | string | - | plain_text (default) or html。 |
-| threadId | string | - | 返信時のみ設定。スレッドとの関連付け。 |
-| inReplyTo | string | - | 返信時必須。元メッセージの Message-ID ヘッダ値。 |
-| references | string | - | 返信時必須。元の References ヘッダ + Message-ID。 |
+| to | array of string | - | Recipients. Specify when creating a new email or a reply-to. Can be omitted for thread replies. |
+| cc | array of string | - | CC recipients. Only when explicitly specified by the user. |
+| bcc | array of string | - | BCC recipients. Only when explicitly specified by the user. |
+| subject | string | - | Subject. Must match the original email when replying. |
+| body | string | Yes | Email body. Signature, disclaimers, and quoted content are not added unless explicitly requested. |
+| bodyFormat | string | - | plain_text (default) or html. |
+| threadId | string | - | Set only when replying. Associates the draft with the thread. |
+| inReplyTo | string | - | Required when replying. The Message-ID header value of the original message. |
+| references | string | - | Required when replying. The original References header plus Message-ID. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Draft ID |
@@ -367,27 +367,27 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | message.historyId | number | History ID |
 | message.internalDate | number | Internal date |
 | message.sizeEstimate | number | Size estimate |
-| message.payload | object | Payload (body, headers, parts -- 再帰構造) |
+| message.payload | object | Payload (body, headers, parts — recursive structure) |
 
 ---
 
 ### update_draft
 
-既存の下書きを編集する。添付の追加/削除は別スキルを使用。
+Edit an existing draft. Use a separate skill to add or remove attachments.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | draftId | string | Yes | Draft ID |
-| to | array of string | - | 宛先 |
+| to | array of string | - | Recipients |
 | cc | array of string | - | CC recipients |
 | bcc | array of string | - | BCC recipients |
-| subject | string | - | 件名 |
-| body | string | - | メール本文 |
+| subject | string | - | Subject |
+| body | string | - | Email body |
 | bodyFormat | string | - | plain_text (default) or html |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Draft ID |
@@ -397,21 +397,21 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 | message.historyId | number | History ID |
 | message.internalDate | number | Internal date |
 | message.sizeEstimate | number | Size estimate |
-| message.payload | object | Payload (body, headers, parts -- 再帰構造) |
+| message.payload | object | Payload (body, headers, parts — recursive structure) |
 
 ---
 
 ### send_draft
 
-下書きを送信する。事前に作成/参照済みの下書きが必要。
+Send a draft. Requires an existing draft that has been created or referenced beforehand.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | draftId | string | Yes | ID of the draft to send |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Message ID |
@@ -432,17 +432,17 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### add_labels
 
-メッセージまたはスレッドにラベルを追加する。事前に list_labels でラベル ID を確認すること。
+Add labels to messages or threads. Look up label IDs with list_labels beforehand.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| messages | array of string | - | Gmail message ID のリスト。最大 10 件。messages か threads のどちらか必須。 |
-| threads | array of string | - | Gmail thread ID のリスト。最大 10 件。 |
-| labels | array of string | Yes | 適用するラベル ID のリスト (例: INBOX, UNREAD, STARRED)。表示名ではなく ID を使用。 |
+| messages | array of string | - | List of Gmail message IDs. Max 10 entries. Either messages or threads is required. |
+| threads | array of string | - | List of Gmail thread IDs. Max 10 entries. |
+| labels | array of string | Yes | List of label IDs to apply (e.g. INBOX, UNREAD, STARRED). Use the ID, not the display name. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | threads[].labelIds | array of string | Label IDs |
@@ -456,17 +456,17 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### remove_labels
 
-メッセージまたはスレッドからラベルを削除する。事前に list_labels でラベル ID を確認すること。
+Remove labels from messages or threads. Look up label IDs with list_labels beforehand.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| messages | array of string | - | Gmail message ID のリスト。最大 10 件。messages か threads のどちらか必須。 |
-| threads | array of string | - | Gmail thread ID のリスト。最大 10 件。 |
-| labels | array of string | Yes | 削除するラベル ID のリスト。表示名ではなく ID を使用。 |
+| messages | array of string | - | List of Gmail message IDs. Max 10 entries. Either messages or threads is required. |
+| threads | array of string | - | List of Gmail thread IDs. Max 10 entries. |
+| labels | array of string | Yes | List of label IDs to remove. Use the ID, not the display name. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | threads[].labelIds | array of string | Label IDs |
@@ -480,66 +480,66 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### add_attachments
 
-既存の下書きに添付ファイルを追加する。Gmail 既存添付 or Google Drive ファイルをソースにできる。
+Add attachments to an existing draft. The source can be an existing Gmail attachment or a Google Drive file.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | draftId | string | Yes | Draft ID |
-| attachments | array of object | Yes | 添付ファイル配列。最低 1 件必須。 |
+| attachments | array of object | Yes | Array of attachments. At least 1 entry is required. |
 | attachments[].source | string | Yes | "gmail" or "gdrive" |
-| attachments[].filename | string | Yes | ファイル名 (拡張子込み、例: report.csv) |
-| attachments[].mimeType | string | Yes | MIME type。Google ネイティブファイルはエクスポート形式を指定。 |
-| attachments[].fileId | string | - | source が "gdrive" の場合必須。Google Drive file ID。 |
-| attachments[].attachmentId | string | - | source が "gmail" の場合必須。Gmail attachment ID。 |
-| attachments[].messageId | string | - | source が "gmail" の場合必須。添付元の message ID。 |
+| attachments[].filename | string | Yes | Filename (with extension, e.g. report.csv) |
+| attachments[].mimeType | string | Yes | MIME type. For Google-native files, specify the export format. |
+| attachments[].fileId | string | - | Required when source is "gdrive". Google Drive file ID. |
+| attachments[].attachmentId | string | - | Required when source is "gmail". Gmail attachment ID. |
+| attachments[].messageId | string | - | Required when source is "gmail". Message ID of the source attachment. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Draft ID |
 | message.id | string | Message ID |
 | message.threadId | string | Thread ID |
 | message.snippet | string | Snippet |
-| message.payload | object | Payload (body, headers, parts -- 再帰構造) |
+| message.payload | object | Payload (body, headers, parts — recursive structure) |
 
 ---
 
 ### remove_attachments
 
-既存の下書きから添付ファイルを削除する。
+Remove attachments from an existing draft.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
 | draftId | string | Yes | Draft ID |
-| fileNames | array of string | Yes | 削除する添付ファイル名のリスト。下書きに存在するファイル名を指定。 |
+| fileNames | array of string | Yes | List of attachment filenames to remove. Specify filenames that exist on the draft. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | id | string | Draft ID |
 | message.id | string | Message ID |
 | message.threadId | string | Thread ID |
 | message.snippet | string | Snippet |
-| message.payload | object | Payload (body, headers, parts -- 再帰構造) |
+| message.payload | object | Payload (body, headers, parts — recursive structure) |
 
 ---
 
 ### star_messages
 
-メッセージにスターを付ける。
+Star messages.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| starMessages | array of object | - | スター対象メッセージの配列。最大 10 件。 |
+| starMessages | array of object | - | Array of messages to star. Max 10 entries. |
 | starMessages[].messageId | string | Yes | Id of the message to be starred |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | starMarkedMessages[].labelIds | string | Label IDs |
@@ -550,16 +550,16 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### unstar_messages
 
-メッセージのスターを外す。
+Remove stars from messages.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| unStarMessages | array of object | - | スター解除対象メッセージの配列。最大 10 件。 |
+| unStarMessages | array of object | - | Array of messages to unstar. Max 10 entries. |
 | unStarMessages[].messageId | string | Yes | Id of the message to be unstarred |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | unStarMarkedMessages[].labelIds | string | Label IDs |
@@ -570,16 +570,16 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### archive_threads
 
-スレッドをアーカイブする (INBOX ラベルを除去)。
+Archive threads (removes the INBOX label).
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| archiveThreads | array of object | Yes | アーカイブ対象スレッドの配列。最大 10 件。 |
+| archiveThreads | array of object | Yes | Array of threads to archive. Max 10 entries. |
 | archiveThreads[].threadId | string | Yes | Id of the thread to be archived |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | archivedThreads[].labelIds | string | Label IDs |
@@ -590,16 +590,16 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### unarchive_threads
 
-アーカイブ済みスレッドを受信トレイに戻す。
+Move archived threads back to the inbox.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| unArchiveThreads | array of object | Yes | アーカイブ解除対象スレッドの配列。最大 10 件。 |
+| unArchiveThreads | array of object | Yes | Array of threads to unarchive. Max 10 entries. |
 | unArchiveThreads[].threadId | string | Yes | Id of the thread to be unarchived |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | unArchivedThreads[].labelIds | string | Label IDs |
@@ -610,18 +610,18 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ### mark_message_read_state
 
-メッセージを既読/未読に変更する。
+Mark messages as read or unread.
 
 #### Parameters
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| readMessageIds | array of object | - | 既読にするメッセージの配列。最大 10 件。 |
+| readMessageIds | array of object | - | Array of messages to mark as read. Max 10 entries. |
 | readMessageIds[].messageId | string | Yes | ID of the Gmail message to be marked as read. |
-| unreadMessageIds | array of object | - | 未読にするメッセージの配列。最大 10 件。 |
+| unreadMessageIds | array of object | - | Array of messages to mark as unread. Max 10 entries. |
 | unreadMessageIds[].messageId | string | Yes | ID of the Gmail message to be marked as unread. |
 
 #### Result
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | error | string | Error message (transient error) |
 | markedMessagesRead[].labelIds | string | Label IDs |
@@ -633,16 +633,16 @@ Gmail は `gmail` プロバイダーで `__adhoc_http_action` を使用して Gm
 
 ---
 
-## 学習サマリ
+## Learning summary
 
-最終実行: 2026-04-27 by /auto-learn
-- 試行: 1 op
-- 完全成功: 1
-- 部分学習: 0
-- 学習失敗: 0
-- スキップ:
+Last run: 2026-04-27 by `/auto-learn`
+- Attempted: 1 op
+- Fully learned: 1
+- Partially learned: 0
+- Failed: 0
+- Skipped:
   - Deprecated: 0
   - adhoc: 1 — `__adhoc_http_action`
-  - 既学習: 2 — `new_email`, `download_attachment`
+  - Already learned: 2 — `new_email`, `download_attachment`
 
-要 follow-up なし。
+No follow-up needed.

--- a/docs/connectors/gong.md
+++ b/docs/connectors/gong.md
@@ -1,16 +1,16 @@
-# Gong.io コネクタ
+# Gong.io connector
 
 Provider: `gong`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New call | `new_call` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add call | `add_call` | - |  |

--- a/docs/connectors/google_big_query.md
+++ b/docs/connectors/google_big_query.md
@@ -1,10 +1,10 @@
-# Google BigQuery コネクタ
+# Google BigQuery connector
 
 Provider: `google_big_query`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New job completed | `new_job_completed` | - |  |
 | New row | `new_row` | - |  |
@@ -13,7 +13,7 @@ Provider: `google_big_query`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Get batch of rows by Job ID | `get_query_job_output` | Yes |  |
@@ -30,15 +30,15 @@ Provider: `google_big_query`
 | Select rows using custom SQL | `search_rows_using_custom_sql_sync` | Yes |  |
 | Select rows using custom SQL and insert into table | `search_rows_using_custom_sql_sync_insert_table` | Yes |  |
 
-## フィールド詳細
+## Field details
 
 ### new_job_completed (New job completed)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up trigger events from this specified date and time. Defaults to fetching records created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
@@ -49,7 +49,7 @@ Provider: `google_big_query`
 | Job type | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | ID | text | — |
 | Kind | text | — |
@@ -78,17 +78,17 @@ Provider: `google_big_query`
 | Errors | array | — |
 | User email | text | — |
 
-> ⚠ `Load` / `Extract` / `Query` / `State` は Statistics と Configuration の各 object 配下に重複登場する。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+> ⚠ `Load` / `Extract` / `Query` / `State` appear duplicated under both the `Statistics` and `Configuration` objects. Note that they look flat because the data tree's paddingLeft is uniformly 0.
 
 ### new_row (New row)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -100,17 +100,17 @@ Provider: `google_big_query`
 | Output columns | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマのため Project/Dataset/Table を選択しないと output が表示されない）
+(Unlearned: dynamic schema — output is not displayed unless Project/Dataset/Table are selected)
 
 ### new_rows_batch (New rows)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -123,17 +123,17 @@ Provider: `google_big_query`
 | Output columns | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマのため Project/Dataset/Table を選択しないと output が表示されない）
+(Unlearned: dynamic schema — output is not displayed unless Project/Dataset/Table are selected)
 
 ### scheduled_query (Scheduled query)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. It will support only select query. |
@@ -145,17 +145,17 @@ Provider: `google_big_query`
 | Use legacy SQL | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマのため Query の結果カラムが output になる。`Automatic schema introspection=Yes` か `Output fields` 手動定義時のみ確定）
+(Unlearned: dynamic schema — the Query result columns become the output. Only resolved when `Automatic schema introspection=Yes` or `Output fields` is defined manually)
 
 ### get_query_job_output (Get batch of rows by Job ID)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Job ID | text | Yes | Yes | ID of the job. This can be found from the 'Job completed in BigQuery Trigger'. |
@@ -166,15 +166,15 @@ Provider: `google_big_query`
 | Location | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマ。`Output fields` の手動定義に依存して結果カラムが生成される）
+(Unlearned: dynamic schema — result columns are generated based on the manual definition in `Output fields`)
 
 ### insert_row (Insert row)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -182,10 +182,10 @@ Provider: `google_big_query`
 | Ignore schema mismatch | text | - | No | — |
 | Skip invalid rows | text | - | No | — |
 
-> ⚠ 動的入力: Project/Dataset/Table 選択後に対象テーブルのカラムが入力フィールドとして展開される（UI 観察時は static のみキャプチャ）
+> ⚠ Dynamic input: after Project/Dataset/Table are selected, the target table's columns expand as input fields (UI observation captures only the static fields).
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Errors | array | — |
 | Reason | text | — |
@@ -197,13 +197,13 @@ Provider: `google_big_query`
 
 ### insert_rows_stream (Insert rows)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -211,20 +211,20 @@ Provider: `google_big_query`
 | Ignore schema mismatch | text | - | No | — |
 | Skip invalid rows | text | - | No | — |
 
-> ⚠ 動的入力: Project/Dataset/Table 選択後に対象テーブルのカラムが入力配列内 schema として展開される
+> ⚠ Dynamic input: after Project/Dataset/Table are selected, the target table's columns expand as the schema inside the input array.
 
 #### Output fields
-（未学習: 動的スキーマ。Batch アクションのため、insert_row と同様 `Errors[]` ベースの output が想定される）
+(Unlearned: dynamic schema. As a batch action, an `Errors[]`-based output similar to insert_row is expected.)
 
 ### load_data_from_file (Load data into BigQuery)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing（ファイルロードは fire-and-forget 寄りのアクションで output が空になる場合あり）
+> ⚠ Partial learning: output_group_missing (file loads are fire-and-forget-ish actions and the output can be empty).
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -246,17 +246,17 @@ Provider: `google_big_query`
 | Description | text | - | No | — |
 
 #### Output fields
-（未学習: ロードジョブ系アクションは output schema を持たない可能性が高い）
+(Unlearned: load-job actions likely do not have an output schema.)
 
 ### load_data_from_google_table (Load data from Google Cloud Storage into BigQuery)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing（ロードジョブ系のため output schema が空の可能性）
+> ⚠ Partial learning: output_group_missing (load-job action; output schema may be empty).
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -277,17 +277,17 @@ Provider: `google_big_query`
 | Description | text | - | No | — |
 
 #### Output fields
-（未学習: ロードジョブ系のため output schema が空の可能性）
+(Unlearned: load-job action; output schema may be empty.)
 
 ### run_custom_sql_sync (Run custom SQL in BigQuery)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing
+> ⚠ Partial learning: output_group_missing
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project ID of the project that contains the destination table. |
 | Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. |
@@ -295,17 +295,17 @@ Provider: `google_big_query`
 | Location | text | - | No | — |
 
 #### Output fields
-（未学習: 同期実行 SQL の output 構造は UI 観察時に group が出現せず。実行時に取得すべき）
+(Unlearned: the output structure of the synchronous SQL run did not surface a group during UI observation. Capture it at runtime.)
 
 ### search_rows_sync (Select rows)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -320,17 +320,17 @@ Provider: `google_big_query`
 | Offset | integer | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマ。Project/Dataset/Table 選択時に Rows[] 配下にテーブルのカラムが展開される）
+(Unlearned: dynamic schema. When Project/Dataset/Table are selected, the table's columns expand under Rows[].)
 
 ### search_rows (Select rows (Old))
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)。Legacy バージョン（新規実装は `search_rows_sync` を推奨）
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected). Legacy version (prefer `search_rows_sync` for new implementations).
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Dataset |  | Yes | Yes | The dataset which contains the table to load the data to. |
@@ -343,15 +343,15 @@ Provider: `google_big_query`
 | Offset | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマ）
+(Unlearned: dynamic schema.)
 
 ### search_rows_using_custom_sql_sync (Select rows using custom SQL)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project which contains the table. |
 | Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Use bind variables, e.g. id = @id, and the parameter field below to parameters inputs. |
@@ -361,7 +361,7 @@ Provider: `google_big_query`
 | Location | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Output contains rows? | boolean | — |
 | Rows | array | — |
@@ -381,17 +381,17 @@ Provider: `google_big_query`
 | Job complete | boolean | — |
 | Cache hit | boolean | — |
 
-> ⚠ `Rows[]` 配下の各カラムは `Output fields` で定義した内容に応じて動的展開される（UI 観察時は static のみ）
+> ⚠ Each column under `Rows[]` expands dynamically based on the contents defined in `Output fields` (UI observation captures only the static fields).
 
 ### search_rows_using_custom_sql (Select rows using custom SQL (Old))
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: output_group_missing, dynamic schema unresolved (project not selected)。Legacy バージョン（新規実装は `search_rows_using_custom_sql_sync` を推奨）
+> ⚠ Partial learning: output_group_missing, dynamic schema unresolved (project not selected). Legacy version (prefer `search_rows_using_custom_sql_sync` for new implementations).
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project to be billed for the query. |
 | Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Toggle the 'use legacy SQL' field if you want to use legacy SQL in the input above. |
@@ -405,15 +405,15 @@ Provider: `google_big_query`
 | Offset | text | - | No | — |
 
 #### Output fields
-（未学習: 動的スキーマ）
+(Unlearned: dynamic schema.)
 
 ### search_rows_using_custom_sql_sync_insert_table (Select rows using custom SQL and insert into table)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Project |  | Yes | Yes | The project which contains the table. |
 | Query | string (code editor) | Yes | Yes | Provide a valid SQL string to be executed. Use bind variables, e.g. id = @id, and the parameter field below to parameters inputs. |
@@ -425,7 +425,7 @@ Provider: `google_big_query`
 | Write disposition | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Rows | array | — |
 | List size | integer | — |
@@ -444,47 +444,47 @@ Provider: `google_big_query`
 | Job complete | boolean | — |
 | Cache hit | boolean | — |
 
-> ⚠ `Rows[]` 配下のカラム構造は `Output fields` で定義した内容に応じて動的展開される
+> ⚠ The column structure under `Rows[]` expands dynamically based on the contents defined in `Output fields`.
 
-## 備考
+## Notes
 
-- BigQuery のオペレーションは多くが「Project → Dataset → Table」picklist の選択で動的に input/output schema が生成される。`/auto-learn` の自動収集では project picklist を選ばないため、テーブル列に対応する動的フィールドは未取得（`> ⚠ 動的入力` 注記）。詳細列スキーマは `/learn-recipe` で個別レシピから補完する。
-- 共通入力フィールド: `Project`、`Dataset`、`Table` は ほぼ全アクションで必須。`Location` は地域指定（オプション）。
-- Legacy ops（`Select rows (Old)` / `Select rows using custom SQL (Old)`）は picker に表示されるが、新規実装では同期版（`search_rows_sync` / `search_rows_using_custom_sql_sync`）を推奨。
-- Skip 済み: `__adhoc_http_action`（カスタム HTTP）、`insert_rows`（deprecated → `insert_rows_stream`）、`run_custom_sql`（deprecated → `run_custom_sql_sync`）。
+- Most BigQuery operations generate input/output schemas dynamically based on the "Project → Dataset → Table" picklist selection. The automated `/auto-learn` collection does not select a project picklist, so the dynamic fields corresponding to table columns are not fetched (see the `> ⚠ Dynamic input` notes). Fill in the detailed column schema from individual recipes using `/learn-recipe`.
+- Common input fields: `Project`, `Dataset`, and `Table` are required in nearly all actions. `Location` is an optional region specifier.
+- Legacy ops (`Select rows (Old)` / `Select rows using custom SQL (Old)`) are shown in the picker, but for new implementations prefer the synchronous versions (`search_rows_sync` / `search_rows_using_custom_sql_sync`).
+- Already skipped: `__adhoc_http_action` (custom HTTP), `insert_rows` (deprecated → `insert_rows_stream`), `run_custom_sql` (deprecated → `run_custom_sql_sync`).
 
-## 学習失敗ログ
+## Learning failures
 
-（なし — 全 op が `status=ok` で完了。一部は dynamic schema 由来の partial learning）
+(None — all ops completed with `status=ok`. Some are partial learning due to dynamic schema.)
 
 ---
 
-## 学習サマリ
+## Learning summary
 
-最終実行: 2026-04-27 by /auto-learn
-- 試行: 15 op
-- 完全成功: 4
-- 部分学習: 11
-- 学習失敗: 0
-- スキップ:
-  - Deprecated: 2 — `insert_rows`（→ `insert_rows_stream`）, `run_custom_sql`（→ `run_custom_sql_sync`）
+Last run: 2026-04-27 by `/auto-learn`
+- Attempted: 15 op
+- Fully learned: 4
+- Partially learned: 11
+- Failed: 0
+- Skipped:
+  - Deprecated: 2 — `insert_rows` (→ `insert_rows_stream`), `run_custom_sql` (→ `run_custom_sql_sync`)
   - adhoc: 1 — `__adhoc_http_action`
-  - 既学習: 0
+  - Already learned: 0
 
-### 要 follow-up
+### Needs follow-up
 
-- **Dynamic schema (要 /learn-recipe)** — Project/Dataset/Table picklist 未選択により output schema が UI 観察では取れない
-  - `new_row` / `new_rows_batch` / `scheduled_query` — 行系トリガー
-  - `get_query_job_output` — Job ID から行を取得
-  - `insert_row` / `insert_rows_stream` — Insert 系（output schema 動的）
-  - `run_custom_sql_sync` — 同期 SQL 実行（output 出現せず要再調査）
-  - `search_rows` / `search_rows_sync` — 検索 (Legacy + 現行)
-  - `search_rows_using_custom_sql` / `search_rows_using_custom_sql_sync` — SQL 検索 (Legacy + 現行)
-- **Fire-and-forget 寄り (要再確認)**
-  - `load_data_from_file` / `load_data_from_google_table` — ファイル/GCS ロードジョブ
+- **Dynamic schema (needs `/learn-recipe`)** — Because the Project/Dataset/Table picklist is not selected, the output schema cannot be captured via UI observation
+  - `new_row` / `new_rows_batch` / `scheduled_query` — Row-based triggers
+  - `get_query_job_output` — Fetch rows by Job ID
+  - `insert_row` / `insert_rows_stream` — Insert ops (dynamic output schema)
+  - `run_custom_sql_sync` — Synchronous SQL execution (output did not appear; needs re-investigation)
+  - `search_rows` / `search_rows_sync` — Search (Legacy + current)
+  - `search_rows_using_custom_sql` / `search_rows_using_custom_sql_sync` — SQL search (Legacy + current)
+- **Fire-and-forget-ish (needs re-confirmation)**
+  - `load_data_from_file` / `load_data_from_google_table` — File/GCS load jobs
 
-### 構造的注記（参考）
+### Structural notes (for reference)
 
-- `new_job_completed` の output で `Load` / `Extract` / `Query` / `State` が `Statistics` と `Configuration` の object 配下に重複登場（`paddingLeft: 0` 起因）
-- `Insert rows` ピッカーは新 UI では `insert_rows_stream` のみ表示（`insert_rows` は picker から非表示）
-- `Run custom SQL in BigQuery` ピッカーは `run_custom_sql_sync` のみ表示
+- In the output of `new_job_completed`, `Load` / `Extract` / `Query` / `State` appear duplicated under both the `Statistics` and `Configuration` objects (caused by `paddingLeft: 0`)
+- In the new UI, the `Insert rows` picker shows only `insert_rows_stream` (`insert_rows` is hidden from the picker)
+- The `Run custom SQL in BigQuery` picker shows only `run_custom_sql_sync`

--- a/docs/connectors/google_calendar.md
+++ b/docs/connectors/google_calendar.md
@@ -1,10 +1,10 @@
-# Google Calendar コネクタ
+# Google Calendar connector
 
 Provider: `google_calendar`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Event end | `event_end` | - |  |
 | Event start | `event_start` | - |  |
@@ -13,7 +13,7 @@ Provider: `google_calendar`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add attendees to an event | `add_attendee_to_an_event` | Yes |  |
@@ -30,21 +30,21 @@ Provider: `google_calendar`
 | Update event | `update_event` | - |  |
 | Update task | `update_task` | - |  |
 
-## フィールド詳細
+## Field details
 
 ### event_end (Event end)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select a calendar to monitor for event end. |
 | Search term | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Calendar ID | text | — |
 | Kind | text | — |
@@ -125,11 +125,11 @@ Provider: `google_calendar`
 
 ### event_start (Event start)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select a calendar to monitor for event start. |
 | Time before unit |  | Yes | Yes | Select a time unit for Time before event start. |
@@ -137,7 +137,7 @@ Provider: `google_calendar`
 | Search term | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Calendar ID | text | — |
 | Kind | text | — |
@@ -218,17 +218,17 @@ Provider: `google_calendar`
 
 ### new_event (New event)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select a calendar to monitor for events |
 | Include deleted events? | text | - | Yes | When set to true, job will be triggered for deleted events also. Defaults to false |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Calendar ID | text | — |
 | Kind | text | — |
@@ -289,17 +289,17 @@ Provider: `google_calendar`
 
 ### updated_event (New/updated event)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select a calendar to monitor for events |
 | Include deleted events? | text | - | Yes | When set to true, job will be triggered for deleted events also. Defaults to false |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Calendar ID | text | — |
 | Kind | text | — |
@@ -360,11 +360,11 @@ Provider: `google_calendar`
 
 ### add_attendee_to_an_event (Add attendees to an event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select calendar that event belongs to |
 | Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
@@ -375,7 +375,7 @@ Provider: `google_calendar`
 | Response status | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -432,11 +432,11 @@ Provider: `google_calendar`
 
 ### create_allday_event (Create all day event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select the calendar to create event in |
 | Start date | date | Yes | Yes | Enter event start date |
@@ -455,7 +455,7 @@ Provider: `google_calendar`
 | Show me as | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -507,18 +507,18 @@ Provider: `google_calendar`
 
 ### create_calendar (Create calendar)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar name | text | Yes | Yes | — |
 | Description | text | - | No | — |
 | Time zone | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -533,11 +533,11 @@ Provider: `google_calendar`
 
 ### create_event (Create event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select the calendar to create event in |
 | Start date time | date-time | Yes | Yes | Event start date and time |
@@ -556,7 +556,7 @@ Provider: `google_calendar`
 | Show me as | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -608,11 +608,11 @@ Provider: `google_calendar`
 
 ### create_task (Create task)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Tasklist |  | Yes | Yes | — |
 | Task name | text | Yes | Yes | — |
@@ -623,7 +623,7 @@ Provider: `google_calendar`
 | Hidden | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | ID | text | — |
 | Etag | text | — |
@@ -647,11 +647,11 @@ Provider: `google_calendar`
 
 ### delete_attendees_from_an_event (Delete attendees from an event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select calendar that event belongs to |
 | Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
@@ -659,7 +659,7 @@ Provider: `google_calendar`
 | Send notifications? | text | - | Yes | If true, will notify all attendees about changed event |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -719,13 +719,13 @@ Provider: `google_calendar`
 
 ### delete_event (Delete event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: 出力スキーマなし (fire-and-forget action)
+> ⚠ Partial learning: no output schema (fire-and-forget action)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar |  | Yes | Yes | Select calendar that event belongs to |
 | Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
@@ -733,16 +733,16 @@ Provider: `google_calendar`
 
 ### get_calendar_by_id (Get calendar by ID)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar ID | text | Yes | Yes | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -757,17 +757,17 @@ Provider: `google_calendar`
 
 ### get_event_by_id (Get event by ID)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar ID | text | Yes | Yes | ID of calendar that event belongs to. Click calendar settings in the drop down menu next to the specific calendar. Get calendar ID from calendar address field. |
 | Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -827,18 +827,18 @@ Provider: `google_calendar`
 
 ### list_calendars_public (List calendars)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Minimum access role | text | - | No | — |
 | Show deleted | text | - | No | — |
 | Show hidden | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Items | array | — |
 | Kind | text | — |
@@ -861,11 +861,11 @@ Provider: `google_calendar`
 
 ### search_events (Search events)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Calendar ID | text | Yes | Yes | The calendar to search for events in. Click calendar settings in the drop down menu next to the specific calendar. Get calendar ID from calendar address field. |
 | Search terms | text | - | Yes | Input terms in the event name or description. Partial matches are returned. |
@@ -874,7 +874,7 @@ Provider: `google_calendar`
 | Date to | date-time | - | Yes | Fetch events ending on or before this datetime |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Events | array | — |
 | Kind | text | — |
@@ -910,11 +910,11 @@ Provider: `google_calendar`
 
 ### update_event (Update event)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Event ID | text | Yes | Yes | Obtain event ID from the Search events action. You can also obtain the event ID from your event URL. |
 | Start date time | date-time | - | Yes | Event start date and time |
@@ -933,7 +933,7 @@ Provider: `google_calendar`
 | Visibility | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Etag | text | — |
@@ -993,11 +993,11 @@ Provider: `google_calendar`
 
 ### update_task (Update task)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Tasklist |  | Yes | Yes | — |
 | Task ID | text | Yes | Yes | — |
@@ -1008,7 +1008,7 @@ Provider: `google_calendar`
 | Hidden | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | ID | text | — |
 | Etag | text | — |
@@ -1032,25 +1032,25 @@ Provider: `google_calendar`
 
 ---
 
-## 学習サマリ
+## Learning summary
 
-最終実行: 2026-04-27 by /auto-learn
-- 試行: 17 op
-- 完全成功: 16
-- 部分学習: 1
-- 学習失敗: 0
-- スキップ:
+Last run: 2026-04-27 by `/auto-learn`
+- Attempted: 17 op
+- Fully learned: 16
+- Partially learned: 1
+- Failed: 0
+- Skipped:
   - Deprecated: 0
   - adhoc: 1 — `__adhoc_http_action`
-  - 既学習: 0
+  - Already learned: 0
 
-### 要 follow-up
+### Needs follow-up
 
-- **Fire-and-forget (UI 仕様・追加学習不要)**
-  - `delete_event` — 削除アクション。output_group_not_found
+- **Fire-and-forget (UI spec, no additional learning required)**
+  - `delete_event` — delete action. output_group_not_found
 
-### 構造的注記（参考）
+### Structural notes (for reference)
 
-- 重複ラベル `Email`: `Creator` / `Organizer` / `Attendees[]` 配下で出現。データツリー paddingLeft=0 でフラット表示
-- `event_start` / `event_end` トリガー: `Conference data` / `Focus time properties` / `Out of office properties` / `Working location properties` を含む 76 フィールドが output に出る（`new_event` / `updated_event` の 56 フィールドより多い）
-- 内部 JSON キーと UI label のマッピングは UI 観察では取れない（`/learn-recipe` で補完）
+- Duplicate label `Email`: appears under `Creator` / `Organizer` / `Attendees[]`. The data tree renders flat with paddingLeft=0.
+- `event_start` / `event_end` triggers: 76 fields appear in the output, including `Conference data` / `Focus time properties` / `Out of office properties` / `Working location properties` (more than the 56 fields of `new_event` / `updated_event`).
+- The mapping between internal JSON keys and UI labels cannot be obtained via UI observation (supplement via `/learn-recipe`).

--- a/docs/connectors/google_cloud_storage.md
+++ b/docs/connectors/google_cloud_storage.md
@@ -1,14 +1,14 @@
-# Google Cloud Storage コネクタ
+# Google Cloud Storage connector
 
 Provider: `google_cloud_storage`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create bucket | `create_bucket` | - |  |

--- a/docs/connectors/google_contacts.md
+++ b/docs/connectors/google_contacts.md
@@ -1,17 +1,17 @@
-# Google Contacts コネクタ
+# Google Contacts connector
 
 Provider: `google_contacts`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New contact added | `new_contact` | - |  [deprecated] |
 | Updated contact | `updated_contact` | - |  [deprecated] |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Create contact | `create_contact` | - |  [deprecated] |
 | Search contacts | `search_contact` | - |  [deprecated] |

--- a/docs/connectors/google_docs.md
+++ b/docs/connectors/google_docs.md
@@ -1,14 +1,14 @@
-# Google Docs コネクタ
+# Google Docs connector
 
 Provider: `google_docs`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Create document | `create_document` | - |  |

--- a/docs/connectors/google_drive.md
+++ b/docs/connectors/google_drive.md
@@ -1,10 +1,10 @@
-# Google Drive コネクタ
+# Google Drive connector
 
 Provider: `google_drive`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New activity | `new_activity` | - |  |
 | New CSV file | `new_csv_file_batch` | Yes |  |
@@ -13,7 +13,7 @@ Provider: `google_drive`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add permission to a file | `add_permission` | - |  |
@@ -31,15 +31,15 @@ Provider: `google_drive`
 | Upload small file | `upload_file` | - |  [deprecated] |
 | Upload file | `upload_file_stream` | - |  |
 
-## フィールド詳細
+## Field details
 
 ### new_activity (New activity)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Parent folder |  | Yes | Yes | The parent folder which needs to be monitored for activities. Note that the subfolders are monitored too. Either the drive or drive.readonly scope is necessary to populate the picklist. |
 | Start time | date-time | - | Yes | When you start recipe for the first time, it picks up activity from this specified date and time. Defaults to fetching activity an hour ago if left blank. |
@@ -47,7 +47,7 @@ Provider: `google_drive`
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | ID | text | — |
 | Title | text | — |
@@ -78,15 +78,15 @@ Provider: `google_drive`
 | Type | text | — |
 | Timestamp | date-time | — |
 
-> ⚠ `List size` / `List index` は `Actions` と `Actors` の各配列配下に重複登場する。データツリーの paddingLeft が一律 0 のためフラットに見える点に注意。
+> ⚠ `List size` / `List index` appear duplicated under both the `Actions` and `Actors` arrays. Note that they look flat because the data tree uses a uniform paddingLeft of 0.
 
 ### new_csv_file_batch (New CSV file)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up files created from specified time. Defaults to fetching files created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
 | Parent folder |  | Yes | Yes | Select the parent folder. The uploaded file will be saved under My Drive if not specified. |
@@ -98,7 +98,7 @@ Provider: `google_drive`
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Event | object | — |
 | ID | text | — |
@@ -137,18 +137,18 @@ Provider: `google_drive`
 
 ### new_file_in_subfolder (New file or folder in folder hierarchy)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Folder |  | Yes | Yes | Select the folder to monitor for new files or folders. All subfolders will be monitored as well. |
 | Trigger poll interval | integer | - | No | — |
 | Chunk size (KB) | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Is folder | boolean | — |
 | Is google file | boolean | — |
@@ -161,7 +161,7 @@ Provider: `google_drive`
 | Starred | boolean | — |
 | Trashed | boolean | — |
 | Explicitly trashed | boolean | — |
-| Parents | array | Parents 配列の子要素は ID (text) |
+| Parents | array | Child element of the Parents array is ID (text) |
 | Version | integer | — |
 | Web content link | text | — |
 | Web view link | text | — |
@@ -172,9 +172,9 @@ Provider: `google_drive`
 | Created time | date-time | — |
 | Modified time | date-time | — |
 | Modified by me time | date-time | — |
-| Sharing user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
-| Owners | array | 各要素は Display name / Email address / Permission ID / Photo link / Me / List size / List index |
-| Last modifying user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Sharing user | object | Includes Display name / Email address / Permission ID / Photo link / Me |
+| Owners | array | Each element has Display name / Email address / Permission ID / Photo link / Me / List size / List index |
+| Last modifying user | object | Includes Display name / Email address / Permission ID / Photo link / Me |
 | Shared | boolean | — |
 | Owned by me | boolean | — |
 | Viewers can copy content | boolean | — |
@@ -187,22 +187,22 @@ Provider: `google_drive`
 | Quota bytes used | number | — |
 | Head revision ID | text | — |
 
-> ⚠ データツリー観察ではネスト構造がフラットに表示されるため、Sharing user / Owners / Last modifying user の子要素 (Display name, Email address, Permission ID, Photo link, Me) が同じ階層に重複出現する。実際のスキーマ上は object/array の配下に位置する。
+> ⚠ Because the data tree observation renders the nested structure as flat, the child elements of Sharing user / Owners / Last modifying user (Display name, Email address, Permission ID, Photo link, Me) appear duplicated at the same hierarchy level. In the actual schema they live under the object/array.
 
 ### new_file_or_folder (New file or folder)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Folder |  | Yes | Yes | Select the folder to monitor for new files or folders. Sub-folders will not be monitored. |
 | When first started, this recipe should pick up events from | date-time | - | Yes | When you start recipe for the first time, it picks up new files or folders created from this specified date and time. Defaults to fetching files or folders created an hour ago if left blank. Once recipe has been run or tested, value cannot be changed. |
 | Chunk size (KB) | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Is folder | number | — |
 | Is google file | number | — |
@@ -215,7 +215,7 @@ Provider: `google_drive`
 | Starred | number | — |
 | Trashed | number | — |
 | Explicitly trashed | number | — |
-| Parents | array | 各要素は ID (text) |
+| Parents | array | Each element is ID (text) |
 | Version | integer | — |
 | Web content link | text | — |
 | Web view link | text | — |
@@ -226,9 +226,9 @@ Provider: `google_drive`
 | Created time | date-time | — |
 | Modified time | date-time | — |
 | Modified by me time | date-time | — |
-| Sharing user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
-| Owners | array | 各要素は Display name / Email address / Permission ID / Photo link / Me |
-| Last modifying user | object | Display name / Email address / Permission ID / Photo link / Me を含む |
+| Sharing user | object | Includes Display name / Email address / Permission ID / Photo link / Me |
+| Owners | array | Each element has Display name / Email address / Permission ID / Photo link / Me |
+| Last modifying user | object | Includes Display name / Email address / Permission ID / Photo link / Me |
 | Shared | number | — |
 | Owned by me | number | — |
 | Viewers can copy content | number | — |
@@ -243,11 +243,11 @@ Provider: `google_drive`
 
 ### add_permission (Add permission to a file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
 | Role |  | Yes | Yes | The role granted by this permission. |
@@ -262,7 +262,7 @@ Provider: `google_drive`
 | Use domain admin access? | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Type | text | — |
@@ -274,44 +274,44 @@ Provider: `google_drive`
 | Allow file discovery | number | — |
 | Display name | text | — |
 | Photo link | text | — |
-| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
-| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Team drive permission details | array | Array element: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | Array element: Permission type / Role / Inherited from / Inherited / List size / List index |
 | Deleted | number | — |
 
 ### copy_file (Copy file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
 | File name | text | - | Yes | Define new file name for the copied file. |
 | Destination folder | text | - | Yes | Select the folder to place the copied file in. By default the file will be copied within the same folder. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Name | text | — |
 | File ID | text | — |
 | Mime type | text | — |
-| Parents | array | 各要素は ID (text) |
+| Parents | array | Each element is ID (text) |
 
 ### create_folder (Create folder)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Parent folder |  | Yes | Yes | Select parent folder to create new folder in. |
 | Name |  | Yes | Yes | Name of new folder. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | ID | text | — |
 | Name | text | — |
@@ -319,68 +319,68 @@ Provider: `google_drive`
 
 ### delete_file (Delete file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Success | text | — |
 
 ### download_file_contents (Download file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
 | Chunk size (KB) | text | - | No | — |
 | Encoding of the file content | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | File contents | text | — |
 | Size | integer | — |
 
 ### export_file (Export file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
 | MIME type |  | Yes | Yes | Eg: text/csv. Supported MIME types can be found in Google Drive API docs. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | File content | text | — |
 | Size | text | — |
 
 ### get_permission (Get permission of a file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
 | Permission |  | Yes | Yes | Permission ID can be obtained from list permissions action. |
 | Use domain admin access? | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Type | text | — |
@@ -392,17 +392,17 @@ Provider: `google_drive`
 | Allow file discovery | number | — |
 | Display name | text | — |
 | Photo link | text | — |
-| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
-| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Team drive permission details | array | Array element: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | Array element: Permission type / Role / Inherited from / Inherited / List size / List index |
 | Deleted | number | — |
 
 ### list_permission (List permissions of a file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
 | Maximum results | integer | - | Yes | Enter a value for maximum results to be returned per page. Default maximum is 100. |
@@ -410,57 +410,57 @@ Provider: `google_drive`
 | Use domain admin access? | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Next page token | text | — |
-| Permissions | array | 配列要素: Kind / Type / Permission ID / Email address / Domain / Role / View / Allow file discovery / Display name / Photo link / Team drive permission details / Permission details / Deleted / List size / List index |
+| Permissions | array | Array element: Kind / Type / Permission ID / Email address / Domain / Role / View / Allow file discovery / Display name / Photo link / Team drive permission details / Permission details / Deleted / List size / List index |
 
 ### move_rename_file (Rename or move file/folder)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File or folder ID |  | Yes | Yes | For folder ID, click on the required folder and folder ID can be found at the end of URL. For file ID, right click on the file and select Get shareable link. |
 | Name | text | - | Yes | New name of the file or folder. |
 | Parent folder | text | - | Yes | Select the parent folder. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Name | text | — |
 | File ID | text | — |
 | Mime type | text | — |
-| Parents | array | 各要素は ID (text) |
+| Parents | array | Each element is ID (text) |
 
 ### remove_permission (Remove permissions from a file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of the shareable link. |
 | Permission |  | Yes | Yes | Permission ID can be obtained using the List permissions action. In the select permission option, permissions are listed in the role - type - email address format. |
 | Enforce expansive access | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Success | text | — |
 
 ### search_file_or_folder (Search files or folders)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Files or folders |  | Yes | Yes | Select whether to search for files or for folders. |
 | Query | text | - | Yes | Query for filtering the search results. Use this field to specify an exact query based on which the files need to be fetched. |
@@ -477,19 +477,19 @@ Provider: `google_drive`
 | Shared with me? | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Next page token | text | — |
 | Incomplete search | number | — |
-| Files | array | 配列要素: ID / Name / Mime type / Description / Starred / Trashed / Explicitly trashed / Parents / Version / Web content link / Web view link / Icon link / Thumbnail link / Viewed by me / Viewed by me time / Created time / Modified time / Modified by me time / Sharing user / Owners / Last modifying user / Shared / Owned by me / Viewers can copy content / Writers can share / Original filename / Full file extension / File extension / Md 5 checksum / Size / Quota bytes used / Head revision ID / List size / List index |
+| Files | array | Array element: ID / Name / Mime type / Description / Starred / Trashed / Explicitly trashed / Parents / Version / Web content link / Web view link / Icon link / Thumbnail link / Viewed by me / Viewed by me time / Created time / Modified time / Modified by me time / Sharing user / Owners / Last modifying user / Shared / Owned by me / Viewers can copy content / Writers can share / Original filename / Full file extension / File extension / Md 5 checksum / Size / Quota bytes used / Head revision ID / List size / List index |
 
 ### update_permission (Update permission of a file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File |  | Yes | Yes | File ID can be found in the output of other triggers/actions of Google Drive connector, or at the end of a file's shareable link. |
 | Permission |  | Yes | Yes | Permission ID can be obtained using the List permissions action. |
@@ -500,7 +500,7 @@ Provider: `google_drive`
 | Enforce expansive access | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | Type | text | — |
@@ -512,17 +512,17 @@ Provider: `google_drive`
 | Allow file discovery | number | — |
 | Display name | text | — |
 | Photo link | text | — |
-| Team drive permission details | array | 配列要素: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
-| Permission details | array | 配列要素: Permission type / Role / Inherited from / Inherited / List size / List index |
+| Team drive permission details | array | Array element: Team drive permission type / Role / Inherited from / Inherited / List size / List index |
+| Permission details | array | Array element: Permission type / Role / Inherited from / Inherited / List size / List index |
 | Deleted | number | — |
 
 ### upload_file_stream (Upload file)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-26
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-26
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | File contents |  | Yes | Yes | Contents of the file to upload. |
 | File name | text | - | Yes | Name of the uploaded file. If not specified, the uploaded file will be named as Untitled. |
@@ -538,54 +538,54 @@ Provider: `google_drive`
 | Copy requires writer permission | text | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Kind | text | — |
 | ID | text | — |
 | Name | text | — |
 | Mime type | text | — |
-| Parents | array | 各要素は ID (text) |
+| Parents | array | Each element is ID (text) |
 | Description | text | — |
 | Starred | boolean | — |
 | Viewers can copy content | boolean | — |
 | Writers can share | boolean | — |
-| Properties | array | 各要素は Key (text) / Value (text) |
+| Properties | array | Each element has Key (text) / Value (text) |
 | Web view link | text | — |
 
 ### upload_file (Action)
 
-レシピ: Upload Gmail attachments to Google Drive
+Recipe: Upload Gmail attachments to Google Drive
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| fileContent | string | Yes | アップロードするファイルのコンテンツ（バイナリ） |
-| name | string | Yes | アップロード先のファイル名 |
+| fileContent | string | Yes | Contents of the file to upload (binary) |
+| name | string | Yes | File name at the upload destination |
 
-## 備考
-- OAuth 2.0 またはサービスアカウント認証
-- Google Drive API v3 使用
-- provider 名: `google_drive`
+## Notes
+- OAuth 2.0 or service account authentication
+- Uses Google Drive API v3
+- provider name: `google_drive`
 
 ---
 
-## 学習サマリ
+## Learning summary
 
-最終実行: 2026-04-27 by /auto-learn
-- 試行: 17 op
-- 完全成功: 17
-- 部分学習: 0
-- 学習失敗: 0
-- スキップ:
-  - Deprecated: 1 — `upload_file`（→ `upload_file_stream` 推奨）
+Last run: 2026-04-27 by `/auto-learn`
+- Attempted: 17 op
+- Fully learned: 17
+- Partially learned: 0
+- Failed: 0
+- Skipped:
+  - Deprecated: 1 — `upload_file` (use `upload_file_stream` instead)
   - adhoc: 1 — `__adhoc_http_action`
-  - 既学習: 0
+  - Already learned: 0
 
-### 構造的注記（参考）
+### Structural notes (for reference)
 
-- 重複ラベル `List size` / `List index`: `Actions` と `Actors` の各配列配下に同名で出現（`new_activity` 等）。データツリー `paddingLeft: 0` でフラット表示
-- Sharing user / Owners / Last modifying user の object/array 配下が `Display name` / `Email address` / `Permission ID` / `Photo link` / `Me` でフラット重複表示（`new_file_or_folder` 等）
-- 型表示の揺れ: `new_csv_file_batch` は `Starred` / `Trashed` を `boolean` 表示、`new_file_or_folder` は同フィールドを `number` 表示。Workato UI 側の不整合
-- 大文字小文字の揺れ: `MIME type` (`new_csv_file_batch`) vs `Mime type` (他)。UI そのまま捕捉
+- Duplicate label `List size` / `List index`: appears under both the `Actions` and `Actors` arrays with the same name (e.g. `new_activity`). The data tree renders flat with `paddingLeft: 0`.
+- The object/array contents under Sharing user / Owners / Last modifying user appear as a flat duplicate display of `Display name` / `Email address` / `Permission ID` / `Photo link` / `Me` (e.g. `new_file_or_folder`).
+- Type display inconsistency: `new_csv_file_batch` shows `Starred` / `Trashed` as `boolean`, while `new_file_or_folder` shows the same fields as `number`. This is an inconsistency on the Workato UI side.
+- Case inconsistency: `MIME type` (`new_csv_file_batch`) vs `Mime type` (others). Captured as the UI presents it.
 
-要 follow-up なし（全 op で input/output 取得済み）。構造的注記は `/learn-recipe` または手動補完の対象。
+No follow-up needed (input/output captured for every op). Structural notes are to be supplemented via `/learn-recipe` or manually.

--- a/docs/connectors/google_people.md
+++ b/docs/connectors/google_people.md
@@ -1,17 +1,17 @@
-# Google People コネクタ
+# Google People connector
 
 Provider: `google_people`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New contact | `new_contact` | - |  |
 | New or updated contact | `updated_contact` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Copy other contacts to my contacts | `copy_other_contacts` | - |  |

--- a/docs/connectors/google_secret_manager.md
+++ b/docs/connectors/google_secret_manager.md
@@ -1,11 +1,11 @@
-# Google Secret Manager コネクタ
+# Google Secret Manager connector
 
 Provider: `google_secret_manager`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-なし
+None

--- a/docs/connectors/google_sheets.md
+++ b/docs/connectors/google_sheets.md
@@ -1,10 +1,10 @@
-# Google Sheets コネクタ
+# Google Sheets connector
 
 Provider: `google_sheets`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New row in sheet in My Drive | `new_polling_spreadsheet_row_v4` | - |  |
 | New spreadsheet row added | `new_spreadsheet_row` | - |  [deprecated] |
@@ -18,7 +18,7 @@ Provider: `google_sheets`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add rows in bulk | `add_row_v4_bulk` | Yes |  |
@@ -33,42 +33,42 @@ Provider: `google_sheets`
 | Update a row | `update_spreadsheet_row` | - |  [deprecated] |
 | Update row using row ID (Deprecated) | `update_spreadsheet_row_v3_new` | - |  |
 
-## フィールド詳細
+## Field details
 
 ### search_spreadsheet_rows_v4_new (Search rows)
 
-種別: Action
-学習元: 既存ナレッジ（手動）
+Kind: Action
+Learned from: existing knowledge (manual)
 
 #### Input fields
-| フィールド | 型 | 必須 | 説明 |
+| Field | Type | Required | Description |
 |---|---|---|---|
-| spreadsheet_id | string | Yes | スプレッドシート ID（URL の /d/ と /edit の間） |
-| sheet | string | Yes | シート名 |
+| spreadsheet_id | string | Yes | Spreadsheet ID (between /d/ and /edit in the URL) |
+| sheet | string | Yes | Sheet name |
 | team_drives | string | - | `my_drive` or Team Drive ID |
-| count | integer | - | 取得件数（デフォルト: 200） |
+| count | integer | - | Number of entries to fetch (default: 200) |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| rows[] | array of object | 検索結果の行一覧 |
-| rows[].col_<カラム名> | string | スプレッドシートのヘッダー名が `col_` プレフィックス付きでフィールド名になる |
+| rows[] | array of object | List of rows in the search result |
+| rows[].col_<column_name> | string | The spreadsheet header name becomes the field name prefixed with `col_` |
 
 ### new_polling_spreadsheet_row_v4 (New row in sheet in My Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+> ⚠ Partial learning: dynamic schema unresolved (spreadsheet/sheet not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -78,18 +78,18 @@ Provider: `google_sheets`
 
 ### new_spreadsheet_row_v4 (New row in sheet in My Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Real-time variant; dynamic schema unresolved (spreadsheet/sheet not selected)
+> ⚠ Partial learning: Real-time variant; dynamic schema unresolved (spreadsheet/sheet not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -99,20 +99,20 @@ Provider: `google_sheets`
 
 ### team_drive_new_spreadsheet_row_v4 (New row in sheet in Team Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+> ⚠ Partial learning: dynamic schema unresolved (spreadsheet/sheet not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a team drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new row. |
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -122,19 +122,19 @@ Provider: `google_sheets`
 
 ### updated_polling_spreadsheet_row_v4_2 (New/updated row in sheet in My Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Polling variant; dynamic schema unresolved (spreadsheet/sheet not selected)
+> ⚠ Partial learning: Polling variant; dynamic schema unresolved (spreadsheet/sheet not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -145,18 +145,18 @@ Provider: `google_sheets`
 
 ### updated_spreadsheet_row_v4_2 (New/updated row in sheet in My Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Real-time variant; dynamic schema unresolved
+> ⚠ Partial learning: Real-time variant; dynamic schema unresolved
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -167,20 +167,20 @@ Provider: `google_sheets`
 
 ### team_drive_updated_spreadsheet_row_v4_2 (New/updated row in sheet in Team Drive)
 
-種別: Trigger
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Trigger
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: dynamic schema unresolved (spreadsheet/sheet not selected)
+> ⚠ Partial learning: dynamic schema unresolved (spreadsheet/sheet not selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a team drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to monitor for new/updated row. |
 | Trigger poll interval | integer | - | No | — |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -191,20 +191,20 @@ Provider: `google_sheets`
 
 ### add_spreadsheet_row_v4 (Add row)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: dynamic Rows column schema unresolved (no spreadsheet selected)
+> ⚠ Partial learning: dynamic Rows column schema unresolved (no spreadsheet selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to add row to. |
 | Enforce top-left insert | text | - | Yes | Choose this option to insert into the leftmost logical table when there are more than one table in same sheet. Default is set to no. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -216,20 +216,20 @@ Provider: `google_sheets`
 
 ### add_row_v4_bulk (Add rows in bulk)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
+> ⚠ Partial learning: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to add row to. |
 | Enforce top-left insert | text | - | Yes | Choose this option to insert into the leftmost logical table when there are more than one table in same sheet. Default is set to no. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Sheet name | text | — |
@@ -237,23 +237,23 @@ Provider: `google_sheets`
 | Number of rows added | integer | — |
 | Number of rows failed | integer | — |
 | CSV contents of failed rows | text | — |
-| List of batches | array | 配列要素: Batch number / All rows successfully added? / Starting row / Ending row / Number of rows added / Number of rows failed / Error code / Error text / List size / List index |
+| List of batches | array | Array elements: Batch number / All rows successfully added? / Starting row / Ending row / Number of rows added / Number of rows failed / Error code / Error text / List size / List index |
 
 ### update_row_v4_new (Update row)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Dynamic input row columns and search criteria unresolved (no spreadsheet selected)
+> ⚠ Partial learning: Dynamic input row columns and search criteria unresolved (no spreadsheet selected)
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to update row. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Spreadsheet name | text | — |
@@ -263,19 +263,19 @@ Provider: `google_sheets`
 
 ### update_row_v4_bulk (Update rows in bulk)
 
-種別: Action
-学習元: /auto-learn (UI 観察) — 2026-04-27
+Kind: Action
+Learned from: `/auto-learn` (UI observation) — 2026-04-27
 
-> ⚠ 部分学習: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
+> ⚠ Partial learning: Batch action; List of batches contains repeated child fields (per row). Dynamic Rows column schema unresolved.
 
 #### Input fields
-| フィールド | 型 | 必須 | デフォルト表示 | 説明 |
+| Field | Type | Required | Visible by default | Description |
 |---|---|---|---|---|
 | Google Drive | text | - | Yes | Select a personal drive or a team drive. Defaults to your personal drive. |
 | Spreadsheet |  | Yes | Yes | Select a spreadsheet to update row. |
 
 #### Output fields
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
 | Spreadsheet ID | text | — |
 | Sheet name | text | — |
@@ -283,37 +283,37 @@ Provider: `google_sheets`
 | Number of rows updated | integer | — |
 | Number of rows failed | integer | — |
 | CSV contents of failed rows | text | — |
-| List of batches | array | 配列要素: Batch number / All rows successfully updated? / Starting row / Ending row / Number of rows updated / Number of rows failed / Error code / Error text / List size / List index |
+| List of batches | array | Array elements: Batch number / All rows successfully updated? / Starting row / Ending row / Number of rows updated / Number of rows failed / Error code / Error text / List size / List index |
 
-## 学習失敗ログ
+## Learning failures
 
-（なし — 全 op が `status=ok` で完了。`get_spreadsheet_rows_v4` の output schema は dynamic 由来の partial で、本ログではなく上記セクションの `> ⚠ 部分学習` に記録済み）
+(None — all ops completed with `status=ok`. The output schema of `get_spreadsheet_rows_v4` is partial due to dynamic schema, recorded under the `> ⚠ Partial learning` notes in the sections above rather than in this log.)
 
 ---
 
-## 学習サマリ
+## Learning summary
 
-最終実行: 2026-04-27 by /auto-learn
-- 試行: 11 op (6 triggers + 5 actions)
-- 完全成功: 1 — `update_row_v4_new`
-- 部分学習: 10 — 6 triggers (`new_polling_spreadsheet_row_v4`, `new_spreadsheet_row_v4`, `team_drive_new_spreadsheet_row_v4`, `updated_polling_spreadsheet_row_v4_2`, `updated_spreadsheet_row_v4_2`, `team_drive_updated_spreadsheet_row_v4_2`) + 4 actions (`add_spreadsheet_row_v4`, `add_row_v4_bulk`, `get_spreadsheet_rows_v4`, `update_row_v4_bulk`)
-- 学習失敗: 0
-- スキップ:
+Last run: 2026-04-27 by `/auto-learn`
+- Attempted: 11 op (6 triggers + 5 actions)
+- Fully learned: 1 — `update_row_v4_new`
+- Partially learned: 10 — 6 triggers (`new_polling_spreadsheet_row_v4`, `new_spreadsheet_row_v4`, `team_drive_new_spreadsheet_row_v4`, `updated_polling_spreadsheet_row_v4_2`, `updated_spreadsheet_row_v4_2`, `team_drive_updated_spreadsheet_row_v4_2`) + 4 actions (`add_spreadsheet_row_v4`, `add_row_v4_bulk`, `get_spreadsheet_rows_v4`, `update_row_v4_bulk`)
+- Failed: 0
+- Skipped:
   - Deprecated: 7
   - adhoc: 1 — `__adhoc_http_action`
-  - 既学習: 1 — `search_spreadsheet_rows_v4_new`
+  - Already learned: 1 — `search_spreadsheet_rows_v4_new`
 
-### 要 follow-up
+### Needs follow-up
 
-- **Dynamic schema (要 /learn-recipe)** — Spreadsheet/Sheet picklist 未選択により `Rows[]` 配下の動的列スキーマが取れない
-  - 6 triggers — output の `Rows[]` 配下のカラムが未展開（`new_polling_spreadsheet_row_v4` 他 5 件）
-  - `get_spreadsheet_rows_v4` — output schema 全体が未確定（datatree に group 出現せず）
-  - `add_spreadsheet_row_v4` — input の Rows カラム未展開
-  - `add_row_v4_bulk` / `update_row_v4_bulk` — `List of batches` 配下の per-row column schema が未確定
-  - 全 op 共通: `Spreadsheet` picklist 選択時にしか `Rows[]` 配下のカラムは展開されない
+- **Dynamic schema (needs `/learn-recipe`)** — Because the Spreadsheet/Sheet picklist is not selected, the dynamic column schema under `Rows[]` cannot be captured
+  - 6 triggers — columns under output `Rows[]` are not expanded (`new_polling_spreadsheet_row_v4` and 5 others)
+  - `get_spreadsheet_rows_v4` — the entire output schema is unresolved (no group appears in the datatree)
+  - `add_spreadsheet_row_v4` — input Rows columns are not expanded
+  - `add_row_v4_bulk` / `update_row_v4_bulk` — the per-row column schema under `List of batches` is unresolved
+  - Common to all ops: columns under `Rows[]` are only expanded once the `Spreadsheet` picklist is selected
 
-### 構造的注記（参考）
+### Structural notes (for reference)
 
-- Triggers の output は metadata（`Spreadsheet ID`, `Spreadsheet name`, `Sheet name`, `Row number`）のみ resolve 可能。実カラムは sandbox spreadsheet 選択が必要
-- `search_spreadsheet_rows_v4_new` 既存セクションは snake_case 手動 schema。再学習時は `--force` で UI 由来の label format に統一推奨
-- 既存 Actions テーブルの行ずれ（rows 47-50）を本 run で修正済み
+- The output for triggers can only resolve metadata (`Spreadsheet ID`, `Spreadsheet name`, `Sheet name`, `Row number`). Capturing actual columns requires selecting a sandbox spreadsheet.
+- The existing `search_spreadsheet_rows_v4_new` section uses a snake_case manual schema. When re-learning, prefer `--force` to unify on the UI-derived label format.
+- Row misalignment in the existing Actions table (rows 47-50) was fixed in this run.

--- a/docs/connectors/google_speech_to_text.md
+++ b/docs/connectors/google_speech_to_text.md
@@ -1,14 +1,14 @@
-# Google Speech to Text コネクタ
+# Google Speech to Text connector
 
 Provider: `google_speech_to_text`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Convert short speech to text | `speech_to_text` | - |  |

--- a/docs/connectors/google_text_to_speech.md
+++ b/docs/connectors/google_text_to_speech.md
@@ -1,14 +1,14 @@
-# Google Text to Speech コネクタ
+# Google Text to Speech connector
 
 Provider: `google_text_to_speech`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Convert text to speech | `text_to_speech` | - |  |

--- a/docs/connectors/google_translate.md
+++ b/docs/connectors/google_translate.md
@@ -1,14 +1,14 @@
-# Google Translate コネクタ
+# Google Translate connector
 
 Provider: `google_translate`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Translate text | `text_translate` | - |  |

--- a/docs/connectors/google_vision.md
+++ b/docs/connectors/google_vision.md
@@ -1,14 +1,14 @@
-# Google Vision コネクタ
+# Google Vision connector
 
 Provider: `google_vision`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Read text from image | `text_from_image` | - |  |

--- a/docs/connectors/google_workspace.md
+++ b/docs/connectors/google_workspace.md
@@ -1,10 +1,10 @@
-# Google Workspace コネクタ
+# Google Workspace connector
 
 Provider: `google_workspace`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New admin activity event | `new_admin_activity_event` | - |  |
 | New application activity event | `new_application_activity_event` | - |  |
@@ -12,7 +12,7 @@ Provider: `google_workspace`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Add record | `add_object` | - |  |

--- a/docs/connectors/goombal.md
+++ b/docs/connectors/goombal.md
@@ -1,16 +1,16 @@
-# Goombal コネクタ
+# Goombal connector
 
 Provider: `goombal`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Updated attendee | `updated_attendee` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Add attendee | `add_attendee` | - |  |
 | Get activities | `get_activities` | Yes |  |

--- a/docs/connectors/goto_webinar.md
+++ b/docs/connectors/goto_webinar.md
@@ -1,16 +1,16 @@
-# GotoWebinar コネクタ
+# GotoWebinar connector
 
 Provider: `goto_webinar`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New webinar session | `new_webinar_session` | - |  |
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Get attendees from session | `get_attendees_from_session` | Yes |  |

--- a/docs/connectors/graphs_and_charts.md
+++ b/docs/connectors/graphs_and_charts.md
@@ -1,14 +1,14 @@
-# Charts by Workato コネクタ
+# Charts by Workato connector
 
 Provider: `graphs_and_charts`
 
 ## Triggers
 
-なし
+None
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Generate column chart | `column_chart` | Yes |  |
 | Generate pie chart | `pie_chart` | Yes |  |

--- a/docs/connectors/greenhouse.md
+++ b/docs/connectors/greenhouse.md
@@ -1,10 +1,10 @@
-# Greenhouse コネクタ
+# Greenhouse connector
 
 Provider: `greenhouse`
 
 ## Triggers
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | New event | `new_event` | - |  |
 | New object | `new_object` | - |  [deprecated] |
@@ -14,7 +14,7 @@ Provider: `greenhouse`
 
 ## Actions
 
-| 名前 | provider 内名称 | Batch | 説明 |
+| Name | Internal name | Batch | Description |
 |---|---|---|---|
 | Custom action | `__adhoc_http_action` | - |  |
 | Advance application | `advance_application` | - |  [deprecated] |


### PR DESCRIPTION
## Summary

Translate **109 connector docs** starting with letters A-G to English (~4,400 lines, 859 ins / 859 del).

## Approach

- **Mechanical heading/table-header substitution** via Python script (one-shot) for the 104 standard-format files:
  - `# <Provider> コネクタ` → `# <Provider> connector`
  - Table headers: `| 名前 | provider 内名称 | Batch | 説明 |` → `| Name | Internal name | Batch | Description |`
  - `## フィールド詳細` → `## Field details`, `## 学習サマリ` → `## Learning summary`, `## アクション詳細` → `## Action details`, `## トリガー詳細` → `## Trigger details`, `## 学習失敗ログ` → `## Learning failures`, etc.
  - Standalone `なし` → `None` (for empty Triggers/Actions sections)
- **LLM full-pass** for 5 Google connector docs carrying rich `/auto-learn` and `/learn-recipe` accumulated field knowledge:
  - gmail.md (648 lines)
  - google_big_query.md (490 lines)
  - google_calendar.md (1056 lines)
  - google_drive.md (591 lines)
  - google_sheets.md (319 lines)

  Every internal identifier (`spreadsheet_id`, `messageId`, `bq_dataset`, op names, type names) preserved verbatim; only descriptions, "Learned from:" RHS text, `> ⚠` annotations, and `## Learning summary` bullets translated.

## Verification

- [x] No JP characters across all A-G connector docs (`grep -lE '[ぁ-んァ-ヶ一-鿿]' docs/connectors/[a-g]*.md` → empty).
- [x] Field-table row structure preserved (only Description column changed).
- [x] Internal identifiers preserved (op names, type names, field names).

## Stack position

base: `i18n/english-migration` (hub) ← `i18n/phase-7a-connectors-a-g`

Previous: P6 merged via #139.
Next: P7b (H-O, ~110 files) and P7c (P-Z, ~107 files) — can be created in parallel since they touch disjoint file sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)