### PR TITLE
docs(if-conditions): fix operator internal names and JSON structure ordering (#154)

### DIFF
--- a/docs/logic/if-conditions.md
+++ b/docs/logic/if-conditions.md
@@ -40,7 +40,16 @@ All 14 values were verified by building a recipe that exercises every operator a
 | Is present | `present` | All | A value exists (null/empty string is false). **`present`, not `is_present`** |
 | Is not present | `blank` | All | No value exists. **`blank` — note the UI label is "Is not present"** |
 
-Unary operators (`is_true`, `is_not_true`, `present`, `blank`) still require `rhs` in the JSON — set it to an empty string (`"rhs": ""`).
+Unary operators (`is_true`, `is_not_true`, `present`, `blank`) still require `rhs` in the JSON — set it to an empty string (`"rhs": ""`). Minimal example:
+
+```json
+{
+  "operand": "present",
+  "lhs": "#{_dp('...')}",
+  "rhs": "",
+  "uuid": "..."
+}
+```
 
 > The Workato public docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) presents short identifiers such as `eq`, `not_eq`, `gt`, `lt`, and `not_present`. **Those are not what the recipe JSON contains.** Use the JSON values in the table above.
 
@@ -64,6 +73,8 @@ Unary operators (`is_true`, `is_not_true`, `present`, `blank`) still require `rh
 
 Real recipe JSON places the `input` fields in the order `type`, `operand`, `conditions` (JSON object key order is cosmetic, but matching what `workato pull` writes makes diffs cleaner).
 
+Every step (`if` / `elsif` / `else` and the inner actions) carries its own top-level `uuid` — the examples below show it explicitly so the field doesn't look optional.
+
 ### if (conditional branch)
 ```json
 {
@@ -84,7 +95,8 @@ Real recipe JSON places the `input` fields in the order `type`, `operand`, `cond
   "block": [
     /* actions when true */
     { /* else or elsif — placed at the end of block */ }
-  ]
+  ],
+  "uuid": "..."
 }
 ```
 
@@ -111,7 +123,8 @@ Real recipe JSON places the `input` fields in the order `type`, `operand`, `cond
     "operand": "and",
     "conditions": [ /* conditions required */ ]
   },
-  "block": [ /* actions when the condition is true */ ]
+  "block": [ /* actions when the condition is true */ ],
+  "uuid": "..."
 }
 ```
 

--- a/docs/logic/if-conditions.md
+++ b/docs/logic/if-conditions.md
@@ -19,33 +19,39 @@ ELSE → actions                   ← default branch
 
 ### Condition operators (14)
 
-| Operator | Supported types | Description |
-|---|---|---|
-| `contains` | Array, String | Contains the value (case-sensitive) |
-| `doesn't contain` | Array, String | Does not contain the value |
-| `starts with` | String | Starts with the value |
-| `doesn't start with` | String | Does not start with the value |
-| `ends with` | String | Ends with the value |
-| `doesn't end with` | String | Does not end with the value |
-| `equals` | All | Exact match (numerics compared as floats) |
-| `doesn't equal` | All | Does not match |
-| `greater than` | String, Integer, Number | Greater than (strings compared by ASCII) |
-| `less than` | String, Integer, Number | Less than |
-| `is true` | Boolean | Is true |
-| `is not true` | Boolean | Is not true |
-| `is present` | All | A value exists (null/empty string is false) |
-| `is not present` | All | No value exists |
+The first column is the label shown in the Workato UI. The second column is the literal string written to the recipe JSON's `operand` field — this is what you put in `conditions[].operand` when generating recipes.
+
+| UI label | JSON `operand` | Supported types | Description |
+|---|---|---|---|
+| Contains | `contains` ✓ | Array, String | Contains the value (case-sensitive) |
+| Doesn't contain | `not_contains` | Array, String | Does not contain the value |
+| Starts with | `starts_with` | String | Starts with the value |
+| Doesn't start with | `not_starts_with` | String | Does not start with the value |
+| Ends with | `ends_with` | String | Ends with the value |
+| Doesn't end with | `not_ends_with` | String | Does not end with the value |
+| Equals | `equals_to` ✓ | All | Exact match (numerics compared as floats) — **note: `equals_to`, not `equals` or `eq`** |
+| Doesn't equal | `not_equals` | All | Does not match |
+| Greater than | `greater_than` | String, Integer, Number | Greater than (strings compared by ASCII) |
+| Less than | `less_than` | String, Integer, Number | Less than |
+| Is true | `is_true` ✓ | Boolean | Is true |
+| Is not true | `is_false` | Boolean | Is not true (JSON value is `is_false`) |
+| Is present | `is_present` | All | A value exists (null/empty string is false) |
+| Is not present | `is_not_present` | All | No value exists |
+
+✓ = directly verified against pulled recipe JSON in this repo. The other values come from the kit's accumulated learning (see `@.claude/rules/workato-recipe-format.md`). If you encounter a discrepancy, capture the JSON and update both tables.
+
+> The Workato public docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) presents short identifiers such as `eq`, `not_eq`, `gt`, `lt`, `present`, `not_present`, and `is_not_true`. **Those are not what the recipe JSON contains.** Use the JSON values in the table above.
 
 ### Notes
 
 - All text comparisons are **case-sensitive**
 - Comparing a null value with `greater_than` / `less_than` raises an error → combine with `is_present`
