### PR TITLE
feat(api): add `sdk pull` command for custom connectors

### DIFF
--- a/docs/connector-sdk/overview.md
+++ b/docs/connector-sdk/overview.md
@@ -32,19 +32,24 @@ Used for local testing and development. Because the `workato` command name colli
 | `bundle exec workato edit <PATH>` | Edit an encrypted file |
 | `bundle exec workato generate <SUBCOMMAND>` | Generate code from templates |
 
-### Uploading to Workato (API helper recommended)
+### Uploading to / downloading from Workato (API helper recommended)
 
-Use the API helper to push connectors. It authenticates via the Platform CLI profile, so gem-side authentication (API Client token) is not required.
+Use the API helper for push and pull. It authenticates via the Platform CLI profile, so gem-side authentication (API Client token) is not required.
 
 ```bash
-# Create new
+# Push: create new
 python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --title "<Title>"
 
-# Update an existing connector
+# Push: update an existing connector
 python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.rb --connector-id <id>
+
+# Pull: download a connector that exists in the workspace
+python3 scripts/workato-api.py sdk pull --connector-id <id>
+# (or by name)
+python3 scripts/workato-api.py sdk pull --name <name>
 ```
 
-> **Note**: `bundle exec workato push` is still usable, but it requires a separate API Client token.
+> **Note**: `bundle exec workato push` / `workato sdk pull` are still usable, but they require a separate API Client token.
 
 ## Project structure
 

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -616,7 +616,9 @@ python3 scripts/workato-api.py sdk pull --connector-id <id>
 python3 scripts/workato-api.py sdk pull --name <name>
 ```
 
-Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+Writes to `connectors/<name>/connector.rb` and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+
+`--output-dir` overrides the destination, but it bypasses the canonical `connectors/` layout, so `connector_id` is **not** saved to docs frontmatter in that case — pass `--connector-id <id>` explicitly on the matching `sdk push`.
 
 ### Connector taxonomy
 

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -577,6 +577,7 @@ python3 scripts/workato-api.py <command>
 | `connectors list-custom` | List custom connectors |
 | `recipes list [--folder-id <id>]` | List recipes (JSON) |
 | `sdk push --connector <path> [--connector-id <id>]` | Push a custom connector (**recommended**) |
+| `sdk pull (--connector-id <id> \| --name <name>)` | Pull a custom connector's source into `connectors/<name>/` |
 | `profile show` | Show the resolved profile |
 
 ### 3. Connector SDK CLI (custom connector development & local testing)
@@ -603,6 +604,19 @@ python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.
 ```
 
 > `bundle exec workato push` and `workato sdk push` also work, but the API helper is preferred for its profile auto-resolution and release automation.
+
+#### Pulling a custom connector
+
+Mirror of `sdk push`: download a connector that already exists in the Workato workspace into the local repo.
+
+```bash
+# By connector ID
+python3 scripts/workato-api.py sdk pull --connector-id <id>
+# Or by connector name / title (resolved through list-custom)
+python3 scripts/workato-api.py sdk pull --name <name>
+```
+
+Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
 
 ### Connector taxonomy
 

--- a/framework/claude/rules/workato-cli.md
+++ b/framework/claude/rules/workato-cli.md
@@ -37,6 +37,7 @@ python3 scripts/workato-api.py <command>
 | `connectors list-custom` | List custom connectors |
 | `recipes list [--folder-id <id>]` | List recipes (JSON) |
 | `sdk push --connector <path> [--connector-id <id>]` | Push a custom connector (**recommended**) |
+| `sdk pull (--connector-id <id> \| --name <name>)` | Pull a custom connector's source into `connectors/<name>/` |
 | `profile show` | Show the resolved profile |
 
 ## 3. Connector SDK CLI (custom connector development & local testing)
