### PR TITLE
feat(security): block agent reads of credential files across editors

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,8 +61,11 @@ In a user repository (one that has added the kit as a submodule), running `bash 
 | `.cursor/.kit-manifest` | generated | list of kit-managed files (used for prune decisions on the next setup) |
 | `.agents/skills/<name>/` | symlink | `kit/framework/codex/skills/<name>/` |
 | `.codex/agents/<file>.toml` | symlink | `kit/framework/codex/agents/<file>.toml` |
+| `.codex/hooks/<file>.sh` | symlink | `kit/framework/codex/hooks/<file>.sh` |
+| `.codex/hooks.json` | initial copy | `kit/framework/codex/hooks.json` |
 | `.gemini/skills/<name>/` | symlink | `kit/framework/gemini/skills/<name>/` |
 | `.gemini/agents/<file>.md` | symlink | `kit/framework/gemini/agents/<file>.md` |
+| `.cursorignore` / `.geminiignore` / `.codexignore` | append | credential globs from `kit/framework/credential-patterns.txt` |
 | `AGENTS.md` | symlink | `kit/framework/AGENTS.md` |
 | `GEMINI.md` | symlink | `kit/framework/AGENTS.md` (same artifact) |
 

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -75,9 +75,33 @@ elif tool == "NotebookEdit":
     if np:
         paths.append(np)
 elif tool in ("Grep", "Glob"):
-    pp = ti.get("path")
-    if pp:
-        paths.append(pp)
+    # Direct path match (e.g. Grep(path="master.key")) — block immediately.
+    pp = ti.get("path") or "."
+    direct = path_hit(pp)
+    if direct:
+        print(f"DENY:{direct}:{pp}")
+        sys.exit(0)
+    # Reachability check: if Grep/Glob points at a directory that contains
+    # any credential file, its results would expose it. Walk the tree and
+    # deny if a credential basename is found. Bounded by skipping known
+    # heavy dirs (.git, node_modules, …) so the hook stays interactive.
+    try:
+        target = pp if os.path.isabs(pp) else os.path.abspath(pp)
+        if os.path.isdir(target):
+            SKIP_DIRS = {".git", "node_modules", ".venv", "venv",
+                         "dist", "build", "__pycache__", ".cache"}
+            for root, dirs, files in os.walk(target, followlinks=False):
+                dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+                for f in files:
+                    for pat in patterns:
+                        if fnmatch.fnmatchcase(f, pat):
+                            rel = os.path.join(root, f)
+                            print(f"DENY:{pat}:{tool} on '{pp}' would expose {rel}")
+                            sys.exit(0)
+    except Exception:
+        pass  # fail open on traversal errors; Read/Bash hook layers still apply
+    print("OK")
+    sys.exit(0)
 elif tool == "Bash":
     hit = bash_hit(ti.get("command", "") or "")
     if hit:

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# block-credential-read.sh — PreToolUse hook (Claude Code).
+#
+# Blocks every tool call that would read or shell-access a credential file
+# (patterns in framework/credential-patterns.txt). Covers Read / Edit / Write /
+# NotebookEdit / Grep / Glob via tool_input paths, and Bash via command-string
+# scanning.
+#
+# Defense-in-depth: the .claude/settings.json permissions.deny list also
+# blocks these tools, but that list has known enforcement bugs in some Claude
+# Code versions. This hook is the reliable enforcement layer.
+
+INPUT=$(cat)
+
+# Resolve framework/credential-patterns.txt relative to this script — works
+# even when invoked through the .claude/hooks/ symlink (realpath strips it).
+SCRIPT_PATH="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0" 2>/dev/null || echo "$0")"
+PATTERNS_FILE="$(dirname "$SCRIPT_PATH")/../../credential-patterns.txt"
+
+if [ ! -f "$PATTERNS_FILE" ]; then
+  # Fail open — without patterns we cannot decide, so allow.
+  exit 0
+fi
+
+DECISION="$(INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
+import fnmatch, json, os, re, sys
+
+raw = os.environ.get("INPUT", "")
+try:
+    data = json.loads(raw)
+except Exception:
+    print("OK")
+    sys.exit(0)
+
+patterns = []
+with open(os.environ["PATTERNS_FILE"]) as f:
+    for line in f:
+        line = line.strip()
+        if line and not line.startswith("#"):
+            patterns.append(line)
+
+def path_hit(p):
+    """Return the matching pattern, or None. Checks the basename and each
+    path segment so .workatoignore-style globs apply at any depth."""
+    parts = p.replace("\\", "/").split("/")
+    candidates = [p, parts[-1]] + parts
+    for pat in patterns:
+        for cand in candidates:
+            if cand and fnmatch.fnmatchcase(cand, pat):
+                return pat
+    return None
+
+def pat_to_bash_re(p):
+    """Glob → regex that matches the pattern as a whole token inside a shell
+    command (preceded and followed by non-word characters or boundaries)."""
+    body = re.escape(p).replace(r"\*", r"\S*")
+    return re.compile(rf"(?<!\w){body}(?!\w)")
+
+def bash_hit(cmd):
+    for pat in patterns:
+        if pat_to_bash_re(pat).search(cmd):
+            return pat
+    return None
+
+tool = data.get("tool_name", "")
+ti = data.get("tool_input") or {}
+
+paths = []
+if tool in ("Read", "Edit", "Write"):
+    fp = ti.get("file_path")
+    if fp:
+        paths.append(fp)
+elif tool == "NotebookEdit":
+    np = ti.get("notebook_path")
+    if np:
+        paths.append(np)
+elif tool in ("Grep", "Glob"):
+    pp = ti.get("path")
+    if pp:
+        paths.append(pp)
+elif tool == "Bash":
+    hit = bash_hit(ti.get("command", "") or "")
+    if hit:
+        print(f"DENY:{hit}:bash command references credential file")
+        sys.exit(0)
+    print("OK")
+    sys.exit(0)
+
+for p in paths:
+    hit = path_hit(p)
+    if hit:
+        print(f"DENY:{hit}:{p}")
+        sys.exit(0)
+
+print("OK")
+PY
+)"
+
+case "$DECISION" in
+  DENY:*)
+    REASON="${DECISION#DENY:}"
+    echo "Blocked by workato-dev-kit credential guard: $REASON" >&2
+    echo "  Credential files (see kit/framework/credential-patterns.txt) must not be" >&2
+    echo "  read by the agent. If this is intentional, edit that file or temporarily" >&2
+    echo "  remove this hook from .claude/settings.json." >&2
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/framework/claude/settings.json
+++ b/framework/claude/settings.json
@@ -9,6 +9,15 @@
             "command": ".claude/hooks/validate-before-push.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash|Read|Edit|Write|NotebookEdit|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-credential-read.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -34,7 +43,18 @@
     ],
     "deny": [
       "Bash(rm -rf:*)",
-      "Bash(sudo:*)"
+      "Bash(sudo:*)",
+      "Read(./**/.workatoenv)",
+      "Read(./**/master.key)",
+      "Read(./**/settings.yaml)",
+      "Read(./**/settings.yaml.enc)",
+      "Read(./**/.resource-providers.yml)",
+      "Read(./**/.env)",
+      "Read(./**/.env.*)",
+      "Read(./**/*.key)",
+      "Read(./**/*.pem)",
+      "Read(./**/*.secret)",
+      "Read(./**/*.credential*)"
     ]
   }
 }

--- a/framework/codex/hooks.json
+++ b/framework/codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/block-credential-read.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# block-credential-read.sh — PreToolUse hook (Codex CLI, Bash-only).
+#
+# Codex CLI's PreToolUse hook only fires for the Bash tool — Read / Write /
+# Edit / web fetch / MCP tool calls do not trigger it (documented limitation).
+# So this hook can only block credential reads that happen through the shell
+# (e.g. `cat .workatoenv`, `grep token master.key`).
+#
+# The kit also ships `.codexignore` with the same patterns, but Codex
+# currently ignores that file (openai/codex#6530); this hook is the best
+# enforcement available today.
+
+INPUT=$(cat)
+
+SCRIPT_PATH="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0" 2>/dev/null || echo "$0")"
+PATTERNS_FILE="$(dirname "$SCRIPT_PATH")/../../credential-patterns.txt"
+
+if [ ! -f "$PATTERNS_FILE" ]; then
+  exit 0   # fail open — without patterns we cannot decide.
+fi
+
+DECISION="$(INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
+import json, os, re, sys
+
+raw = os.environ.get("INPUT", "")
+try:
+    data = json.loads(raw)
+except Exception:
+    print("OK")
+    sys.exit(0)
+
+# Codex PreToolUse fires only for Bash, but be defensive.
+if data.get("tool_name") != "Bash":
+    print("OK")
+    sys.exit(0)
+
+cmd = (data.get("tool_input") or {}).get("command", "") or ""
+
+patterns = []
+with open(os.environ["PATTERNS_FILE"]) as f:
+    for line in f:
+        line = line.strip()
+        if line and not line.startswith("#"):
+            patterns.append(line)
+
+for pat in patterns:
+    body = re.escape(pat).replace(r"\*", r"\S*")
+    if re.search(rf"(?<!\w){body}(?!\w)", cmd):
+        print(f"DENY:{pat}")
+        sys.exit(0)
+
+print("OK")
+PY
+)"
+
+case "$DECISION" in
+  DENY:*)
+    PAT="${DECISION#DENY:}"
+    echo "Blocked by workato-dev-kit credential guard: bash command references $PAT" >&2
+    echo "  Credential files (see kit/framework/credential-patterns.txt) must not be" >&2
+    echo "  read through the shell. Edit that file or temporarily remove this hook" >&2
+    echo "  from .codex/hooks.json if this is intentional." >&2
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/framework/credential-patterns.txt
+++ b/framework/credential-patterns.txt
@@ -1,0 +1,32 @@
+# workato-dev-kit — credential and secret patterns (single source of truth).
+#
+# Consumed by:
+#   - setup.sh                                  → .cursorignore, .geminiignore,
+#                                                 .codexignore at workspace root
+#                                                 and the Claude permissions.deny
+#                                                 list in .claude/settings.json
+#   - framework/claude/hooks/block-credential-read.sh   (Claude PreToolUse hook)
+#   - framework/codex/hooks/block-credential-read.sh    (Codex PreToolUse hook,
+#                                                        Bash-only — best Codex can do today)
+#
+# Gitignore-style globs, one pattern per line. Blank lines and lines starting
+# with `#` are ignored.
+
+# Workato Platform CLI — contains API tokens
+.workatoenv
+
+# Connector SDK secrets
+master.key
+settings.yaml
+settings.yaml.enc
+
+# Resource provider settings (environment-specific; can contain tokens)
+.resource-providers.yml
+
+# Generic env / secret files
+.env
+.env.*
+*.key
+*.pem
+*.secret
+*.credential*

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for the credential-block PreToolUse hooks.
+
+Covers framework/claude/hooks/block-credential-read.sh (every read-ish
+tool plus Bash) and framework/codex/hooks/block-credential-read.sh
+(Bash-only — the rest do not fire PreToolUse in Codex).
+
+Run with:
+    python3 scripts/tests/test_block_credential_read.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+CLAUDE_HOOK = REPO / "framework" / "claude" / "hooks" / "block-credential-read.sh"
+CODEX_HOOK = REPO / "framework" / "codex" / "hooks" / "block-credential-read.sh"
+
+
+def run(hook: Path, payload: dict | str) -> subprocess.CompletedProcess:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        ["bash", str(hook)],
+        input=body, capture_output=True, text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Claude hook — paths
+# ---------------------------------------------------------------------------
+
+def test_claude_blocks_read_workatoenv():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": "projects/foo/.workatoenv"}})
+    assert r.returncode == 2, r.stderr
+    assert ".workatoenv" in r.stderr
+
+
+def test_claude_blocks_read_master_key():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": "/abs/connectors/x/master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_read_settings_yaml_enc():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": "connectors/y/settings.yaml.enc"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_read_glob_dot_key():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": "secrets/id_rsa.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_read_dot_env_variant():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": ".env.production"}})
+    assert r.returncode == 2
+
+
+def test_claude_allows_normal_recipe_read():
+    r = run(CLAUDE_HOOK, {"tool_name": "Read",
+                          "tool_input": {"file_path": "projects/foo/Recipes/a.recipe.json"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_blocks_edit_credential():
+    r = run(CLAUDE_HOOK, {"tool_name": "Edit",
+                          "tool_input": {"file_path": "master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_write_credential():
+    r = run(CLAUDE_HOOK, {"tool_name": "Write",
+                          "tool_input": {"file_path": "settings.yaml"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_grep_inside_credential_dir():
+    r = run(CLAUDE_HOOK, {"tool_name": "Grep",
+                          "tool_input": {"path": "connectors/foo/master.key"}})
+    assert r.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Claude hook — Bash
+# ---------------------------------------------------------------------------
+
+def test_claude_blocks_bash_cat_workatoenv():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "cat projects/foo/.workatoenv | head"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_bash_glob_token():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "openssl pkey -in id_rsa.key -text"}})
+    assert r.returncode == 2
+
+
+def test_claude_allows_bash_ls_projects():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "ls projects/"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_allows_bash_no_creds():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git status"}})
+    assert r.returncode == 0, r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Claude hook — fail-open on malformed input
+# ---------------------------------------------------------------------------
+
+def test_claude_allows_malformed_json():
+    r = run(CLAUDE_HOOK, "not-json{")
+    assert r.returncode == 0, r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Codex hook (Bash-only)
+# ---------------------------------------------------------------------------
+
+def test_codex_blocks_bash_grep_master_key():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "grep token connectors/x/master.key"}})
+    assert r.returncode == 2
+
+
+def test_codex_blocks_bash_cat_workatoenv():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "cat .workatoenv"}})
+    assert r.returncode == 2
+
+
+def test_codex_allows_non_bash_read():
+    # Codex PreToolUse only fires for Bash; if a non-Bash payload somehow
+    # arrives, the hook must not block (it has no signal to act on).
+    r = run(CODEX_HOOK, {"tool_name": "Read",
+                         "tool_input": {"file_path": ".workatoenv"}})
+    assert r.returncode == 0
+
+
+def test_codex_allows_bash_no_creds():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "git status"}})
+    assert r.returncode == 0
+
+
+def test_codex_allows_malformed_json():
+    r = run(CODEX_HOOK, "{broken")
+    assert r.returncode == 0
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -90,6 +90,40 @@ def test_claude_blocks_grep_inside_credential_dir():
     assert r.returncode == 2
 
 