-- `equals` converts strings to floats for numeric comparison. Watch out for octal notation (`"0123"` → `83`). Floats with more than 15 digits may lose precision
-- `contains` / `does not contain` return false for null (no error)
+- `equals_to` converts strings to floats for numeric comparison. Watch out for octal notation (`"0123"` → `83`). Floats with more than 15 digits may lose precision
+- `contains` / `not_contains` return false for null (no error)
 - `starts_with` / `ends_with` raise a trigger error when comparing non-string types directly (datapills are auto-converted)
-- Multiple conditions can be combined with `and` / `or`
+- Multiple conditions are combined with the top-level `input.operand` field set to `"and"` or `"or"`
 - Conditions are used in three places: IF branches, While loops, and trigger filters
-- Trigger `filter` uses the same condition structure
+- Trigger `filter` uses the same condition structure (see `@docs/logic/triggers.md`)
 
 ---
 
@@ -54,22 +60,24 @@ ELSE → actions                   ← default branch
 > The structural details below are not in the official Workato documentation;
 > they are findings derived from analysing actual recipe JSON.
 
+Real recipe JSON places the `input` fields in the order `type`, `operand`, `conditions` (JSON object key order is cosmetic, but matching what `workato pull` writes makes diffs cleaner).
+
 ### if (conditional branch)
 ```json
 {
   "number": N,
   "keyword": "if",
   "input": {
+    "type": "compound",
+    "operand": "and",
     "conditions": [
       {
-        "operand": "contains",
+        "operand": "equals_to",
         "lhs": "#{_dp('...')}",
         "rhs": "value",
         "uuid": "..."
       }
-    ],
-    "operand": "and",
-    "type": "compound"
+    ]
   },
   "block": [
     /* actions when true */
@@ -93,9 +101,9 @@ ELSE → actions                   ← default branch
   "number": N,
   "keyword": "elsif",
   "input": {
-    "conditions": [ /* conditions required */ ],
+    "type": "compound",
     "operand": "and",
-    "type": "compound"
+    "conditions": [ /* conditions required */ ]
   },
   "block": [ /* actions when the condition is true */ ]
 }

--- a/docs/logic/if-conditions.md
+++ b/docs/logic/if-conditions.md
@@ -21,31 +21,33 @@ ELSE → actions                   ← default branch
 
 The first column is the label shown in the Workato UI. The second column is the literal string written to the recipe JSON's `operand` field — this is what you put in `conditions[].operand` when generating recipes.
 
+All 14 values were verified by building a recipe that exercises every operator and reading back the recipe API response (`code` field). Several deviate noticeably from the UI label — in particular **`not_equals_to`** (not `not_equals`), **`present`** (not `is_present`), and **`blank`** (not `is_not_present` — the UI label is "Is not present").
+
 | UI label | JSON `operand` | Supported types | Description |
 |---|---|---|---|
-| Contains | `contains` ✓ | Array, String | Contains the value (case-sensitive) |
+| Contains | `contains` | Array, String | Contains the value (case-sensitive) |
 | Doesn't contain | `not_contains` | Array, String | Does not contain the value |
 | Starts with | `starts_with` | String | Starts with the value |
 | Doesn't start with | `not_starts_with` | String | Does not start with the value |
 | Ends with | `ends_with` | String | Ends with the value |
 | Doesn't end with | `not_ends_with` | String | Does not end with the value |
-| Equals | `equals_to` ✓ | All | Exact match (numerics compared as floats) — **note: `equals_to`, not `equals` or `eq`** |
-| Doesn't equal | `not_equals` | All | Does not match |
+| Equals | `equals_to` | All | Exact match (numerics compared as floats). **`equals_to`, not `equals` or `eq`** |
+| Doesn't equal | `not_equals_to` | All | Does not match. **`not_equals_to`, not `not_equals`** |
 | Greater than | `greater_than` | String, Integer, Number | Greater than (strings compared by ASCII) |
 | Less than | `less_than` | String, Integer, Number | Less than |
-| Is true | `is_true` ✓ | Boolean | Is true |
-| Is not true | `is_false` | Boolean | Is not true (JSON value is `is_false`) |
-| Is present | `is_present` | All | A value exists (null/empty string is false) |
-| Is not present | `is_not_present` | All | No value exists |
+| Is true | `is_true` | Boolean | Is true |
+| Is not true | `is_not_true` | Boolean | Is not true |
+| Is present | `present` | All | A value exists (null/empty string is false). **`present`, not `is_present`** |
+| Is not present | `blank` | All | No value exists. **`blank` — note the UI label is "Is not present"** |
 
-✓ = directly verified against pulled recipe JSON in this repo. The other values come from the kit's accumulated learning (see `@.claude/rules/workato-recipe-format.md`). If you encounter a discrepancy, capture the JSON and update both tables.
+Unary operators (`is_true`, `is_not_true`, `present`, `blank`) still require `rhs` in the JSON — set it to an empty string (`"rhs": ""`).
 
-> The Workato public docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) presents short identifiers such as `eq`, `not_eq`, `gt`, `lt`, `present`, `not_present`, and `is_not_true`. **Those are not what the recipe JSON contains.** Use the JSON values in the table above.
+> The Workato public docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) presents short identifiers such as `eq`, `not_eq`, `gt`, `lt`, and `not_present`. **Those are not what the recipe JSON contains.** Use the JSON values in the table above.
 
 ### Notes
 
 - All text comparisons are **case-sensitive**
-- Comparing a null value with `greater_than` / `less_than` raises an error → combine with `is_present`
+- Comparing a null value with `greater_than` / `less_than` raises an error → combine with `present`
 - `equals_to` converts strings to floats for numeric comparison. Watch out for octal notation (`"0123"` → `83`). Floats with more than 15 digits may lose precision
 - `contains` / `not_contains` return false for null (no error)
 - `starts_with` / `ends_with` raise a trigger error when comparing non-string types directly (datapills are auto-converted)
@@ -91,9 +93,13 @@ Real recipe JSON places the `input` fields in the order `type`, `operand`, `cond
 {
   "number": N,
   "keyword": "else",
-  "block": [ /* default actions */ ]
+  "input": {},
+  "block": [ /* default actions */ ],
+  "uuid": "..."
 }
 ```
+
+`else` still has an empty `input: {}` object (verified from API response). It has no `conditions` field.
 
 ### elsif (additional conditional branch = ELSE IF)
 ```json

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -1304,24 +1304,24 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
 
 | Display | JSON `operand` |
 |---|---|
 | contains | `contains` |
 | doesn't contain | `not_contains` |
 | starts with | `starts_with` |
