### PR TITLE
fix(setup): handle git worktree submodule breakage (#147)

### DIFF
--- a/guides/quickstart-claude-code.md
+++ b/guides/quickstart-claude-code.md
@@ -177,6 +177,32 @@ git push origin feature/learn-jira-fields
 # Open a PR on GitHub
 ```
 
+## Using git worktree
+
+`git worktree add` does **not** populate submodules in the new worktree, so the
+`kit/` submodule starts out empty there. Every `.claude/` symlink (and `docs/`,
+`guides/`, …) then points at nothing, and Claude Code cannot load the framework's
+rules or skills.
+
+After creating a worktree, initialize the submodule and re-run setup **inside it**:
+
+```bash
+git worktree add ../my-org-workato-feature feature-branch
+cd ../my-org-workato-feature
+git submodule update --init --recursive   # populate kit/ in this worktree
+bash kit/setup.sh                          # refresh the symlinks
+```
+
+`bash kit/setup.sh` verifies the symlinks at the end and prints a `DANGLING`
+warning if the submodule is still missing.
+
+> **Note on shared submodule state**: all worktrees share one `.git/modules/kit`,
+> and its `core.worktree` can only point at one worktree at a time. `git status` /
+> `git submodule status` for `kit/` may therefore look noisy across worktrees.
+> This is harmless because the kit is consumed read-only — just don't stage a
+> `kit` pointer change unless you intentionally bumped the kit version
+> (`git submodule update --remote kit`).
+
 ## FAQ
 
 ### Q: What is a Workato project?

--- a/guides/quickstart-claude-code.md
+++ b/guides/quickstart-claude-code.md
@@ -179,22 +179,33 @@ git push origin feature/learn-jira-fields
 
 ## Using git worktree
 
-`git worktree add` does **not** populate submodules in the new worktree, so the
-`kit/` submodule starts out empty there. Every `.claude/` symlink (and `docs/`,
-`guides/`, …) then points at nothing, and Claude Code cannot load the framework's
-rules or skills.
+`git worktree add` does **not** populate submodules in a new worktree on its own —
+left unhandled, the `kit/` submodule would start out empty there, every `.claude/`
+symlink (and `docs/`, `guides/`, …) would point at nothing, and Claude Code could
+not load the framework's rules or skills.
 
-After creating a worktree, initialize the submodule and re-run setup **inside it**:
+To prevent this, `bash kit/setup.sh` installs a git `post-checkout` hook that runs
+`git submodule update --init --recursive` automatically. So creating a worktree
+fills in `kit/` for you — just re-run setup to refresh the symlinks:
 
 ```bash
-git worktree add ../my-org-workato-feature feature-branch
+git worktree add ../my-org-workato-feature feature-branch   # hook populates kit/
 cd ../my-org-workato-feature
-git submodule update --init --recursive   # populate kit/ in this worktree
-bash kit/setup.sh                          # refresh the symlinks
+bash kit/setup.sh                                            # refresh the symlinks
+```
+
+If the hook is not active — you had a pre-existing `post-checkout` hook, or
+`core.hooksPath` is set (husky etc.) — `setup.sh` prints a `SKIP` notice. In that
+case populate the submodule manually first:
+
+```bash
+cd ../my-org-workato-feature
+git submodule update --init --recursive
+bash kit/setup.sh
 ```
 
 `bash kit/setup.sh` verifies the symlinks at the end and prints a `DANGLING`
-warning if the submodule is still missing.
+warning if the kit submodule is still missing.
 
 > **Note on shared submodule state**: all worktrees share one `.git/modules/kit`,
 > and its `core.worktree` can only point at one worktree at a time. `git status` /

--- a/guides/quickstart-cursor.md
+++ b/guides/quickstart-cursor.md
@@ -233,6 +233,33 @@ git submodule update --remote kit
 bash kit/setup.sh    # Copy new skills/rules, prune old ones
 ```
 
+## Using git worktree
+
+`git worktree add` does **not** populate submodules in the new worktree, so the
+`kit/` submodule starts out empty there. The `docs/` and `guides/` symlinks then
+point at nothing — and although `.cursor/` holds real file copies, its rules
+reference `@docs/...`, so the framework is effectively broken in that worktree.
+
+After creating a worktree, initialize the submodule and re-run setup **inside it**:
+
+```bash
+git worktree add ../my-org-workato-feature feature-branch
+cd ../my-org-workato-feature
+git submodule update --init --recursive   # populate kit/ in this worktree
+bash kit/setup.sh                          # refresh symlinks + re-copy .cursor/
+```
+
+`bash kit/setup.sh` re-copies `.cursor/` from the now-populated kit and verifies
+the symlinks at the end, printing a `DANGLING` warning if the submodule is still
+missing.
+
+> **Note on shared submodule state**: all worktrees share one `.git/modules/kit`,
+> and its `core.worktree` can only point at one worktree at a time. `git status` /
+> `git submodule status` for `kit/` may therefore look noisy across worktrees.
+> This is harmless because the kit is consumed read-only — just don't stage a
+> `kit` pointer change unless you intentionally bumped the kit version
+> (`git submodule update --remote kit`).
+
 ## FAQ
 
 ### Q: What is a Workato project?

--- a/guides/quickstart-cursor.md
+++ b/guides/quickstart-cursor.md
@@ -235,18 +235,31 @@ bash kit/setup.sh    # Copy new skills/rules, prune old ones
 
 ## Using git worktree
 
-`git worktree add` does **not** populate submodules in the new worktree, so the
-`kit/` submodule starts out empty there. The `docs/` and `guides/` symlinks then
-point at nothing — and although `.cursor/` holds real file copies, its rules
-reference `@docs/...`, so the framework is effectively broken in that worktree.
+`git worktree add` does **not** populate submodules in a new worktree on its own —
+left unhandled, the `kit/` submodule would start out empty there. The `docs/` and
+`guides/` symlinks would point at nothing, and although `.cursor/` holds real file
+copies, its rules reference `@docs/...`, so the framework would be effectively
+broken in that worktree.
 
-After creating a worktree, initialize the submodule and re-run setup **inside it**:
+To prevent this, `bash kit/setup.sh` installs a git `post-checkout` hook that runs
+`git submodule update --init --recursive` automatically. So creating a worktree
+fills in `kit/` for you — just re-run setup to refresh the symlinks and re-copy
+`.cursor/`:
 
 ```bash
-git worktree add ../my-org-workato-feature feature-branch
+git worktree add ../my-org-workato-feature feature-branch   # hook populates kit/
 cd ../my-org-workato-feature
-git submodule update --init --recursive   # populate kit/ in this worktree
-bash kit/setup.sh                          # refresh symlinks + re-copy .cursor/
+bash kit/setup.sh                                            # refresh symlinks + re-copy .cursor/
+```
+
+If the hook is not active — you had a pre-existing `post-checkout` hook, or
+`core.hooksPath` is set (husky etc.) — `setup.sh` prints a `SKIP` notice. In that
+case populate the submodule manually first:
+
+```bash
+cd ../my-org-workato-feature
+git submodule update --init --recursive
+bash kit/setup.sh
 ```
 
 `bash kit/setup.sh` re-copies `.cursor/` from the now-populated kit and verifies

--- a/setup.sh
+++ b/setup.sh
@@ -514,7 +514,59 @@ if [ -f "$KIT_DIR/framework/AGENTS.md" ]; then
   done
 fi
 
-# ── 12. Verify kit symlinks resolve ──────────────────────────
+# ── 12. Install git post-checkout hook ───────────────────────
+# `git worktree add` does not populate submodules, so a new worktree
+# starts with an empty kit/. A post-checkout hook — shared across every
+# worktree via the common .git — initialises submodules automatically
+# whenever a worktree or branch is checked out.
+echo ""
+echo "--- Setting up git post-checkout hook ---"
+if ! git -C "$WORKSPACE_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "  SKIP (workspace is not a git repository yet)"
+else
+  _hooks_path_cfg="$(git -C "$WORKSPACE_ROOT" config --get core.hooksPath 2>/dev/null || true)"
+  if [ -n "$_hooks_path_cfg" ]; then
+    echo "  SKIP (core.hooksPath is set — hooks are managed elsewhere, e.g. husky)"
+    echo "        To auto-init submodules in new worktrees, add to your post-checkout hook:"
+    echo "          [ \"\$3\" = \"1\" ] && git submodule update --init --recursive"
+  else
+    # Submodule git data and hooks both live in the *common* git dir, so
+    # the hook is installed once and every worktree shares it.
+    _common_dir="$(git -C "$WORKSPACE_ROOT" rev-parse --git-common-dir 2>/dev/null || echo .git)"
+    case "$_common_dir" in
+      /*) ;;
+      *) _common_dir="$WORKSPACE_ROOT/$_common_dir" ;;
+    esac
+    HOOK="$_common_dir/hooks/post-checkout"
+    if [ -e "$HOOK" ] && ! grep -q 'workato-dev-kit:post-checkout' "$HOOK" 2>/dev/null; then
+      echo "  SKIP post-checkout (a non-kit hook exists — preserving it)"
+      echo "        To auto-init submodules in new worktrees, add to $HOOK:"
+      echo "          [ \"\$3\" = \"1\" ] && git submodule update --init --recursive"
+    else
+      _had_hook=0
+      [ -e "$HOOK" ] && _had_hook=1
+      mkdir -p "$_common_dir/hooks"
+      cat > "$HOOK" <<'HOOK_EOF'
+#!/bin/sh
+# workato-dev-kit:post-checkout — managed by kit/setup.sh (safe to delete).
+# `git worktree add` does not check out submodules; without this the kit/
+# submodule stays empty in new worktrees and every setup.sh symlink dangles.
+# $3 == 1 marks a branch / worktree checkout (vs. a file checkout).
+if [ "$3" = "1" ]; then
+  git submodule update --init --recursive
+fi
+HOOK_EOF
+      chmod +x "$HOOK"
+      if [ "$_had_hook" -eq 1 ]; then
+        echo "  ✓ post-checkout hook refreshed ($HOOK)"
+      else
+        echo "  ✓ Installed post-checkout hook — 'git worktree add' now auto-inits the kit/ submodule"
+      fi
+    fi
+  fi
+fi
+
+# ── 13. Verify kit symlinks resolve ──────────────────────────
 # A linked worktree with an un-initialised kit submodule leaves the
 # symlinks above pointing at nothing. Surface that instead of letting
 # Claude Code / Cursor silently fail to load rules and skills.
@@ -564,8 +616,8 @@ echo "  git submodule update --remote kit && bash kit/setup.sh"
 
 if [ "$IS_WORKTREE" -eq 1 ]; then
   echo ""
-  echo "Note: this is a linked git worktree. Submodules are not populated"
-  echo "automatically by 'git worktree add' — in every new worktree run"
-  echo "'git submodule update --init --recursive' before 'bash $KIT_NAME/setup.sh'."
-  echo "See guides/quickstart-claude-code.md ('Using git worktree')."
+  echo "Note: this is a linked git worktree. The installed post-checkout hook"
+  echo "auto-populates the kit/ submodule whenever you run 'git worktree add'."
+  echo "If kit/ is ever empty, run 'git submodule update --init --recursive'"
+  echo "then 'bash $KIT_NAME/setup.sh'. See guides/quickstart-claude-code.md."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,34 @@ echo ""
 
 cd "$WORKSPACE_ROOT"
 
+# ── Detect git worktree context ──────────────────────────────
+# `git worktree add` does NOT check out submodules into the new worktree,
+# so in a linked worktree the kit submodule can be empty and every symlink
+# created below would dangle. Detect a linked worktree (its --git-dir
+# differs from the shared --git-common-dir) so we can warn precisely.
+IS_WORKTREE=0
+if git -C "$WORKSPACE_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  _git_dir="$(git -C "$WORKSPACE_ROOT" rev-parse --git-dir 2>/dev/null || true)"
+  _common_dir="$(git -C "$WORKSPACE_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$_common_dir" ] && [ "$_git_dir" != "$_common_dir" ]; then
+    IS_WORKTREE=1
+  fi
+fi
+
+# ── Verify the kit submodule is checked out ──────────────────
+# setup.sh running implies kit/setup.sh exists, but a partial checkout
+# could still lack framework/. Fail fast with a precise remedy rather
+# than building a tree of dangling symlinks.
+if [ ! -d "$KIT_DIR/framework/claude/rules" ]; then
+  echo "ERROR: the kit submodule is not fully checked out." >&2
+  echo "  Missing: $KIT_DIR/framework/claude/rules" >&2
+  echo "" >&2
+  echo "  Submodules are not auto-populated in a new 'git worktree'." >&2
+  echo "  Run this in the current working tree, then re-run setup.sh:" >&2
+  echo "    git submodule update --init --recursive" >&2
+  exit 1
+fi
+
 # ── Helpers ──────────────────────────────────────────────────
 
 # Symlink each file inside src_dir into dst_dir so the user can add
@@ -486,6 +514,42 @@ if [ -f "$KIT_DIR/framework/AGENTS.md" ]; then
   done
 fi
 
+# ── 12. Verify kit symlinks resolve ──────────────────────────
+# A linked worktree with an un-initialised kit submodule leaves the
+# symlinks above pointing at nothing. Surface that instead of letting
+# Claude Code / Cursor silently fail to load rules and skills.
+echo ""
+echo "--- Verifying kit symlinks ---"
+DANGLING=0
+while IFS= read -r -d '' link; do
+  target="$(readlink "$link")"
+  case "$target" in
+    *"$KIT_REL/"*) ;;
+    *) continue ;;
+  esac
+  if [ -e "$link" ]; then
+    continue
+  fi
+  echo "  ⚠️  DANGLING: ${link#$WORKSPACE_ROOT/} → $target" >&2
+  DANGLING=$((DANGLING + 1))
+done < <(
+  find "$WORKSPACE_ROOT/.claude" "$WORKSPACE_ROOT/.agents" "$WORKSPACE_ROOT/.gemini" \
+       -type l -print0 2>/dev/null
+  for top in docs guides scripts templates AGENTS.md GEMINI.md; do
+    if [ -L "$WORKSPACE_ROOT/$top" ]; then
+      printf '%s\0' "$WORKSPACE_ROOT/$top"
+    fi
+  done
+)
+if [ "$DANGLING" -gt 0 ]; then
+  echo "" >&2
+  echo "  $DANGLING kit symlink(s) above do not resolve — the kit submodule" >&2
+  echo "  is not checked out in this working tree. Fix with:" >&2
+  echo "    git submodule update --init --recursive" >&2
+else
+  echo "  ✓ all kit symlinks resolve"
+fi
+
 # ── Done ─────────────────────────────────────────────────────
 echo ""
 echo "=== Setup complete ==="
@@ -497,3 +561,11 @@ echo "  3. Run 'git add .claude/ .cursor/ .agents/ .gemini/ AGENTS.md GEMINI.md 
 echo ""
 echo "To update the framework later:"
 echo "  git submodule update --remote kit && bash kit/setup.sh"
+
+if [ "$IS_WORKTREE" -eq 1 ]; then
+  echo ""
+  echo "Note: this is a linked git worktree. Submodules are not populated"
+  echo "automatically by 'git worktree add' — in every new worktree run"
+  echo "'git submodule update --init --recursive' before 'bash $KIT_NAME/setup.sh'."
+  echo "See guides/quickstart-claude-code.md ('Using git worktree')."
+fi


### PR DESCRIPTION
Closes #147

## 背景

利用者のワークスペースリポジトリ（`kit/` をサブモジュールに持つ側）で `git worktree add` を使うと、新 worktree に `kit/` サブモジュールが checkout されず、`setup.sh` が生成した symlink がすべてダングリングになる。Claude Code / Cursor はルール・スキルを読み込めなくなる。

## 変更内容

### `setup.sh`

1. **post-checkout フック設置（保証レベルの対策）** — `git worktree add` 時に発火する git `post-checkout` フックを設置し、`git submodule update --init --recursive` を自動実行。フックは共通 `.git`（全 worktree 共有）に置かれるため一度の設置で以降の `git worktree add` すべてに効く。
   - `core.hooksPath` 設定時（husky 等）は SKIP し、手動追記方法を案内。
   - kit 製でない既存 `post-checkout` フックがある場合は SKIP（保護）。`workato-dev-kit` マーカーを持つフックのみ作成/更新。
   - `$3 == 1` ガードでブランチ/worktree checkout 時のみ発火。
2. **kit checkout ガード** — `framework/claude/rules` が無ければ `git submodule update --init --recursive` を促して `exit 1`。
3. **worktree 検知** — リンク worktree を検知し終了メッセージに固有ガイダンスを表示。
4. **symlink 検証ステップ** — 全 kit symlink の解決可否を確認し、`DANGLING` を検出したら修復コマンドを明示。

### ドキュメント

`guides/quickstart-claude-code.md` / `quickstart-cursor.md` に **"Using git worktree"** セクションを追加。フックが worktree を自動対応すること、SKIP 時のフォールバック手順、`.git/modules/kit` 共有（`core.worktree`）の注記を記載。

## テスト

実環境を作って検証（いずれも期待通り）:
- **フック機構** — 実サブモジュール + フック設置 + `git worktree add` → 新 worktree の `kit/` が自動 populate されることを確認
- **フック設置ロジック** — 新規作成 / 冪等 refresh / 既存フック保護(SKIP) / `core.hooksPath` 時 SKIP
- 基本セットアップ + 冪等性、worktree 検知、ダングリング検出、kit 未 checkout ガード

既存テスト（`test_sync_agents.py` 41/41、`test_sdk_pull.py` 21/21）通過。`setup.sh` と `guides/` は sync 対象外。

## 設計判断

- 当初の advisory のみ（チェック/警告）では「`submodule update` が実行される保証」が無く、しかも典型ケースでは `kit/` が空のため `bash kit/setup.sh` 自体が起動できない。post-checkout フックはこのギャップを塞ぐ唯一の確実な手段（`git worktree add` がフックを発火することを検証済み）。
- 原因2（`.git/modules/kit` の `core.worktree` 共有）は git の制約でコードでは塞げないため、「kit は read-only 消費なので実害なし」とドキュメントで整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)