### PR TITLE
docs(environments): document dev/test/prod model and deploy-only promotion

### DIFF
--- a/docs/platform/cli-profiles.md
+++ b/docs/platform/cli-profiles.md
@@ -1,0 +1,97 @@
+# Platform CLI profiles (dev / test / prod)
+
+## Overview
+
+A **CLI profile** is a named credential set in `~/.workato/profiles` that tells the Workato Platform CLI which workspace to talk to. Each workspace (dev, test, prod) gets its own profile.
+
+> **Not to be confused with "Custom OAuth profiles"** (`workato oauth-profiles ...`), which is a workspace feature for storing OAuth client credentials for custom OAuth-based connectors. That feature has nothing to do with environment selection. This document is about CLI profiles only.
+
+## Naming convention
+
+```
+<org>-<env>
+```
+
+| Profile name | Workspace | Example |
+|---|---|---|
+| `<org>-dev` | Dev workspace | `acme-dev` |
+| `<org>-test` | Test workspace | `acme-test` |
+| `<org>-prod` | Prod workspace | `acme-prod` |
+
+The `<org>` prefix lets one developer hold profiles for multiple Workato tenants on the same machine (e.g. `acme-dev`, `beta-dev`).
+
+## Push / pull matrix
+
+This is the rule for AI agents and human developers alike. **Push is dev-only.** Promotion to test/prod must go through the Deploy feature (see `@docs/platform/environments.md`).
+
+| Profile | `workato pull` | `workato push` | `workato init` | Notes |
+|---|---|---|---|---|
+| `<org>-dev` | ✅ | ✅ | ✅ | Default for daily work |
+| `<org>-test` | ✅ | ❌ forbidden | ❌ | Pull only — e.g. to inspect what test currently has |
+| `<org>-prod` | ✅ | ❌ forbidden | ❌ | Pull only — e.g. to verify a deploy succeeded |
+
+"Forbidden" means the policy disallows it even though the CLI itself does not enforce it. Treat any `workato push` against `<org>-test` or `<org>-prod` as a bug.
+
+## Profile selection rules
+
+When you (or an AI agent) need to choose a profile, follow this order:
+
+1. **If `.workatoenv` has `workspace_id`**: let `scripts/workato-api.py` auto-resolve. The `workspace_id` in `.workatoenv` is matched against the `workspace_id` field in each profile.
+2. **If `.workatoenv` is missing**: explicitly pass `--profile <org>-dev`. **Never default to `-test` or `-prod`.**
+3. **When in doubt**: default to `<org>-dev`. The cost of a misfire against prod is far higher than the cost of a misfire against dev.
+
+The AI-agent shortcut: **if you cannot tell which profile to use, choose dev.**
+
+## How AI agents should reason about profiles
+
+- The `/push-project` skill operates on the project named in `.workatoenv` and the profile auto-resolved from `workspace_id`. If `workspace_id` points at prod, the agent **must refuse** and ask the user to switch to dev.
+- `/pull-project` is safe against any profile — pull does not mutate the remote.
+- When `--profile` is passed on the command line and it ends with `-test` or `-prod`, refuse `push` and only allow `pull` / read commands.
+
+## Setting up profiles
+
+```bash
+# First-time setup for a workspace
+workato init --non-interactive --profile <org>-dev --project-id <id> --folder-name "projects/<name>"
+
+# Verify the profile maps to the right workspace
+python3 scripts/workato-api.py profile show
+```
+
+Switch the **current profile** (used when no `.workatoenv` is present):
+
+```bash
+workato profiles use <org>-dev
+```
+
+List all profiles:
+
+```bash
+workato profiles list
+```
+
+## Where the credentials live
+
+| File | Contents |
+|---|---|
+| `~/.workato/profiles` | Profile metadata (workspace_id, region, current_profile) — **not** the API tokens |
+| OS keyring (macOS Keychain / Linux Secret Service) | API token per profile, managed by `workato init` |
+| `.workatoenv` (per project) | `workspace_id` + `folder_id`; no credentials. Auto-generated; gitignored |
+
+Never commit `.workatoenv` or anything from `~/.workato/`.
+
+## Common mistakes
+
+| Mistake | Consequence | Prevention |
+|---|---|---|
+| Naming a profile `dev` (no org prefix) | Collides across tenants; agent cannot disambiguate | Use `<org>-dev` |
+| Setting `current_profile` to `<org>-prod` | Any CLI command without `--profile` hits prod | Keep `current_profile` on dev; pass `--profile <org>-prod` explicitly when needed |
+| `workato push --profile <org>-prod` | Bypasses Deploy; overwrites prod | Push is dev-only; promote via Deploy |
+| Sharing one profile across teammates | Audit log shows the wrong actor | Each developer runs `workato init` for their own profile |
+
+## Related
+
+- `@docs/platform/environments.md` — the three-tier environment model and Deploy feature
+- `@.claude/rules/workato-deployment-flow.md` — the inviolable push-target rule
+- `@.claude/rules/workato-cli.md` — Platform CLI reference
+- `@.claude/rules/workato-cli-autonomy.md` — when to use the CLI vs. ask the user