+def test_claude_blocks_grep_on_dir_containing_credential(tmp_path=None):
+    """Codex P1 regression: Grep(path=<dir>) must block if the directory
+    contains a credential file, even when the path itself is innocent."""
+    import os, tempfile
+    with tempfile.TemporaryDirectory() as d:
+        cred_dir = Path(d) / "connectors" / "x"
+        cred_dir.mkdir(parents=True)
+        (cred_dir / "master.key").write_text("secret")
+        (cred_dir / "connector.rb").write_text("# code")
+        r = run(CLAUDE_HOOK, {"tool_name": "Grep",
+                              "tool_input": {"path": str(Path(d) / "connectors")}})
+        assert r.returncode == 2, r.stderr
+        assert "master.key" in r.stderr
+
+
+def test_claude_blocks_glob_on_dir_containing_credential():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "settings.yaml.enc").write_text("ciphertext")
+        r = run(CLAUDE_HOOK, {"tool_name": "Glob",
+                              "tool_input": {"path": str(d), "pattern": "**/*.rb"}})
+        assert r.returncode == 2, r.stderr
+
+
+def test_claude_allows_grep_on_clean_dir():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "a.recipe.json").write_text("{}")
+        (Path(d) / "b.recipe.json").write_text("{}")
+        r = run(CLAUDE_HOOK, {"tool_name": "Grep",
+                              "tool_input": {"path": str(d)}})
+        assert r.returncode == 0, r.stderr
+
+
 # ---------------------------------------------------------------------------
 # Claude hook — Bash
 # ---------------------------------------------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -244,15 +244,18 @@ PY
   echo "  ✓ Created .claude/settings.json (from kit template)"
 else
   # Existing settings: migrate hook paths written by older setup.sh to the
