### PR TITLE
docs(uuid): document 36-character limit on Step uuid (#155)

### DIFF
--- a/docs/logic/if-conditions.md
+++ b/docs/logic/if-conditions.md
@@ -107,3 +107,7 @@ ELSE → actions                   ← default branch
 - Use `else` for the default branch without a condition (using `elsif` without a condition is incorrect)
 - `elsif` can be chained multiple times (`if` → `elsif` → `elsif` → `else`)
 
+### `uuid` constraint
+
+Each entry under `conditions[]` has a `uuid` field. It is a UUID v4 and must be **36 characters or fewer** — same limit as the step-level `uuid`. Generate with `uuidgen` and use the raw output (do not add a prefix). Push rejects longer values.
+

--- a/docs/logic/triggers.md
+++ b/docs/logic/triggers.md
@@ -79,3 +79,5 @@ Apply additional filtering after events are fetched.
 ```
 
 See `@docs/logic/if-conditions.md` for the full list of condition operators.
+
+Each entry's `uuid` is a UUID v4 and must be **36 characters or fewer** (push rejects longer values). Generate with `uuidgen` and use the raw 36-character output without prefixes.

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -1124,7 +1124,7 @@ Each step has:
 | `block` | array | Array of child steps (nestable). |
 | `filter` | object | Conditional filter (optional). |
 | `comment` | string | Step comment (optional). |
-| `uuid` | string | UUID v4. |
+| `uuid` | string | UUID v4. **36 characters or fewer** (do not prefix or extend it — push rejects longer values). The same limit applies to `uuid` fields inside `filter.conditions[]` and `input.conditions[]`. |
 | `extended_output_schema` | array/null | Custom output schema. **Recommended on both triggers and actions** — omitting it forces a UI refresh. |
 | `extended_input_schema` | array/null | Custom input schema. Required on `return_result` and similar. |
 

--- a/framework/claude/rules/workato-recipe-format.md
+++ b/framework/claude/rules/workato-recipe-format.md
@@ -50,7 +50,7 @@ Each step has:
 | `block` | array | Array of child steps (nestable). |
 | `filter` | object | Conditional filter (optional). |
 | `comment` | string | Step comment (optional). |
-| `uuid` | string | UUID v4. |
+| `uuid` | string | UUID v4. **36 characters or fewer** (do not prefix or extend it — push rejects longer values). The same limit applies to `uuid` fields inside `filter.conditions[]` and `input.conditions[]`. |
 | `extended_output_schema` | array/null | Custom output schema. **Recommended on both triggers and actions** — omitting it forces a UI refresh. |
 | `extended_input_schema` | array/null | Custom input schema. Required on `return_result` and similar. |
 

--- a/framework/claude/skills/create-workflow-app/SKILL.md
+++ b/framework/claude/skills/create-workflow-app/SKILL.md
@@ -92,7 +92,7 @@ File layout follows `@.claude/rules/workato-project-structure.md`.
 ```
 
 - The three system field UUIDs are common across every table.
-- Generate a fresh UUID with `uuidgen` for each user-defined field.
+- Generate a fresh UUID with `uuidgen` for each user-defined field. Use the raw 36-character output as-is — **do not add a prefix or suffix** (e.g. no `field-<uuid>`). The same 36-character limit applies to recipe step `uuid` fields; push rejects anything longer.
 - `type`: `short-text`, `long-text`, `number`, `boolean`, `date`, `date-time`, `file`, `relation`.
 
 ### 2. Pages/lcap_page.json (page definitions)

--- a/framework/claude/skills/validate-recipe/SKILL.md
+++ b/framework/claude/skills/validate-recipe/SKILL.md
@@ -22,6 +22,7 @@ Validates the structure of Workato JSON files.
 - [ ] Every step has `number`, `provider`, `name`, `keyword`, `uuid`
 - [ ] `number` values are sequential
 - [ ] `uuid` is a valid UUID v4
+- [ ] `uuid` is 36 characters or fewer (push rejects longer values; applies to step `uuid`, `filter.conditions[].uuid`, and `input.conditions[].uuid`)
 - [ ] Steps inside `block` recursively follow the same structure
 - [ ] Every `provider` in `config` is actually used by the recipe
 - [ ] Datapill references (`_dp`) point at a real step (`provider` + `line`)
@@ -50,6 +51,7 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ❌ file3.recipe.json — 1 error
   - E001: code.keyword is not "trigger"
 ```

--- a/framework/claude/skills/validate-recipe/SKILL.md
+++ b/framework/claude/skills/validate-recipe/SKILL.md
@@ -51,9 +51,9 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
-  - E002: Step 5 uuid exceeds 36 characters (push will fail)
-❌ file3.recipe.json — 1 error
+❌ file3.recipe.json — 2 errors
   - E001: code.keyword is not "trigger"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ```
 
 Severity: ❌ Error (likely to fail on push) > ⚠️ Warning (works but discouraged) > ℹ️ Info (informational).

--- a/framework/codex/skills/create-workflow-app/SKILL.md
+++ b/framework/codex/skills/create-workflow-app/SKILL.md
@@ -92,7 +92,7 @@ File layout follows `AGENTS.md`.
 ```
 
 - The three system field UUIDs are common across every table.
-- Generate a fresh UUID with `uuidgen` for each user-defined field.
+- Generate a fresh UUID with `uuidgen` for each user-defined field. Use the raw 36-character output as-is — **do not add a prefix or suffix** (e.g. no `field-<uuid>`). The same 36-character limit applies to recipe step `uuid` fields; push rejects anything longer.
 - `type`: `short-text`, `long-text`, `number`, `boolean`, `date`, `date-time`, `file`, `relation`.
 
 ### 2. Pages/lcap_page.json (page definitions)

--- a/framework/codex/skills/validate-recipe/SKILL.md
+++ b/framework/codex/skills/validate-recipe/SKILL.md
@@ -22,6 +22,7 @@ Validates the structure of Workato JSON files.
 - [ ] Every step has `number`, `provider`, `name`, `keyword`, `uuid`
 - [ ] `number` values are sequential
 - [ ] `uuid` is a valid UUID v4
+- [ ] `uuid` is 36 characters or fewer (push rejects longer values; applies to step `uuid`, `filter.conditions[].uuid`, and `input.conditions[].uuid`)
 - [ ] Steps inside `block` recursively follow the same structure
 - [ ] Every `provider` in `config` is actually used by the recipe
 - [ ] Datapill references (`_dp`) point at a real step (`provider` + `line`)
@@ -50,6 +51,7 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ❌ file3.recipe.json — 1 error
   - E001: code.keyword is not "trigger"
 ```

--- a/framework/codex/skills/validate-recipe/SKILL.md
+++ b/framework/codex/skills/validate-recipe/SKILL.md
@@ -51,9 +51,9 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
-  - E002: Step 5 uuid exceeds 36 characters (push will fail)
-❌ file3.recipe.json — 1 error
+❌ file3.recipe.json — 2 errors
   - E001: code.keyword is not "trigger"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ```
 
 Severity: ❌ Error (likely to fail on push) > ⚠️ Warning (works but discouraged) > ℹ️ Info (informational).

--- a/framework/cursor/rules/workato-recipe-format.mdc
+++ b/framework/cursor/rules/workato-recipe-format.mdc
@@ -51,7 +51,7 @@ Each step has:
 | `block` | array | Array of child steps (nestable). |
 | `filter` | object | Conditional filter (optional). |
 | `comment` | string | Step comment (optional). |
-| `uuid` | string | UUID v4. |
+| `uuid` | string | UUID v4. **36 characters or fewer** (do not prefix or extend it — push rejects longer values). The same limit applies to `uuid` fields inside `filter.conditions[]` and `input.conditions[]`. |
 | `extended_output_schema` | array/null | Custom output schema. **Recommended on both triggers and actions** — omitting it forces a UI refresh. |
 | `extended_input_schema` | array/null | Custom input schema. Required on `return_result` and similar. |
 

--- a/framework/cursor/skills/create-workflow-app/SKILL.md
+++ b/framework/cursor/skills/create-workflow-app/SKILL.md
@@ -92,7 +92,7 @@ File layout follows `.cursor/rules/workato-project-structure.mdc`.
 ```
 
 - The three system field UUIDs are common across every table.
-- Generate a fresh UUID with `uuidgen` for each user-defined field.
+- Generate a fresh UUID with `uuidgen` for each user-defined field. Use the raw 36-character output as-is — **do not add a prefix or suffix** (e.g. no `field-<uuid>`). The same 36-character limit applies to recipe step `uuid` fields; push rejects anything longer.
 - `type`: `short-text`, `long-text`, `number`, `boolean`, `date`, `date-time`, `file`, `relation`.
 
 ### 2. Pages/lcap_page.json (page definitions)

--- a/framework/cursor/skills/validate-recipe/SKILL.md
+++ b/framework/cursor/skills/validate-recipe/SKILL.md
@@ -22,6 +22,7 @@ Validates the structure of Workato JSON files.
 - [ ] Every step has `number`, `provider`, `name`, `keyword`, `uuid`
 - [ ] `number` values are sequential
 - [ ] `uuid` is a valid UUID v4
+- [ ] `uuid` is 36 characters or fewer (push rejects longer values; applies to step `uuid`, `filter.conditions[].uuid`, and `input.conditions[].uuid`)
 - [ ] Steps inside `block` recursively follow the same structure
 - [ ] Every `provider` in `config` is actually used by the recipe
 - [ ] Datapill references (`_dp`) point at a real step (`provider` + `line`)
@@ -50,6 +51,7 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ❌ file3.recipe.json — 1 error
   - E001: code.keyword is not "trigger"
 ```

--- a/framework/cursor/skills/validate-recipe/SKILL.md
+++ b/framework/cursor/skills/validate-recipe/SKILL.md
@@ -51,9 +51,9 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
-  - E002: Step 5 uuid exceeds 36 characters (push will fail)
-❌ file3.recipe.json — 1 error
+❌ file3.recipe.json — 2 errors
   - E001: code.keyword is not "trigger"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ```
 
 Severity: ❌ Error (likely to fail on push) > ⚠️ Warning (works but discouraged) > ℹ️ Info (informational).

--- a/framework/gemini/skills/create-workflow-app/SKILL.md
+++ b/framework/gemini/skills/create-workflow-app/SKILL.md
@@ -92,7 +92,7 @@ File layout follows `GEMINI.md`.
 ```
 
 - The three system field UUIDs are common across every table.
-- Generate a fresh UUID with `uuidgen` for each user-defined field.
+- Generate a fresh UUID with `uuidgen` for each user-defined field. Use the raw 36-character output as-is — **do not add a prefix or suffix** (e.g. no `field-<uuid>`). The same 36-character limit applies to recipe step `uuid` fields; push rejects anything longer.
 - `type`: `short-text`, `long-text`, `number`, `boolean`, `date`, `date-time`, `file`, `relation`.
 
 ### 2. Pages/lcap_page.json (page definitions)

--- a/framework/gemini/skills/validate-recipe/SKILL.md
+++ b/framework/gemini/skills/validate-recipe/SKILL.md
@@ -22,6 +22,7 @@ Validates the structure of Workato JSON files.
 - [ ] Every step has `number`, `provider`, `name`, `keyword`, `uuid`
 - [ ] `number` values are sequential
 - [ ] `uuid` is a valid UUID v4
+- [ ] `uuid` is 36 characters or fewer (push rejects longer values; applies to step `uuid`, `filter.conditions[].uuid`, and `input.conditions[].uuid`)
 - [ ] Steps inside `block` recursively follow the same structure
 - [ ] Every `provider` in `config` is actually used by the recipe
 - [ ] Datapill references (`_dp`) point at a real step (`provider` + `line`)
@@ -50,6 +51,7 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ❌ file3.recipe.json — 1 error
   - E001: code.keyword is not "trigger"
 ```

--- a/framework/gemini/skills/validate-recipe/SKILL.md
+++ b/framework/gemini/skills/validate-recipe/SKILL.md
@@ -51,9 +51,9 @@ Validates the structure of Workato JSON files.
 ⚠️  file2.recipe.json — 2 warnings
   - W001: Step 3 is missing its uuid
   - W002: config contains unused provider "slack"
-  - E002: Step 5 uuid exceeds 36 characters (push will fail)
-❌ file3.recipe.json — 1 error
+❌ file3.recipe.json — 2 errors
   - E001: code.keyword is not "trigger"
+  - E002: Step 5 uuid exceeds 36 characters (push will fail)
 ```
 
 Severity: ❌ Error (likely to fail on push) > ⚠️ Warning (works but discouraged) > ℹ️ Info (informational).


### PR DESCRIPTION
Closes #155.

## What

Workato's recipe push rejects `uuid` values that exceed **36 characters**, but the kit's knowledge only said "UUID v4." If you prefix the output of `uuidgen` (e.g. `field-<uuid>`) you silently break pushes. This PR surfaces the constraint in every place a step or condition `uuid` is documented.

## Changes

- `framework/claude/rules/workato-recipe-format.md` — Step field table: `uuid` description gains the 36-character cap and notes it applies to `filter.conditions[].uuid` / `input.conditions[].uuid` too.
- `framework/claude/skills/validate-recipe/SKILL.md` — Add a checklist item for the length constraint and an `E002` sample line in the example output.
- `framework/claude/skills/create-workflow-app/SKILL.md` — Spell out that the `uuidgen` output must be used as-is (no prefix/suffix); cross-reference the step `uuid` cap.
- `docs/logic/if-conditions.md` / `docs/logic/triggers.md` — Add a short note next to the condition `uuid` examples so per-logic-doc lookups also surface the rule.

Regenerated `framework/{cursor,codex,gemini}/` and `framework/AGENTS.md` via `python3 scripts/sync_agents.py` (CI requires sync).

## Notes / open questions from the issue

The exact failure phase (push vs. validate vs. run) was raised in the issue. I documented it as "push rejects" since that matches the empirical case mentioned; if validate / runtime also catches it we can expand the wording in a follow-up. The Workflow App data-table field `id` is a separate field, but it's also a UUID v4 and tends to be generated the same way, so I co-located the "no prefix" guidance there to prevent the same mistake from leaking in via that codepath.

## Verification

- `python3 scripts/sync_agents.py` — clean (all generated files refreshed).
- Diff is documentation-only; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)