@@ -63,6 +64,19 @@ python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.
 ```
 
 > `bundle exec workato push` and `workato sdk push` also work, but the API helper is preferred for its profile auto-resolution and release automation.
+
+### Pulling a custom connector
+
+Mirror of `sdk push`: download a connector that already exists in the Workato workspace into the local repo.
+
+```bash
+# By connector ID
+python3 scripts/workato-api.py sdk pull --connector-id <id>
+# Or by connector name / title (resolved through list-custom)
+python3 scripts/workato-api.py sdk pull --name <name>
+```
+
+Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
 
 ## Connector taxonomy
 

--- a/framework/claude/rules/workato-cli.md
+++ b/framework/claude/rules/workato-cli.md
@@ -76,7 +76,9 @@ python3 scripts/workato-api.py sdk pull --connector-id <id>
 python3 scripts/workato-api.py sdk pull --name <name>
 ```
 
-Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+Writes to `connectors/<name>/connector.rb` and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+
+`--output-dir` overrides the destination, but it bypasses the canonical `connectors/` layout, so `connector_id` is **not** saved to docs frontmatter in that case — pass `--connector-id <id>` explicitly on the matching `sdk push`.
 
 ## Connector taxonomy
 

--- a/framework/claude/skills/sync-connectors/SKILL.md
+++ b/framework/claude/skills/sync-connectors/SKILL.md
@@ -63,7 +63,15 @@ Read the Ruby DSL in `connectors/<name>/connector.rb` directly. No API call. Cla
 #### When `connector.rb` is missing
 
 For a custom connector that lives only in the UI (no source under `connectors/<name>/`):
-- Suggest running `workato sdk pull`.
+- Pull it via the API helper (preferred — no Ruby needed, auths via the Platform CLI profile):
+  ```bash
+  # Either by ID...
+  python3 scripts/workato-api.py sdk pull --connector-id <id>
+  # ...or by connector name / title
+  python3 scripts/workato-api.py sdk pull --name <name>
+  ```
+  This writes the source to `connectors/<name>/connector.rb` and saves `connector_id` to `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` calls auto-update.
+- `bundle exec workato sdk pull` (the Ruby gem) also works, but it requires a separate API Client token.
 - After the pull, run `/sync-connectors --custom` again.
 
 ### Supplementary source for pre-built

--- a/framework/codex/skills/sync-connectors/SKILL.md
+++ b/framework/codex/skills/sync-connectors/SKILL.md
@@ -63,7 +63,15 @@ Read the Ruby DSL in `connectors/<name>/connector.rb` directly. No API call. Cla
 #### When `connector.rb` is missing
 
 For a custom connector that lives only in the UI (no source under `connectors/<name>/`):
-- Suggest running `workato sdk pull`.
+- Pull it via the API helper (preferred — no Ruby needed, auths via the Platform CLI profile):
+  ```bash
+  # Either by ID...
+  python3 scripts/workato-api.py sdk pull --connector-id <id>
+  # ...or by connector name / title
+  python3 scripts/workato-api.py sdk pull --name <name>
+  ```
+  This writes the source to `connectors/<name>/connector.rb` and saves `connector_id` to `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` calls auto-update.
+- `bundle exec workato sdk pull` (the Ruby gem) also works, but it requires a separate API Client token.
 - After the pull, run `$sync-connectors --custom` again.
 
 ### Supplementary source for pre-built

--- a/framework/cursor/rules/workato-cli.mdc
+++ b/framework/cursor/rules/workato-cli.mdc
@@ -75,7 +75,9 @@ python3 scripts/workato-api.py sdk pull --connector-id <id>
 python3 scripts/workato-api.py sdk pull --name <name>
 ```
 
-Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+Writes to `connectors/<name>/connector.rb` and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
+
+`--output-dir` overrides the destination, but it bypasses the canonical `connectors/` layout, so `connector_id` is **not** saved to docs frontmatter in that case — pass `--connector-id <id>` explicitly on the matching `sdk push`.
 
 ## Connector taxonomy
 

--- a/framework/cursor/rules/workato-cli.mdc
+++ b/framework/cursor/rules/workato-cli.mdc
@@ -36,6 +36,7 @@ python3 scripts/workato-api.py <command>
 | `connectors list-custom` | List custom connectors |
 | `recipes list [--folder-id <id>]` | List recipes (JSON) |
 | `sdk push --connector <path> [--connector-id <id>]` | Push a custom connector (**recommended**) |
+| `sdk pull (--connector-id <id> \| --name <name>)` | Pull a custom connector's source into `connectors/<name>/` |
 | `profile show` | Show the resolved profile |
 
 ## 3. Connector SDK CLI (custom connector development & local testing)
@@ -62,6 +63,19 @@ python3 scripts/workato-api.py sdk push --connector connectors/<name>/connector.
 ```
 
 > `bundle exec workato push` and `workato sdk push` also work, but the API helper is preferred for its profile auto-resolution and release automation.