-  # framework/claude/ layout. Leave hooks the user added (non-kit ones)
-  # alone.
+  # framework/claude/ layout, and top up the credential-guard hook + the
+  # permissions.deny credential rules. Leave hooks / rules the user added
+  # (non-kit ones) alone.
   USER_SETTINGS="$USER_SETTINGS" KIT_REL="$KIT_REL" \
+    CRED_PATTERNS_FILE="$KIT_DIR/framework/credential-patterns.txt" \
     python3 <<'PY'
 import json
 import os
 
 user_settings = os.environ['USER_SETTINGS']
 kit_rel = os.environ['KIT_REL']
+patterns_file = os.environ.get('CRED_PATTERNS_FILE', '')
 old_prefix = kit_rel + '/.claude/hooks/'
 new_prefix = kit_rel + '/framework/claude/hooks/'
 
@@ -268,13 +271,56 @@ for event in s.get('hooks', {}).values():
                 hook['command'] = new_prefix + cmd[len(old_prefix):]
                 migrated += 1
 
-if migrated:
+# Top up the block-credential-read PreToolUse hook.
+hooks_root = s.setdefault('hooks', {})
+pre = hooks_root.setdefault('PreToolUse', [])
+def _has_cred_hook(pre_list):
+    for group in pre_list:
+        for h in group.get('hooks', []):
+            if 'block-credential-read' in h.get('command', ''):
+                return True
+    return False
+
+added_hook = False
+if not _has_cred_hook(pre):
+    pre.append({
+        'matcher': 'Bash|Read|Edit|Write|NotebookEdit|Grep|Glob',
+        'hooks': [{
+            'type': 'command',
+            'command': new_prefix + 'block-credential-read.sh',
+        }],
+    })
+    added_hook = True
+
+# Top up permissions.deny with Read(./**/<glob>) for every credential pattern.
+perms = s.setdefault('permissions', {})
+deny = perms.setdefault('deny', [])
+added_deny = 0
+if patterns_file and os.path.isfile(patterns_file):
+    with open(patterns_file) as pf:
+        for line in pf:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            rule = f'Read(./**/{line})'
+            if rule not in deny:
+                deny.append(rule)
+                added_deny += 1
+
+if migrated or added_hook or added_deny:
     with open(user_settings, 'w') as f:
         json.dump(s, f, indent=2, ensure_ascii=False)
         f.write('\n')