--- a/docs/platform/environments.md
+++ b/docs/platform/environments.md
@@ -1,0 +1,130 @@
+# Environments (dev / test / prod)
+
+Official: https://docs.workato.com/en/recipe-development-lifecycle/environments.html
+
+## Overview
+
+Workato separates each tier of the development lifecycle into a **dedicated workspace**.
+The standard layout is three tiers — **dev**, **test**, **prod** — and any code, connection, or asset change moves between them only through Workato's **Deploy** feature (UI or Recipe Lifecycle Management API).
+
+Direct push to test or prod is prohibited (see `@.claude/rules/workato-deployment-flow.md`). All push operations target dev; promotion to higher tiers goes through Deploy.
+
+## Environment roles
+
+| Environment | Purpose | Who pushes here | How code arrives |
+|---|---|---|---|
+| **dev** | Development, experimentation, AI agent work | Developers, `/push-project`, AI agents | `workato push` (CLI / API) |
+| **test** | QA verification, UAT | Release manager only | **Deploy** from dev |
+| **prod** | Production operations | Release manager only (with approval) | **Deploy** from test |
+
+The flow is one-directional:
+
+```
+dev  ──Deploy──▶  test  ──Deploy──▶  prod
+ ▲
+ │
+push / pull (CLI, API, AI agents)
+```
+
+A change never skips a tier (dev → prod is not allowed) and never flows backward (prod → dev requires a fresh `workato pull` and re-development in dev).
+
+## The Deploy feature
+
+Deploy packages a project (or a subset of assets) from one workspace and applies it to the next-tier workspace. Each deployment is an immutable **manifest** that records the assets, the source environment, the target environment, and the operator.
+
+### Deploy via the Workato UI
+
+1. In the **source** workspace (e.g. dev), open the project.
+2. Click **Deploy** → choose the target environment (e.g. test).
+3. Select the manifest contents:
+   - Recipes (specific recipes or all)
+   - Connections (re-mapping per target)
+   - Data Tables, Lookup Tables, Properties, etc.
+4. Review the diff and submit. The target workspace receives the manifest.
+5. (For prod) The release manager approves the manifest in the target workspace.
+
+### Deploy via the API
+
+Deploy is exposed by the **Recipe Lifecycle Management API** (also called Deploy API). The Platform CLI does not currently provide a high-level wrapper, so use `python3 scripts/workato-api.py` or call the API directly when scripting.
+
+Key endpoints (in the source workspace):
+
+| Action | Endpoint |
+|---|---|
+| Create a deployment manifest | `POST /api/deployments` |
+| List deployments | `GET /api/deployments` |
+| Get deployment status | `GET /api/deployments/{id}` |
+
+See https://docs.workato.com/en/recipe-development-lifecycle/recipe-lifecycle-management.html for the full schema. Wrap usage in helper scripts so AI agents do not call the raw API ad-hoc.
+
+### Approvals
+
+The prod target can require explicit approval before the deployment becomes effective. Approval is a workspace setting; check with the workspace admin if your organization requires it. **AI agents must not bypass or auto-approve** deployment approvals.
+
+## Differences between environments
+
+Although the three workspaces share the same schema, each has its own runtime state. Plan around the following per-environment differences.
+
+### Connections
+
+Each workspace has its own connection credentials. The same connection file (e.g. `Connections/example_jira.connection.json`) is deployed across all three environments, but the **credentials** (OAuth tokens, API keys) are entered in each workspace independently.
+
+| Concern | Per-environment behavior |
+|---|---|
+| Endpoint URL | Often different (e.g. `*-sandbox.example.com` in dev/test, `example.com` in prod) |
+| Credentials | Always different; entered in the UI per workspace |
+| Connection name | Same (use the same display name across environments) |
+
+If the target service itself has a sandbox (e.g. Salesforce Sandbox vs. Production), keep the connection name identical but configure different credentials per workspace. Do **not** rename the connection per environment (it breaks Deploy).
+
+### Data sources
+
+| Source | Per-environment behavior |
+|---|---|
+| Data Tables | Schema is deployed; **records are not** (each environment starts empty) |
+| Lookup Tables | Schema is deployed; rows must be seeded per environment |
+| Environment Properties | Values are workspace-scoped; set them per environment (e.g. dev URL vs. prod URL). See `@docs/platform/environment-properties.md` |
+| Custom Connectors | Source code is deployed; the connector must be **released** in each workspace |
+
+### Runtime resources
+
+| Resource | Per-environment behavior |
+|---|---|
+| Job execution quota | Each workspace has its own concurrency / job-per-minute quota |
+| Job history | Workspace-scoped; you cannot replay a prod job in dev |
+| Recipe ID | Different per environment (do not hardcode recipe IDs in code that crosses environments) |
+| API endpoint base URL | Same Workato region, but the workspace ID in the URL differs |
+
+### Folder / project IDs
+
+`folder_id` and `project_id` are workspace-specific. The `.workatoenv` file therefore differs per environment. **Do not commit a `.workatoenv` that points at prod** — each developer's local checkout should point at dev. See `@.claude/rules/workato-deployment-flow.md` for the safety rule.
+
+## Mapping environments to CLI profiles
+
+Each environment corresponds to one **Platform CLI profile** (stored in `~/.workato/profiles`). The recommended naming is `<org>-<env>`:
+
+| Profile name | Workspace | Allowed CLI operations |
+|---|---|---|
+| `<org>-dev` | Dev workspace | `workato push`, `workato pull`, `workato init` |
+| `<org>-test` | Test workspace | `workato pull` only (push is forbidden by policy) |
+| `<org>-prod` | Prod workspace | `workato pull` only (push is forbidden by policy) |
+
+See `@docs/platform/cli-profiles.md` for the full profile selection rules and the push/pull matrix.
+
+## Common mistakes
+
+| Mistake | Consequence | Prevention |
+|---|---|---|
+| `workato push` against the prod profile | Bypasses Deploy approvals; overwrites prod | Set `<org>-dev` as the default profile in `.workatoenv`; use `<org>-test`/`<org>-prod` only for pull |
+| Renaming a connection per environment | Deploy treats it as a new connection | Keep the same display name across environments |
+| Hardcoding `folder_id` from dev into a doc / script | Targets the wrong workspace when the doc is reused | Always read `folder_id` from `.workatoenv` at runtime |
+| Committing `.workatoenv` for prod | Other developers accidentally push to prod | `.workatoenv` is gitignored by default; keep it that way |
+| Auto-approving prod deploy via script | Skips release-manager review | Manual approval only; never script `POST /api/deployments/{id}/approve` |
+
+## Related
+
+- `@.claude/rules/workato-deployment-flow.md` — the inviolable rule (dev-only push, Deploy-only promotion)
+- `@docs/platform/cli-profiles.md` — profile naming and push/pull matrix
+- `@docs/platform/environment-properties.md` — per-environment configuration values
+- `@docs/patterns/workspace-management.md` — workspace layout and connection management
+- `@docs/patterns/deployment-guide.md` — per-asset deployment procedure

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -786,16 +786,21 @@ This rule applies to AI agents and human developers alike. It exists because:
 
 ### Pre-flight checks before every push
 