-| doesn't start with | `not_starts_with` (unverified) |
+| doesn't start with | `not_starts_with` |
 | ends with | `ends_with` |
-| doesn't end with | `not_ends_with` (unverified) |
-| equals | **`equals_to`** (not `equals`) |
-| doesn't equal | `not_equals` |
+| doesn't end with | `not_ends_with` |
+| equals | `equals_to` (not `equals` / `eq`) |
+| doesn't equal | `not_equals_to` (not `not_equals`) |
 | greater than | `greater_than` |
 | less than | `less_than` |
 | is true | `is_true` |
-| is not true | `is_false` |
-| is present | `is_present` |
-| is not present | `is_not_present` |
+| is not true | `is_not_true` |
+| is present | `present` (not `is_present`) |
+| is not present | `blank` (UI label is "Is not present") |
 
 ### `config`: connection references
 

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -1304,7 +1304,9 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for the supported types, edge cases, and the full investigation):
+
+> The public Workato docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) lists short forms such as `eq`, `not_eq`, `gt`, `lt`, `not_present`. **Recipe JSON does not use these.** Use the values in the table below.
 
 | Display | JSON `operand` |
 |---|---|

--- a/framework/claude/rules/workato-recipe-format.md
+++ b/framework/claude/rules/workato-recipe-format.md
@@ -230,24 +230,24 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
 
 | Display | JSON `operand` |
 |---|---|
 | contains | `contains` |
 | doesn't contain | `not_contains` |
 | starts with | `starts_with` |