-    print(f'  ✓ Migrated {migrated} kit hook path(s) in .claude/settings.json (.claude/hooks/ → framework/claude/hooks/)')
+    msgs = []
+    if migrated:
+        msgs.append(f'migrated {migrated} kit hook path(s)')
+    if added_hook:
+        msgs.append('added block-credential-read PreToolUse hook')
+    if added_deny:
+        msgs.append(f'added {added_deny} credential deny rule(s)')
+    print('  ✓ Updated .claude/settings.json (' + '; '.join(msgs) + ')')
 else:
-    print('  EXISTS .claude/settings.json (no kit hook paths needed migrating — merge manually if other changes are needed)')
+    print('  EXISTS .claude/settings.json (kit entries already present)')
 PY
 fi
 
@@ -338,6 +384,52 @@ if [ $added -gt 0 ]; then
   echo "  ✓ Added $added entries to .gitignore"
 else
   echo "  ✓ .gitignore already up to date"
+fi
+
+# ── 7b. Per-editor credential ignore files ───────────────────
+# Distribute the credential glob list from framework/credential-patterns.txt
+# to each editor's ignore mechanism so the agent will not even index / read
+# credentials:
+#   .cursorignore   — Cursor: "hard block" (.cursorindexingignore is partial).
+#   .geminiignore   — Gemini CLI: gitignore-style; respected by tools.
+#   .codexignore    — Codex CLI: shipped for forward-compat; Codex currently
+#                     does not respect it (openai/codex#6530), so the .codex/
+#                     hooks/block-credential-read.sh hook (Bash-only) is the
+#                     enforcement layer available today.
+# Claude has no working ignore-file convention — credential reads are blocked
+# by the .claude/hooks/block-credential-read.sh PreToolUse hook and the
+# permissions.deny list in .claude/settings.json (section 5).
+CRED_PATTERNS_FILE="$KIT_DIR/framework/credential-patterns.txt"
+if [ -f "$CRED_PATTERNS_FILE" ]; then
+  echo ""
+  echo "--- Setting up per-editor credential ignore files ---"
+  add_credential_patterns() {
+    local target="$1"
+    local header="$2"
+    touch "$target"
+    local added=0
+    while IFS= read -r line; do
+      case "$line" in '#'*|'') continue ;; esac
+      if ! grep -qxF "$line" "$target" 2>/dev/null; then
+        if [ $added -eq 0 ] && [ -n "$header" ] && ! grep -qF "$header" "$target" 2>/dev/null; then
+          { [ -s "$target" ] && echo ""; echo "$header"; } >> "$target"
+        fi
+        echo "$line" >> "$target"
+        added=$((added + 1))
+      fi
+    done < "$CRED_PATTERNS_FILE"
+    local name
+    name="$(basename "$target")"
+    if [ $added -gt 0 ]; then
+      echo "  ✓ Added $added credential entries to $name"
+    else
+      echo "  ✓ $name already covers credentials"
+    fi
+  }
+  HEADER="# workato-dev-kit credential patterns (managed by kit/setup.sh)"
+  add_credential_patterns "$WORKSPACE_ROOT/.cursorignore"  "$HEADER"
+  add_credential_patterns "$WORKSPACE_ROOT/.geminiignore"  "$HEADER"
+  add_credential_patterns "$WORKSPACE_ROOT/.codexignore"   "$HEADER"
 fi
 
 # ── 8. Cursor distribution (copy mode) ───────────────────────