-Run these in order. **Abort the push if any check fails.**
+Run these in order. **Abort the push if any check fails. There is no confirmation-prompt escape hatch — the rule is inviolable.**
 
 1. **Read `.workatoenv`** and extract `workspace_id`.
 2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
-3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+3. **Confirm the profile name ends with `-dev`.** Anything else — `-test`, `-prod`, `-production`, `-staging`, `-qa`, or any non-`-dev` suffix — is a hard stop. Abort and tell the user:
 
    ```
-   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
-   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   Refusing to push: the resolved profile is <profile-name>, which does not match the dev convention (<org>-dev).
+   Push must target dev. Options:
+     (a) Switch to a dev profile: workato profiles use <org>-dev
+     (b) If <profile-name> is in fact your dev workspace, rename it to follow the <org>-dev convention.
+   To promote to test/prod, use the Deploy feature in the Workato UI.
    ```
+
+   Do **not** ask the user for confirmation to proceed. The convention exists specifically so that AI agents can reason about the target environment from the profile name alone; honoring custom names ad-hoc defeats the safety guarantee.
 
 4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
 

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -94,6 +94,7 @@ The three inviolable principles:
 - Custom connectors: `@.claude/rules/workato-connector-sdk.md`
 - CLI: `@.claude/rules/workato-cli.md`
 - CLI/API autonomy (always check before asking the user to do something in the UI): `@.claude/rules/workato-cli-autonomy.md`