-| doesn't start with | `not_starts_with` (unverified) |
+| doesn't start with | `not_starts_with` |
 | ends with | `ends_with` |
-| doesn't end with | `not_ends_with` (unverified) |
-| equals | **`equals_to`** (not `equals`) |
-| doesn't equal | `not_equals` |
+| doesn't end with | `not_ends_with` |
+| equals | `equals_to` (not `equals` / `eq`) |
+| doesn't equal | `not_equals_to` (not `not_equals`) |
 | greater than | `greater_than` |
 | less than | `less_than` |
 | is true | `is_true` |
-| is not true | `is_false` |
-| is present | `is_present` |
-| is not present | `is_not_present` |
+| is not true | `is_not_true` |
+| is present | `present` (not `is_present`) |
+| is not present | `blank` (UI label is "Is not present") |
 
 ## `config`: connection references
 

--- a/framework/claude/rules/workato-recipe-format.md
+++ b/framework/claude/rules/workato-recipe-format.md
@@ -230,7 +230,9 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for the supported types, edge cases, and the full investigation):
+
+> The public Workato docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) lists short forms such as `eq`, `not_eq`, `gt`, `lt`, `not_present`. **Recipe JSON does not use these.** Use the values in the table below.
 
 | Display | JSON `operand` |
 |---|---|

--- a/framework/cursor/rules/workato-recipe-format.mdc
+++ b/framework/cursor/rules/workato-recipe-format.mdc
@@ -231,24 +231,24 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
 
 | Display | JSON `operand` |
 |---|---|
 | contains | `contains` |
 | doesn't contain | `not_contains` |
 | starts with | `starts_with` |
-| doesn't start with | `not_starts_with` (unverified) |
+| doesn't start with | `not_starts_with` |
 | ends with | `ends_with` |
-| doesn't end with | `not_ends_with` (unverified) |
-| equals | **`equals_to`** (not `equals`) |
-| doesn't equal | `not_equals` |
+| doesn't end with | `not_ends_with` |
+| equals | `equals_to` (not `equals` / `eq`) |
+| doesn't equal | `not_equals_to` (not `not_equals`) |
 | greater than | `greater_than` |
 | less than | `less_than` |
 | is true | `is_true` |
-| is not true | `is_false` |
-| is present | `is_present` |
-| is not present | `is_not_present` |
+| is not true | `is_not_true` |
+| is present | `present` (not `is_present`) |
+| is not present | `blank` (UI label is "Is not present") |
 
 ## `config`: connection references
 