@@ -483,6 +575,24 @@ if [ -d "$KIT_DIR/framework/codex" ]; then
       "$KIT_DIR/framework/codex/agents" \
       "$WORKSPACE_ROOT/.codex/agents" \
       "../../$KIT_REL/framework/codex/agents"
+  fi
+
+  # Hooks → .codex/hooks/<file>.sh (referenced by .codex/hooks.json below).
+  if [ -d "$KIT_DIR/framework/codex/hooks" ]; then
+    echo "--- Setting up .codex/hooks/ ---"
+    prune_stale_links "$WORKSPACE_ROOT/.codex/hooks" "framework/codex/hooks/"
+    link_files_in_dir \
+      "$KIT_DIR/framework/codex/hooks" \
+      "$WORKSPACE_ROOT/.codex/hooks" \
+      "../../$KIT_REL/framework/codex/hooks"
+  fi
+
+  # .codex/hooks.json — initial copy only, never overwrites a user-customised
+  # hooks config.
+  if [ -f "$KIT_DIR/framework/codex/hooks.json" ] && [ ! -f "$WORKSPACE_ROOT/.codex/hooks.json" ]; then
+    mkdir -p "$WORKSPACE_ROOT/.codex"
+    cp "$KIT_DIR/framework/codex/hooks.json" "$WORKSPACE_ROOT/.codex/hooks.json"
+    echo "  ✓ Created .codex/hooks.json (from kit template)"
   fi
 fi
 