+
+### Pulling a custom connector
+
+Mirror of `sdk push`: download a connector that already exists in the Workato workspace into the local repo.
+
+```bash
+# By connector ID
+python3 scripts/workato-api.py sdk pull --connector-id <id>
+# Or by connector name / title (resolved through list-custom)
+python3 scripts/workato-api.py sdk pull --name <name>
+```
+
+Writes to `connectors/<name>/connector.rb` (use `--output-dir` to override) and stores `connector_id` in `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place. Use `--force` to overwrite an existing `connector.rb`.
 
 ## Connector taxonomy
 

--- a/framework/cursor/skills/sync-connectors/SKILL.md
+++ b/framework/cursor/skills/sync-connectors/SKILL.md
@@ -63,7 +63,15 @@ Read the Ruby DSL in `connectors/<name>/connector.rb` directly. No API call. Cla
 #### When `connector.rb` is missing
 
 For a custom connector that lives only in the UI (no source under `connectors/<name>/`):
-- Suggest running `workato sdk pull`.
+- Pull it via the API helper (preferred — no Ruby needed, auths via the Platform CLI profile):
+  ```bash
+  # Either by ID...
+  python3 scripts/workato-api.py sdk pull --connector-id <id>
+  # ...or by connector name / title
+  python3 scripts/workato-api.py sdk pull --name <name>
+  ```
+  This writes the source to `connectors/<name>/connector.rb` and saves `connector_id` to `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` calls auto-update.
+- `bundle exec workato sdk pull` (the Ruby gem) also works, but it requires a separate API Client token.
 - After the pull, run `/sync-connectors --custom` again.
 
 ### Supplementary source for pre-built

--- a/framework/gemini/skills/sync-connectors/SKILL.md
+++ b/framework/gemini/skills/sync-connectors/SKILL.md
@@ -63,7 +63,15 @@ Read the Ruby DSL in `connectors/<name>/connector.rb` directly. No API call. Cla
 #### When `connector.rb` is missing
 
 For a custom connector that lives only in the UI (no source under `connectors/<name>/`):
-- Suggest running `workato sdk pull`.
+- Pull it via the API helper (preferred — no Ruby needed, auths via the Platform CLI profile):
+  ```bash
+  # Either by ID...
+  python3 scripts/workato-api.py sdk pull --connector-id <id>
+  # ...or by connector name / title
+  python3 scripts/workato-api.py sdk pull --name <name>
+  ```
+  This writes the source to `connectors/<name>/connector.rb` and saves `connector_id` to `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` calls auto-update.
+- `bundle exec workato sdk pull` (the Ruby gem) also works, but it requires a separate API Client token.
 - After the pull, run `/sync-connectors --custom` again.
 
 ### Supplementary source for pre-built

--- a/scripts/tests/test_sdk_pull.py
+++ b/scripts/tests/test_sdk_pull.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Tests for `sdk pull` helpers in `scripts/workato-api.py`.
+
+Run with:
+    python3 scripts/tests/test_sdk_pull.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+# ---------------------------------------------------------------------------
+# _extract_connector_source
+# ---------------------------------------------------------------------------
+
+
+def test_extract_source_top_level_code():
+    assert wa._extract_connector_source({"code": "{ title: 'X' }"}) == "{ title: 'X' }"
+
+
+def test_extract_source_source_code_alias():
+    assert wa._extract_connector_source({"source_code": "X"}) == "X"
+
+
+def test_extract_source_latest_released_version():
+    rec = {"latest_released_version": {"code": "Y"}}
+    assert wa._extract_connector_source(rec) == "Y"
+
+
+def test_extract_source_released_versions_picks_newest():
+    rec = {
+        "released_versions": [
+            {"version": 1, "code": "v1"},
+            {"version": 3, "code": "v3"},
+            {"version": 2, "code": "v2"},
+        ]
+    }
+    assert wa._extract_connector_source(rec) == "v3"
+
+
+def test_extract_source_released_versions_non_int_version():
+    rec = {
+        "released_versions": [
+            {"version": "abc", "code": "vA"},
+            {"version": 1, "code": "v1"},
+        ]
+    }
+    assert wa._extract_connector_source(rec) == "v1"
+
+
+def test_extract_source_missing():
+    assert wa._extract_connector_source({}) is None
+    assert wa._extract_connector_source({"name": "foo"}) is None
+
+
+def test_extract_source_non_dict():
+    assert wa._extract_connector_source([]) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _connector_slug
+# ---------------------------------------------------------------------------
+
+
+def test_connector_slug_uses_name():
+    assert wa._connector_slug({"name": "my_conn", "title": "Whatever"}) == "my_conn"
+
+
+def test_connector_slug_falls_back_to_title():
+    assert wa._connector_slug({"title": "My Cool Connector"}) == "my_cool_connector"
+
+
+def test_connector_slug_falls_back_to_arg():
+    assert wa._connector_slug({}, fallback="cli-arg") == "cli_arg"
+
+
+def test_connector_slug_falls_back_to_id_when_empty():
+    assert wa._connector_slug({"id": 42}, fallback=None) == "42"
+
+
+# ---------------------------------------------------------------------------
+# cmd_sdk_pull
+# ---------------------------------------------------------------------------
+
+
+class _FakeAPI:
+    """Stub WorkatoAPI for cmd_sdk_pull tests."""
+
+    def __init__(self, *, list_response=None, get_response=None):
+        self._list = list_response or []
+        self._get = get_response or {}
+        self.get_calls: list[int] = []
+        self.list_calls = 0
+
+    def connectors_list_custom(self):
+        self.list_calls += 1
+        return self._list
+
+    def connectors_get_custom(self, connector_id: int):
+        self.get_calls.append(connector_id)
+        return self._get
+
+
+def _chdir(path: Path):
+    """Tiny context-manager-like helper to change cwd for the duration of a test."""
+    import os
+    prev = Path.cwd()
+    os.chdir(path)
+    return prev
+
+
+def test_sdk_pull_requires_id_or_name():
+    api = _FakeAPI()
+    args = SimpleNamespace(
+        connector_id=None, name=None, output_dir=None,
+        force=False, skip_save_id=False,
+    )
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        try:
+            wa.cmd_sdk_pull(api, args)
+        except SystemExit as e:
+            assert e.code == 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    assert "--connector-id" in err
+
+
+def test_sdk_pull_writes_file_and_frontmatter():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(get_response={
+                "id": 42,
+                "name": "my_conn",
+                "title": "My Connector",
+                "code": "{ title: 'My' }\n",
+            })
+            args = SimpleNamespace(
+                connector_id=42, name=None, output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                wa.cmd_sdk_pull(api, args)
+            finally:
+                sys.stderr = saved
+
+            rb = Path(d) / "connectors" / "my_conn" / "connector.rb"
+            assert rb.exists()
+            assert rb.read_text() == "{ title: 'My' }\n"
+
+            docs = Path(d) / "connectors" / "docs" / "my_conn.md"
+            assert docs.exists()
+            assert "connector_id: 42" in docs.read_text()
+            assert api.get_calls == [42]
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_refuses_overwrite_without_force():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            rb_dir = Path(d) / "connectors" / "my_conn"
+            rb_dir.mkdir(parents=True)
+            (rb_dir / "connector.rb").write_text("ORIGINAL\n")
+
+            api = _FakeAPI(get_response={
+                "id": 42, "name": "my_conn", "code": "NEW\n",
+            })
+            args = SimpleNamespace(
+                connector_id=42, name=None, output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            exited = False
+            try:
+                try:
+                    wa.cmd_sdk_pull(api, args)
+                except SystemExit as e:
+                    exited = (e.code == 1)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = saved
+            assert exited, "expected SystemExit(1) for refused overwrite"
+            assert "already exists" in err
+            assert (rb_dir / "connector.rb").read_text() == "ORIGINAL\n"
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_force_overwrites():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            rb_dir = Path(d) / "connectors" / "my_conn"
+            rb_dir.mkdir(parents=True)
+            (rb_dir / "connector.rb").write_text("ORIGINAL\n")
+
+            api = _FakeAPI(get_response={
+                "id": 42, "name": "my_conn", "code": "NEW\n",
+            })
+            args = SimpleNamespace(
+                connector_id=42, name=None, output_dir=None,
+                force=True, skip_save_id=True,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                wa.cmd_sdk_pull(api, args)
+            finally:
+                sys.stderr = saved
+            assert (rb_dir / "connector.rb").read_text() == "NEW\n"
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_resolves_name_via_list():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(
+                list_response=[
+                    {"id": 11, "name": "other", "title": "Other"},
+                    {"id": 42, "name": "my_conn", "title": "My", "code": "Z\n"},
+                ],
+            )
+            args = SimpleNamespace(
+                connector_id=None, name="my_conn", output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                wa.cmd_sdk_pull(api, args)
+            finally:
+                sys.stderr = saved
+
+            rb = Path(d) / "connectors" / "my_conn" / "connector.rb"
+            assert rb.read_text() == "Z\n"
+            # list response carried code, so no per-id fetch was needed
+            assert api.get_calls == []
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_name_not_found():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(list_response=[{"id": 1, "name": "other"}])
+            args = SimpleNamespace(
+                connector_id=None, name="missing", output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            exited = False
+            try:
+                try:
+                    wa.cmd_sdk_pull(api, args)
+                except SystemExit as e:
+                    exited = (e.code == 1)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = saved
+            assert exited
+            assert "no custom connector" in err
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_ambiguous_name():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(list_response=[
+                {"id": 1, "name": "foo", "title": "X"},
+                {"id": 2, "name": "bar", "title": "foo"},
+            ])
+            args = SimpleNamespace(
+                connector_id=None, name="foo", output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            exited = False
+            try:
+                try:
+                    wa.cmd_sdk_pull(api, args)
+                except SystemExit as e:
+                    exited = (e.code == 1)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = saved
+            assert exited
+            assert "ambiguous" in err
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_no_source_in_response():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(get_response={"id": 9, "name": "noc"})
+            args = SimpleNamespace(
+                connector_id=9, name=None, output_dir=None,
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            exited = False
+            try:
+                try:
+                    wa.cmd_sdk_pull(api, args)
+                except SystemExit as e:
+                    exited = (e.code == 1)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = saved
+            assert exited
+            assert "no source code" in err
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def test_sdk_pull_output_dir_override():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(get_response={
+                "id": 7, "name": "abc", "code": "OK\n",
+            })
+            args = SimpleNamespace(
+                connector_id=7, name=None,
+                output_dir=str(Path(d) / "custom_loc"),
+                force=False, skip_save_id=True,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                wa.cmd_sdk_pull(api, args)
+            finally:
+                sys.stderr = saved
+            assert (Path(d) / "custom_loc" / "connector.rb").read_text() == "OK\n"
+        finally:
+            import os
+            os.chdir(prev)
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_sdk_pull.py
+++ b/scripts/tests/test_sdk_pull.py
@@ -376,6 +376,39 @@ def test_sdk_pull_output_dir_override():
             os.chdir(prev)
 
 
+def test_sdk_pull_output_dir_skips_id_save():
+    """With --output-dir the connector_id is not written to docs frontmatter,
+    and no unexpected docs/ directory is created."""
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            api = _FakeAPI(get_response={
+                "id": 7, "name": "abc", "code": "OK\n",
+            })
+            args = SimpleNamespace(
+                connector_id=7, name=None,
+                output_dir=str(Path(d) / "custom_loc"),
+                force=False, skip_save_id=False,
+            )
+            saved = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                wa.cmd_sdk_pull(api, args)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = saved
+
+            assert (Path(d) / "custom_loc" / "connector.rb").read_text() == "OK\n"
+            # The docs path _connector_docs_path() would derive for an
+            # arbitrary --output-dir must NOT be written.
+            assert not (Path(d) / "docs" / "custom_loc.md").exists()
+            assert not (Path(d) / "connectors" / "docs").exists()
+            assert "connector_id not saved" in err
+        finally:
+            import os
+            os.chdir(prev)
+
+
 def main() -> int:
     tests = [(name, obj) for name, obj in sorted(globals().items())
              if name.startswith("test_") and callable(obj)]

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -18,6 +18,9 @@ Usage:
   python3 scripts/workato-api.py sdk push --connector <path> [--title <t>]
     (auto-detects new vs. update by reading connector_id from
      connectors/docs/<name>.md frontmatter; saves ID back after initial create)
+  python3 scripts/workato-api.py sdk pull (--connector-id <id> | --name <name>)
+    (downloads connector source to connectors/<name>/connector.rb and saves
+     connector_id back to connectors/docs/<name>.md frontmatter)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
   python3 scripts/workato-api.py profile show
@@ -331,6 +334,19 @@ class WorkatoAPI:
     def connectors_list_custom(self) -> list:
         result = self._request("/api/custom_connectors")
         return result if isinstance(result, list) else result.get("result", [])
+
+    def connectors_get_custom(self, connector_id: int) -> dict:
+        """Fetch a single custom connector record (id, name, title, code, ...).
+
+        The Platform API has historically returned the source under several
+        shapes — `code`, `result.code`, `latest_released_version.code`, or
+        within `released_versions[]`. The caller is expected to use
+        `_extract_connector_source` to handle whichever shape comes back.
+        """
+        result = self._request(f"/api/custom_connectors/{connector_id}")
+        if isinstance(result, dict):
+            return result.get("data", result.get("result", result))
+        return result  # type: ignore[return-value]
 
     # -- SDK (Custom Connectors) --
 
@@ -720,6 +736,173 @@ def _resolve_connector_id(
         return None, docs_path
 
 
+def _extract_connector_source(record: dict) -> str | None:
+    """Best-effort extraction of the Ruby source from a custom-connector record.
+
+    The Platform API has used several shapes over time; check in order:
+      1. `code` (current).
+      2. `source_code` (some older deployments).
+      3. `latest_released_version.code` (when released-version is nested).
+      4. The newest entry in `released_versions[]` by version number.
+    """
+    if not isinstance(record, dict):
+        return None
+
+    for key in ("code", "source_code"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    latest = record.get("latest_released_version")
+    if isinstance(latest, dict):
+        for key in ("code", "source_code"):
+            value = latest.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+    versions = record.get("released_versions")
+    if isinstance(versions, list) and versions:
+        def _ver_key(v: dict) -> int:
+            try:
+                return int(v.get("version", 0))
+            except (TypeError, ValueError):
+                return 0
+        candidates = [v for v in versions if isinstance(v, dict)]
+        for v in sorted(candidates, key=_ver_key, reverse=True):
+            for key in ("code", "source_code"):
+                value = v.get(key)
+                if isinstance(value, str) and value:
+                    return value
+
+    return None
+
+
+def _connector_slug(record: dict, fallback: str | None = None) -> str:
+    """Pick the directory-name slug for a fetched custom connector.
+
+    Prefers `name` (which is typically a slug), then `title` lowered with
+    non-alnum chars replaced. Falls back to `fallback` (usually the CLI arg)
+    or the connector ID stringified.
+    """
+    import re
+
+    raw = record.get("name") if isinstance(record, dict) else None
+    if not raw:
+        raw = record.get("title") if isinstance(record, dict) else None
+    if not raw:
+        raw = fallback or ""
+    raw = str(raw).strip()
+    slug = re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_")
+    return slug or (str(record.get("id")) if isinstance(record, dict) else "connector")
+
+
+def cmd_sdk_pull(api: WorkatoAPI, args: argparse.Namespace):
+    """Pull a custom connector's source from Workato to the local filesystem."""
+    if args.connector_id is None and not args.name:
+        print(
+            "Error: provide --connector-id <id> or --name <connector-name>.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    connector_id = args.connector_id
+    record: dict | None = None
+
+    if connector_id is None:
+        # Resolve name -> id via the list endpoint
+        listed = api.connectors_list_custom()
+        target = args.name.lower()
+        matches = [
+            c for c in listed
+            if isinstance(c, dict) and (
+                str(c.get("name", "")).lower() == target
+                or str(c.get("title", "")).lower() == target
+            )
+        ]
+        if not matches:
+            print(
+                f"Error: no custom connector with name/title '{args.name}'. "
+                f"Run 'connectors list-custom' to see available connectors.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if len(matches) > 1:
+            ids = ", ".join(str(c.get("id")) for c in matches)
+            print(
+                f"Error: name '{args.name}' is ambiguous (matches ids: {ids}). "
+                f"Re-run with --connector-id.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        record = matches[0]
+        connector_id = int(record["id"])
+        # The list response sometimes already contains the code; only re-fetch
+        # if it doesn't.
+        if _extract_connector_source(record) is None:
+            record = api.connectors_get_custom(connector_id)
+    else:
+        record = api.connectors_get_custom(connector_id)
+
+    source = _extract_connector_source(record or {})
+    if source is None:
+        print(
+            f"Error: connector id={connector_id} has no source code in the "
+            f"API response. (It may have no released version yet.)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    slug = _connector_slug(record or {}, fallback=args.name)
+    target_dir = Path(args.output_dir) if args.output_dir else Path("connectors") / slug
+    target_file = target_dir / "connector.rb"
+
+    if target_file.exists() and not args.force:
+        print(
+            f"Error: {target_file} already exists. Re-run with --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_file.write_text(source)
+
+    try:
+        display_target = target_file.relative_to(Path.cwd())
+    except ValueError:
+        display_target = target_file
+
+    title = record.get("title") if isinstance(record, dict) else None
+    print(
+        f"Pulled connector id={connector_id} "
+        f"({title or slug}) -> {display_target}",
+        file=sys.stderr,
+    )
+
+    # Persist connector_id to docs frontmatter (mirrors sdk push behavior)
+    if not args.skip_save_id:
+        docs_path = _connector_docs_path(target_file)
+        fm, _ = _read_frontmatter(docs_path)
+        existing = fm.get("connector_id")
+        if existing != str(connector_id):
+            fm["connector_id"] = str(connector_id)
+            _write_frontmatter(docs_path, fm, connector_name=slug)
+            try:
+                display_docs = docs_path.relative_to(Path.cwd())
+            except ValueError:
+                display_docs = docs_path
+            if existing is None:
+                print(
+                    f"Saved connector_id={connector_id} to {display_docs}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"Updated connector_id in {display_docs} "
+                    f"({existing} -> {connector_id})",
+                    file=sys.stderr,
+                )
+
+
 def cmd_sdk_push(api: WorkatoAPI, args: argparse.Namespace):
     connector_path = Path(args.connector)
     if not connector_path.exists():
@@ -972,6 +1155,30 @@ def main():
              "connectors/docs/<name>.md frontmatter",
     )
 
+    sdk_pull_p = sdk_sub.add_parser(
+        "pull", help="Pull a custom connector's source from Workato"
+    )
+    sdk_pull_p.add_argument(
+        "--connector-id", type=int, default=None,
+        help="Workato custom connector ID to pull",
+    )
+    sdk_pull_p.add_argument(
+        "--name", default=None,
+        help="Connector name or title (resolved via list-custom)",
+    )
+    sdk_pull_p.add_argument(
+        "--output-dir", default=None,
+        help="Override the output directory (default: connectors/<name>/)",
+    )
+    sdk_pull_p.add_argument(
+        "--force", action="store_true",
+        help="Overwrite connector.rb if it already exists",
+    )
+    sdk_pull_p.add_argument(
+        "--skip-save-id", action="store_true",
+        help="Don't persist connector_id to connectors/docs/<name>.md frontmatter",
+    )
+
     sdk_decrypt_p = sdk_sub.add_parser(
         "decrypt", help="Decrypt a .enc file and print to stdout"
     )
@@ -1068,6 +1275,7 @@ def main():
         ("connectors", "list-custom"): cmd_connectors_list_custom,
         ("recipes", "list"): cmd_recipes_list,
         ("sdk", "push"): cmd_sdk_push,
+        ("sdk", "pull"): cmd_sdk_pull,
         ("sdk", "generate-schema"): cmd_sdk_generate_schema,
         ("oauth-profiles", "list"): cmd_oauth_profiles_list,
         ("oauth-profiles", "get"): cmd_oauth_profiles_get,

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -878,8 +878,21 @@ def cmd_sdk_pull(api: WorkatoAPI, args: argparse.Namespace):
         file=sys.stderr,
     )
 
-    # Persist connector_id to docs frontmatter (mirrors sdk push behavior)
-    if not args.skip_save_id:
+    # Persist connector_id to docs frontmatter (mirrors sdk push behavior).
+    # The docs-frontmatter convention is tied to the canonical
+    # connectors/<slug>/ layout, where docs live in a sibling connectors/docs/.
+    # With --output-dir we cannot assume that layout, so skip the save rather
+    # than writing an unexpected docs/ directory next to an arbitrary path.
+    if args.skip_save_id:
+        pass
+    elif args.output_dir:
+        print(
+            "Note: connector_id not saved to docs frontmatter "
+            "(--output-dir bypasses the canonical connectors/ layout). "
+            f"Pass --connector-id {connector_id} when running sdk push.",
+            file=sys.stderr,
+        )
+    else:
         docs_path = _connector_docs_path(target_file)
         fm, _ = _read_frontmatter(docs_path)
         existing = fm.get("connector_id")
@@ -1168,7 +1181,8 @@ def main():
     )
     sdk_pull_p.add_argument(
         "--output-dir", default=None,
-        help="Override the output directory (default: connectors/<name>/)",
+        help="Override the output directory (default: connectors/<name>/). "
+             "When set, connector_id is not saved to docs frontmatter.",
     )
     sdk_pull_p.add_argument(
         "--force", action="store_true",


### PR DESCRIPTION
## Summary

- Adds `sdk pull` to `scripts/workato-api.py` so a custom connector that lives only in the Workato workspace can be downloaded into the local repo — the missing counterpart to the existing `sdk push`.
- Resolves the connector by `--connector-id <id>` or `--name <name>` (looked up through `list-custom`), writes the Ruby source to `connectors/<name>/connector.rb`, and persists `connector_id` to `connectors/docs/<name>.md` frontmatter so subsequent `sdk push` runs auto-update in place.
- Defensive source extraction handles the `code` / `latest_released_version.code` / `released_versions[]` shapes returned by different Platform API deployments.
- Updates `framework/claude/rules/workato-cli.md`, `framework/claude/skills/sync-connectors/SKILL.md`, and `docs/connector-sdk/overview.md` to document the new command; regenerated `framework/{cursor,codex,gemini}/` + `AGENTS.md` via `scripts/sync_agents.py`.
- Adds `scripts/tests/test_sdk_pull.py` covering source extraction, slug derivation, name resolution, ambiguity/missing handling, overwrite guard, and frontmatter persistence (20 tests).

## Test plan

- [x] `python3 scripts/tests/test_sdk_pull.py` (20/20 passed)
- [x] `python3 scripts/tests/test_sdk_push_frontmatter.py` (11/11 passed, no regressions)
- [x] `python3 scripts/tests/test_sync_agents.py` (41/41 passed)
- [x] `python3 scripts/workato-api.py sdk pull --help` shows the new subcommand
- [ ] End-to-end pull against a live Workato workspace (`sdk pull --connector-id <id>` and `--name <name>`)
- [ ] Verify frontmatter round-trip: pull a connector, then `sdk push` updates it in place without re-creating


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8rCVZfdZ9zHiqwYVdpgsj)_