--- a/framework/cursor/rules/workato-recipe-format.mdc
+++ b/framework/cursor/rules/workato-recipe-format.mdc
@@ -231,7 +231,9 @@ Data references use the `_dp()` function:
 }
 ```
 
-`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for details):
+`operand` values (the literal string in JSON, verified against a recipe exercising all 14 operators — see `@docs/logic/if-conditions.md` for the supported types, edge cases, and the full investigation):
+
+> The public Workato docs page ([conditions.html](https://docs.workato.com/en/features/conditions.html)) lists short forms such as `eq`, `not_eq`, `gt`, `lt`, `not_present`. **Recipe JSON does not use these.** Use the values in the table below.
 
 | Display | JSON `operand` |
 |---|---|


### PR DESCRIPTION
Closes #154.

## 背景

`docs/logic/if-conditions.md` の condition 演算子表が **UI 表示ラベル**（`doesn't contain`, `is true`, `equals` 等）で記載されていたが、実際の recipe JSON では **snake_case の内部表現**が使われていた。kit 内の `framework/claude/rules/workato-recipe-format.md` には類似の mapping table が存在していたものの、こちらも一部誤り・未確認のままだった。

## 検証（ground truth）

User が trial workspace で 14 演算子全てを並べたテスト recipe（id=257562, name=`if-condition`, project_id=16707）を作成。`scripts/workato-api.py recipes list` で取得し、`code` フィールド（recipe JSON 本体）を読み出して、UI ラベル ↔ JSON `operand` の対応を全件確定させた。

| UI label | JSON `operand` | 修正前の doc | 備考 |
|---|---|---|---|
| Contains | `contains` | `contains` ✓ | |
| Doesn't contain | `not_contains` | `not_contains` ✓ | |
| Starts with | `starts_with` | `starts_with` ✓ | |
| Doesn't start with | `not_starts_with` | `not_starts_with` ✓ | |
| Ends with | `ends_with` | `ends_with` ✓ | |
| Doesn't end with | `not_ends_with` | `not_ends_with` ✓ | |
| Equals | `equals_to` | `equals_to` ✓ | `equals` でも `eq` でもない |
| Doesn't equal | **`not_equals_to`** | `not_equals` ❌ | `to` まで付く |
| Greater than | `greater_than` | `greater_than` ✓ | |
| Less than | `less_than` | `less_than` ✓ | |
| Is true | `is_true` | `is_true` ✓ | |
| Is not true | **`is_not_true`** | `is_false` ❌ | |
| Is present | **`present`** | `is_present` ❌ | `is_` 接頭辞なし |
| Is not present | **`blank`** | `is_not_present` ❌ | UI ラベルと大きく乖離 |

その他、`else` ステップが **空オブジェクトの `input: {}`** を持つことも実 JSON で確認（修正前の doc は `input` フィールド自体を省略していた）。`is_true` / `is_not_true` / `present` / `blank` の単項演算子も `"rhs": ""`（空文字列）を必ず JSON に出力する必要があることを記載。

## 変更内容

- `docs/logic/if-conditions.md`
  - 演算子表に `JSON operand` 列を追加し、14 件全件を実 recipe で検証済みの値に更新。
  - UI ラベルと乖離する 3 件（`not_equals_to` / `present` / `blank`）を強調表示。
  - 公開 docs (`conditions.html`) が短縮形（`eq` / `gt` / `not_present` 等）を提示している点に注意書きを追加。
  - JSON 構造例の `input` フィールド順を `type` → `operand` → `conditions` に修正（`workato pull` の出力順に合わせ diff を綺麗に保つため）。
  - `else` 例に `input: {}` と `uuid` を追加。
- `framework/claude/rules/workato-recipe-format.md`
  - `not_equals` → `not_equals_to`、`is_false` → `is_not_true`、`is_present` → `present`、`is_not_present` → `blank` に修正。
  - `(unverified)` マーカーを除去。
  - 検証元を `@docs/logic/if-conditions.md` に集約。
- `framework/AGENTS.md`, `framework/cursor/rules/workato-recipe-format.mdc` は `python3 scripts/sync_agents.py` で自動再生成。

## 関連ファイル（変更なし）

- `framework/claude/rules/workato-page-components.md:214` — 「Same syntax as a recipe's IF condition」参照。本 PR の更新で意味的に正しい状態を維持。
- `framework/claude/skills/validate-recipe/SKILL.md:29` — `filter` の `conditions` / `operand` 検証。構造変更なしで影響なし。
- `docs/logic/triggers.md` — `filter` の例で `operand: "contains"` を使用。修正対象なし（`contains` は元から正しい）。

## コミット

- `d1189d5` 既存 doc 内容を kit 内 mapping table と整合させる第一弾
- `ef7be3f` recipe id=257562 で 14 演算子を直接検証し、4 件の operand 名を確定修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)