### PR DESCRIPTION
## 背景

クレデンシャルファイル（`.workatoenv` `master.key` `settings.yaml(.enc)` `.resource-providers.yml` `.env*` `*.key` `*.pem` `*.secret` `*.credential*`）は `.gitignore` で**コミットだけ**は防いでいたが、エージェントによる読み取り自体は何も塞いでいなかった。

## 調査結果（実装方針の前提）

> 「`.claudeignore` に入れる」案は機能しない — `.claudeignore` は Claude が幻覚で答えるだけで実在しない。`permissions.deny` も既知バグで未強制（issue #6699）。

エディタ別の信頼できる仕組み:

| エディタ | 信頼できる機構 |
|---|---|
| Claude Code | **PreToolUse フック**（唯一信頼可能）+ `permissions.deny`（保険） |
| Cursor | `.cursorignore`（hard block） |
| Gemini CLI | `.geminiignore`（gitignore 構文、ツールが尊重） |
| Codex CLI | `.codexignore`（**現状未強制**, openai/codex#6530）+ **Bash 限定 PreToolUse フック**（公式制限で Read/Write/MCP 等は発火しない、部分保護） |

## 変更内容

クレデンシャル glob の**単一ソース** `framework/credential-patterns.txt` を起点に、各エディタへ展開:

- **`framework/claude/hooks/block-credential-read.sh`** — Claude PreToolUse フック。Read/Edit/Write/NotebookEdit/Grep/Glob/Bash すべてを横取りし、クレデンシャル該当時 `exit 2` でブロック
- **`framework/codex/hooks/block-credential-read.sh`** + **`framework/codex/hooks.json`** — Codex PreToolUse フック（Bash 限定の部分保護）
- **`framework/claude/settings.json`** — PreToolUse 配線 + `Read(./**/<glob>)` の `deny` ルール（保険）
- **`setup.sh`** —
  - 新セクション 7b: `framework/credential-patterns.txt` から `.cursorignore` / `.geminiignore` / `.codexignore` に冪等追記
  - セクション 9: `.codex/hooks/` symlink + `.codex/hooks.json` 初回コピー
  - セクション 5: 既存 settings.json への migrator を拡張し、block-credential-read フックと credential deny ルールを top-up（既存ユーザーも次回 setup で保護される）

## テスト

新規 **`scripts/tests/test_block_credential_read.py`** に19ケース:
- Claude: Read/Edit/Write/Grep/Glob/Bash の各クレデンシャル検出
- Claude: 正常 Read・Bash は通過
- Claude/Codex: malformed JSON は fail-open
- Codex: Bash 限定発火、grep/cat マッチ

実環境で setup.sh の冪等性・既存 settings.json migration・各 ignore ファイル生成も確認。

全テスト通過: **19/19**（hooks 新規）+ 10/10 + 21/21 + 11/11 + 44/44。

## 注意点

- **Codex は完全保護不可**（公式制限）。Bash 経由の漏洩は塞げるが、モデル内蔵 Read ツール経由のクレデンシャル読み取りは現状どの方法でも塞げない。前方互換で `.codexignore` も配置。
- Claude の `permissions.deny` は v1.0.93 時点でバグあり。フックが実質的な強制レイヤ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)