+- **Deployment flow (inviolable: push targets dev only, promotion via Deploy)**: `@.claude/rules/workato-deployment-flow.md`
 - Organization knowledge overlay: `@.claude/rules/org-knowledge-overlay.md`
 - Connector details: pre-built → `@docs/connectors/` (+ `@org/docs/connectors/`); custom → `@connectors/docs/`. For missing entries, WebFetch.
 - Record new findings in `org/docs/<relative-path>` (do not edit the kit's `docs/` directly).
@@ -763,6 +764,86 @@ Steps:
 - `connectors/` lives in the organization's workspace repository.
 
 Details: `@docs/connector-sdk/connector-rb.md`.
+
+<!-- source: framework/claude/rules/workato-deployment-flow.md -->
+## Workato deployment flow (inviolable)
+
+*Applies to: `projects/**`, `.workatoenv`*
+
+### The rule
+
+**Push always targets dev.** Promotion to test or prod must go through Workato's **Deploy** feature (UI or Recipe Lifecycle Management API).
+
+> Never run `workato push` against a `<org>-test` or `<org>-prod` profile.
+> Never script around deployment approvals.
+> If unsure which environment a profile points at, **default to dev**.
+
+This rule applies to AI agents and human developers alike. It exists because:
+
+- A direct push to test or prod skips release-manager review.
+- A direct push leaves no manifest, so the deployment cannot be audited or rolled back.
+- A direct push silently overwrites whatever is currently running in that environment.
+
+### Pre-flight checks before every push
+
+Run these in order. **Abort the push if any check fails.**
+
+1. **Read `.workatoenv`** and extract `workspace_id`.
+2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
+3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+
+   ```
+   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
+   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   ```
+
+4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
+
+### When the user asks "push to prod"
+
+Do not do it. Reply with:
+
+```
+Direct push to prod is not allowed. To release to prod:
+
+1. Push to dev (workato push, with the <org>-dev profile).
+2. Verify in the dev workspace.
+3. In the Workato UI, open the project and click Deploy → test. Get QA sign-off.
+4. From test, click Deploy → prod. Get release-manager approval.
+
+See @docs/platform/environments.md for the full Deploy flow.
+```
+
+### When you must read from test or prod
+
+Reading (pull, list) is allowed against any profile because it does not mutate the remote. Use it sparingly — for example, to diff dev against prod when investigating a release issue:
+
+```bash
+# Allowed
+workato pull --profile <org>-prod   # into a scratch directory
+
+# Forbidden
+workato push --profile <org>-prod
+```
+
+### CLI/API operations the rule covers
+
+| Operation | Against `<org>-dev` | Against `<org>-test` | Against `<org>-prod` |
+|---|---|---|---|
+| `workato push` | ✅ | ❌ refuse | ❌ refuse |
+| `workato push --delete` | ✅ (with care) | ❌ refuse | ❌ refuse |
+| `workato push --restart-recipes` | ✅ | ❌ refuse | ❌ refuse |
+| `workato pull` | ✅ | ✅ | ✅ |
+| `workato recipes start --all` | ✅ | ❌ refuse | ❌ refuse |
+| `python3 scripts/workato-api.py sdk push` | ✅ | ❌ refuse | ❌ refuse |
+| `POST /api/deployments/{id}/approve` | n/a | ❌ never script | ❌ never script |
+
+### Related
+
+- `@docs/platform/environments.md` — environment roles and the Deploy feature
+- `@docs/platform/cli-profiles.md` — profile naming and push/pull matrix
+- `@.claude/rules/workato-cli.md` — Platform CLI commands
+- `@.claude/rules/workato-cli-autonomy.md` — when the CLI is the right answer
 
 <!-- source: framework/claude/rules/workato-page-components.md -->
 ## Workato Page Component JSON Format

--- a/framework/claude/CLAUDE.md
+++ b/framework/claude/CLAUDE.md
@@ -91,6 +91,7 @@ The three inviolable principles:
 - Custom connectors: `@.claude/rules/workato-connector-sdk.md`
 - CLI: `@.claude/rules/workato-cli.md`
 - CLI/API autonomy (always check before asking the user to do something in the UI): `@.claude/rules/workato-cli-autonomy.md`
+- **Deployment flow (inviolable: push targets dev only, promotion via Deploy)**: `@.claude/rules/workato-deployment-flow.md`
 - Organization knowledge overlay: `@.claude/rules/org-knowledge-overlay.md`
 - Connector details: pre-built → `@docs/connectors/` (+ `@org/docs/connectors/`); custom → `@connectors/docs/`. For missing entries, WebFetch.
 - Record new findings in `org/docs/<relative-path>` (do not edit the kit's `docs/` directly).

--- a/framework/claude/rules/workato-deployment-flow.md
+++ b/framework/claude/rules/workato-deployment-flow.md
@@ -1,0 +1,82 @@
+---
+paths:
+  - "projects/**"
+  - ".workatoenv"
+---
+
+# Workato deployment flow (inviolable)
+
+## The rule
+
+**Push always targets dev.** Promotion to test or prod must go through Workato's **Deploy** feature (UI or Recipe Lifecycle Management API).
+
+> Never run `workato push` against a `<org>-test` or `<org>-prod` profile.
+> Never script around deployment approvals.
+> If unsure which environment a profile points at, **default to dev**.
+
+This rule applies to AI agents and human developers alike. It exists because:
+
+- A direct push to test or prod skips release-manager review.
+- A direct push leaves no manifest, so the deployment cannot be audited or rolled back.
+- A direct push silently overwrites whatever is currently running in that environment.
+
+## Pre-flight checks before every push
+
+Run these in order. **Abort the push if any check fails.**
+
+1. **Read `.workatoenv`** and extract `workspace_id`.
+2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
+3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+
+   ```
+   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
+   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   ```
+
+4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
+
+## When the user asks "push to prod"
+
+Do not do it. Reply with:
+
+```
+Direct push to prod is not allowed. To release to prod:
+
+1. Push to dev (workato push, with the <org>-dev profile).
+2. Verify in the dev workspace.
+3. In the Workato UI, open the project and click Deploy → test. Get QA sign-off.
+4. From test, click Deploy → prod. Get release-manager approval.
+
+See @docs/platform/environments.md for the full Deploy flow.
+```
+
+## When you must read from test or prod
+
+Reading (pull, list) is allowed against any profile because it does not mutate the remote. Use it sparingly — for example, to diff dev against prod when investigating a release issue:
+
+```bash
+# Allowed
+workato pull --profile <org>-prod   # into a scratch directory
+
+# Forbidden
+workato push --profile <org>-prod
+```
+
+## CLI/API operations the rule covers
+
+| Operation | Against `<org>-dev` | Against `<org>-test` | Against `<org>-prod` |
+|---|---|---|---|
+| `workato push` | ✅ | ❌ refuse | ❌ refuse |
+| `workato push --delete` | ✅ (with care) | ❌ refuse | ❌ refuse |
+| `workato push --restart-recipes` | ✅ | ❌ refuse | ❌ refuse |
+| `workato pull` | ✅ | ✅ | ✅ |
+| `workato recipes start --all` | ✅ | ❌ refuse | ❌ refuse |
+| `python3 scripts/workato-api.py sdk push` | ✅ | ❌ refuse | ❌ refuse |
+| `POST /api/deployments/{id}/approve` | n/a | ❌ never script | ❌ never script |
+
+## Related
+
+- `@docs/platform/environments.md` — environment roles and the Deploy feature
+- `@docs/platform/cli-profiles.md` — profile naming and push/pull matrix
+- `@.claude/rules/workato-cli.md` — Platform CLI commands
+- `@.claude/rules/workato-cli-autonomy.md` — when the CLI is the right answer

--- a/framework/claude/rules/workato-deployment-flow.md
+++ b/framework/claude/rules/workato-deployment-flow.md
@@ -22,16 +22,21 @@ This rule applies to AI agents and human developers alike. It exists because:
 
 ## Pre-flight checks before every push
 
-Run these in order. **Abort the push if any check fails.**
+Run these in order. **Abort the push if any check fails. There is no confirmation-prompt escape hatch — the rule is inviolable.**
 
 1. **Read `.workatoenv`** and extract `workspace_id`.
 2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
-3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+3. **Confirm the profile name ends with `-dev`.** Anything else — `-test`, `-prod`, `-production`, `-staging`, `-qa`, or any non-`-dev` suffix — is a hard stop. Abort and tell the user:
 
    ```
-   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
-   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   Refusing to push: the resolved profile is <profile-name>, which does not match the dev convention (<org>-dev).
+   Push must target dev. Options:
+     (a) Switch to a dev profile: workato profiles use <org>-dev
+     (b) If <profile-name> is in fact your dev workspace, rename it to follow the <org>-dev convention.
+   To promote to test/prod, use the Deploy feature in the Workato UI.
    ```
+
+   Do **not** ask the user for confirmation to proceed. The convention exists specifically so that AI agents can reason about the target environment from the profile name alone; honoring custom names ad-hoc defeats the safety guarantee.
 
 4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
 

--- a/framework/claude/skills/push-project/SKILL.md
+++ b/framework/claude/skills/push-project/SKILL.md
@@ -28,8 +28,8 @@ Push local changes to the Workato remote and verify the recipes work.
 python3 scripts/workato-api.py profile show
 ```
 
-- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
-- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- **Hard-block: if the resolved profile name does not end with `-dev`, abort immediately.** This covers `-test`, `-prod`, `-production`, `-staging`, `-qa`, and any other non-dev suffix. Do not offer a confirmation prompt — the rule is inviolable.
+- The only way to proceed is for the user to either (a) switch to a `-dev` profile, or (b) rename their dev profile to follow the `<org>-dev` convention. Tell the user which option applies.
 - Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`@docs/platform/environments.md`).
 
 ### 1. Project validation

--- a/framework/claude/skills/push-project/SKILL.md
+++ b/framework/claude/skills/push-project/SKILL.md
@@ -20,6 +20,18 @@ Push local changes to the Workato remote and verify the recipes work.
 
 ## Procedure
 
+### 0. Environment guard (mandatory)
+
+**Before any validation or push, confirm the push target is dev.** See `@.claude/rules/workato-deployment-flow.md` for the full rule.
+
+```bash
+python3 scripts/workato-api.py profile show
+```
+
+- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
+- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`@docs/platform/environments.md`).
+
 ### 1. Project validation
 
 Validate the project's JSON files before pushing. With `--validate-only`, stop here.

--- a/framework/codex/skills/push-project/SKILL.md
+++ b/framework/codex/skills/push-project/SKILL.md
@@ -27,8 +27,8 @@ Push local changes to the Workato remote and verify the recipes work.
 python3 scripts/workato-api.py profile show
 ```
 
-- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
-- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- **Hard-block: if the resolved profile name does not end with `-dev`, abort immediately.** This covers `-test`, `-prod`, `-production`, `-staging`, `-qa`, and any other non-dev suffix. Do not offer a confirmation prompt — the rule is inviolable.
+- The only way to proceed is for the user to either (a) switch to a `-dev` profile, or (b) rename their dev profile to follow the `<org>-dev` convention. Tell the user which option applies.
 - Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
 
 ### 1. Project validation

--- a/framework/codex/skills/push-project/SKILL.md
+++ b/framework/codex/skills/push-project/SKILL.md
@@ -19,6 +19,18 @@ Push local changes to the Workato remote and verify the recipes work.
 
 ## Procedure
 
+### 0. Environment guard (mandatory)
+
+**Before any validation or push, confirm the push target is dev.** See `AGENTS.md` for the full rule.
+
+```bash
+python3 scripts/workato-api.py profile show
+```
+
+- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
+- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
+
 ### 1. Project validation
 
 Validate the project's JSON files before pushing. With `--validate-only`, stop here.

--- a/framework/cursor/rules/workato-deployment-flow.mdc
+++ b/framework/cursor/rules/workato-deployment-flow.mdc
@@ -1,0 +1,82 @@
+---
+description: Workato deployment flow (inviolable)
+globs: "projects/**,.workatoenv"
+alwaysApply: false
+---
+
+# Workato deployment flow (inviolable)
+
+## The rule
+
+**Push always targets dev.** Promotion to test or prod must go through Workato's **Deploy** feature (UI or Recipe Lifecycle Management API).
+
+> Never run `workato push` against a `<org>-test` or `<org>-prod` profile.
+> Never script around deployment approvals.
+> If unsure which environment a profile points at, **default to dev**.
+
+This rule applies to AI agents and human developers alike. It exists because:
+
+- A direct push to test or prod skips release-manager review.
+- A direct push leaves no manifest, so the deployment cannot be audited or rolled back.
+- A direct push silently overwrites whatever is currently running in that environment.
+
+## Pre-flight checks before every push
+
+Run these in order. **Abort the push if any check fails.**
+
+1. **Read `.workatoenv`** and extract `workspace_id`.
+2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
+3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+
+   ```
+   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
+   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   ```
+
+4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
+
+## When the user asks "push to prod"
+
+Do not do it. Reply with:
+
+```
+Direct push to prod is not allowed. To release to prod:
+
+1. Push to dev (workato push, with the <org>-dev profile).
+2. Verify in the dev workspace.
+3. In the Workato UI, open the project and click Deploy → test. Get QA sign-off.
+4. From test, click Deploy → prod. Get release-manager approval.
+
+See @docs/platform/environments.md for the full Deploy flow.
+```
+
+## When you must read from test or prod
+
+Reading (pull, list) is allowed against any profile because it does not mutate the remote. Use it sparingly — for example, to diff dev against prod when investigating a release issue:
+
+```bash
+# Allowed
+workato pull --profile <org>-prod   # into a scratch directory
+
+# Forbidden
+workato push --profile <org>-prod
+```
+
+## CLI/API operations the rule covers
+
+| Operation | Against `<org>-dev` | Against `<org>-test` | Against `<org>-prod` |
+|---|---|---|---|
+| `workato push` | ✅ | ❌ refuse | ❌ refuse |
+| `workato push --delete` | ✅ (with care) | ❌ refuse | ❌ refuse |
+| `workato push --restart-recipes` | ✅ | ❌ refuse | ❌ refuse |
+| `workato pull` | ✅ | ✅ | ✅ |
+| `workato recipes start --all` | ✅ | ❌ refuse | ❌ refuse |
+| `python3 scripts/workato-api.py sdk push` | ✅ | ❌ refuse | ❌ refuse |
+| `POST /api/deployments/{id}/approve` | n/a | ❌ never script | ❌ never script |
+
+## Related
+
+- `@docs/platform/environments.md` — environment roles and the Deploy feature
+- `@docs/platform/cli-profiles.md` — profile naming and push/pull matrix
+- `@.claude/rules/workato-cli.md` — Platform CLI commands
+- `@.claude/rules/workato-cli-autonomy.md` — when the CLI is the right answer

--- a/framework/cursor/rules/workato-deployment-flow.mdc
+++ b/framework/cursor/rules/workato-deployment-flow.mdc
@@ -22,16 +22,21 @@ This rule applies to AI agents and human developers alike. It exists because:
 
 ## Pre-flight checks before every push
 
-Run these in order. **Abort the push if any check fails.**
+Run these in order. **Abort the push if any check fails. There is no confirmation-prompt escape hatch — the rule is inviolable.**
 
 1. **Read `.workatoenv`** and extract `workspace_id`.
 2. **Resolve the profile** via `python3 scripts/workato-api.py profile show`.
-3. **Confirm the profile name ends with `-dev`.** If it ends with `-test` or `-prod`, abort and tell the user:
+3. **Confirm the profile name ends with `-dev`.** Anything else — `-test`, `-prod`, `-production`, `-staging`, `-qa`, or any non-`-dev` suffix — is a hard stop. Abort and tell the user:
 
    ```
-   Refusing to push: the resolved profile is <profile-name>, which targets a non-dev environment.
-   Push must target dev. To promote to test/prod, use the Deploy feature in the Workato UI.
+   Refusing to push: the resolved profile is <profile-name>, which does not match the dev convention (<org>-dev).
+   Push must target dev. Options:
+     (a) Switch to a dev profile: workato profiles use <org>-dev
+     (b) If <profile-name> is in fact your dev workspace, rename it to follow the <org>-dev convention.
+   To promote to test/prod, use the Deploy feature in the Workato UI.
    ```
+
+   Do **not** ask the user for confirmation to proceed. The convention exists specifically so that AI agents can reason about the target environment from the profile name alone; honoring custom names ad-hoc defeats the safety guarantee.
 
 4. **Confirm `workspace_id` matches a dev workspace.** If your organization tags workspaces (e.g. in a comment field), verify the tag says dev.
 

--- a/framework/cursor/skills/push-project/SKILL.md
+++ b/framework/cursor/skills/push-project/SKILL.md
@@ -28,8 +28,8 @@ Push local changes to the Workato remote and verify the recipes work.
 python3 scripts/workato-api.py profile show
 ```
 
-- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
-- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- **Hard-block: if the resolved profile name does not end with `-dev`, abort immediately.** This covers `-test`, `-prod`, `-production`, `-staging`, `-qa`, and any other non-dev suffix. Do not offer a confirmation prompt — the rule is inviolable.
+- The only way to proceed is for the user to either (a) switch to a `-dev` profile, or (b) rename their dev profile to follow the `<org>-dev` convention. Tell the user which option applies.
 - Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
 
 ### 1. Project validation

--- a/framework/cursor/skills/push-project/SKILL.md
+++ b/framework/cursor/skills/push-project/SKILL.md
@@ -20,6 +20,18 @@ Push local changes to the Workato remote and verify the recipes work.
 
 ## Procedure
 
+### 0. Environment guard (mandatory)
+
+**Before any validation or push, confirm the push target is dev.** See `.cursor/rules/workato-deployment-flow.mdc` for the full rule.
+
+```bash
+python3 scripts/workato-api.py profile show
+```
+
+- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
+- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
+
 ### 1. Project validation
 
 Validate the project's JSON files before pushing. With `--validate-only`, stop here.

--- a/framework/gemini/skills/push-project/SKILL.md
+++ b/framework/gemini/skills/push-project/SKILL.md
@@ -27,8 +27,8 @@ Push local changes to the Workato remote and verify the recipes work.
 python3 scripts/workato-api.py profile show
 ```
 
-- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
-- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- **Hard-block: if the resolved profile name does not end with `-dev`, abort immediately.** This covers `-test`, `-prod`, `-production`, `-staging`, `-qa`, and any other non-dev suffix. Do not offer a confirmation prompt — the rule is inviolable.
+- The only way to proceed is for the user to either (a) switch to a `-dev` profile, or (b) rename their dev profile to follow the `<org>-dev` convention. Tell the user which option applies.
 - Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
 
 ### 1. Project validation

--- a/framework/gemini/skills/push-project/SKILL.md
+++ b/framework/gemini/skills/push-project/SKILL.md
@@ -19,6 +19,18 @@ Push local changes to the Workato remote and verify the recipes work.
 
 ## Procedure
 
+### 0. Environment guard (mandatory)
+
+**Before any validation or push, confirm the push target is dev.** See `GEMINI.md` for the full rule.
+
+```bash
+python3 scripts/workato-api.py profile show
+```
+
+- If the resolved profile name ends with `-test` or `-prod`, **abort immediately** with the message in the deployment-flow rule.
+- If the resolved profile name does not end with `-dev`, ask the user to confirm before proceeding.
+- Direct push to test/prod is forbidden; promotion goes through the Deploy feature (`docs/platform/environments.md`).
+
 ### 1. Project validation
 
 Validate the project's JSON files before pushing. With `--validate-only`, stop here.


### PR DESCRIPTION
## Summary

Closes #161 items A, B, C. Item D (CLI helper warning when push target is not dev) is tracked separately as it depends on the helper-script expansion issue.

- **A. `docs/platform/environments.md`** — three-tier environment roles, the Deploy feature (UI + Recipe Lifecycle Management API), per-environment differences (connections, data sources, runtime resources), and the mapping to CLI profiles.
- **B. `docs/platform/cli-profiles.md`** — `<org>-<env>` profile naming, the push/pull matrix (push is **dev-only**), profile selection rules for AI agents ("when in doubt, dev"), and an explicit note distinguishing CLI profiles from the unrelated *custom OAuth profiles* feature.
- **C. `framework/claude/rules/workato-deployment-flow.md`** — the inviolable rule: push targets dev only; promotion to test/prod must go through Deploy. Includes a pre-flight check sequence and a refusal template for "push to prod" requests.
- Wired the new rule into `framework/claude/CLAUDE.md` and added a mandatory environment-guard step (Step 0) to the `/push-project` skill.
- Regenerated `framework/{cursor,codex,gemini}/` and `AGENTS.md` via `scripts/sync_agents.py`.

## Why now

The dev/test/prod model and Deploy-only promotion flow were tribal knowledge. Without explicit docs and a rule, AI agents had no guard against `workato push --profile <org>-prod`, and new contributors had no canonical reference for how releases move between environments.

## Test plan

- [ ] Verify `framework/AGENTS.md` includes the new rule body (`grep "Workato deployment flow"`)
- [ ] Verify the regenerated `framework/cursor/rules/workato-deployment-flow.mdc` exists and matches the canonical source
- [ ] Sanity-check the new docs render correctly in GitHub's markdown view
- [ ] In a downstream user repo, run `bash kit/setup.sh` after pulling this branch and confirm the new rule symlink resolves and the new docs are reachable via `@docs/platform/...`
- [ ] Confirm `/push-project` Step 0 fires by triggering it in a test workspace whose `.workatoenv` is intentionally pointed at a non-dev profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)