### PR TITLE
feat(deploy): add `deploy preview` with env-transition guards (PR-2a of #160)

### DIFF
--- a/scripts/tests/test_deploy_preview.py
+++ b/scripts/tests/test_deploy_preview.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Tests for `deploy preview` helpers in `scripts/workato-api.py`.
+
+Run with:
+    python3 scripts/tests/test_deploy_preview.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _chdir(target: Path) -> Path:
+    prev = Path.cwd()
+    os.chdir(target)
+    return prev
+
+
+def _capture_stderr_exit(fn):
+    """Run fn() with stderr captured; return (exited:bool, code:int, err:str)."""
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    return exited, code, err
+
+
+def _capture_stdout(fn):
+    saved = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        fn()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved
+
+
+# ---------------------------------------------------------------------------
+# check_deploy_transition
+# ---------------------------------------------------------------------------
+
+
+def test_transition_allows_dev_to_test():
+    # Should not raise / exit
+    wa.check_deploy_transition("dev", "test")
+
+
+def test_transition_allows_test_to_prod():
+    wa.check_deploy_transition("test", "prod")
+
+
+def test_transition_refuses_skip_tier_dev_to_prod():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.check_deploy_transition("dev", "prod")
+    )
+    assert exited and code == 1
+    assert "dev->prod" in err
+    assert "not allowed" in err
+
+
+def test_transition_refuses_backward_test_to_dev():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.check_deploy_transition("test", "dev")
+    )
+    assert exited and code == 1
+    assert "test->dev" in err
+
+
+def test_transition_refuses_prod_as_source():
+    for to_env in ("dev", "test", "prod"):
+        exited, code, err = _capture_stderr_exit(
+            lambda te=to_env: wa.check_deploy_transition("prod", te)
+        )
+        assert exited and code == 1, f"prod->{to_env} should be refused"
+
+
+def test_transition_refuses_same_env():
+    for env in ("dev", "test", "prod"):
+        exited, code, err = _capture_stderr_exit(
+            lambda e=env: wa.check_deploy_transition(e, e)
+        )
+        assert exited and code == 1
+        assert "both" in err and env in err
+
+
+# ---------------------------------------------------------------------------
+# _strip_env_suffix / derive_sibling_profile
+# ---------------------------------------------------------------------------
+
+
+def test_strip_env_suffix_dev():
+    assert wa._strip_env_suffix("acme-dev") == "acme"
+
+
+def test_strip_env_suffix_test():
+    assert wa._strip_env_suffix("acme-test") == "acme"
+
+
+def test_strip_env_suffix_prod():
+    assert wa._strip_env_suffix("acme-prod") == "acme"
+
+
+def test_strip_env_suffix_missing_returns_none():
+    assert wa._strip_env_suffix("randomname") is None
+
+
+def test_strip_env_suffix_just_suffix_returns_none():
+    # The suffix alone shouldn't count as an org match (empty prefix).
+    assert wa._strip_env_suffix("-dev") is None
+
+
+def test_strip_env_suffix_multi_dash_org():
+    # Multi-dash org names like "my-corp" should still strip correctly.
+    assert wa._strip_env_suffix("my-corp-dev") == "my-corp"
+
+
+def test_derive_sibling_dev_to_test():
+    assert wa.derive_sibling_profile("acme-dev", "test") == "acme-test"
+
+
+def test_derive_sibling_test_to_prod():
+    assert wa.derive_sibling_profile("acme-test", "prod") == "acme-prod"
+
+
+def test_derive_sibling_unparseable_returns_none():
+    assert wa.derive_sibling_profile("plain-name", "test") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_deploy_folder_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_folder_id_uses_explicit():
+    assert wa.resolve_deploy_folder_id(42) == 42
+
+
+def test_resolve_folder_id_reads_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            (Path(d) / ".workatoenv").write_text(
+                json.dumps({"workspace_id": 1, "folder_id": 777})
+            )
+            assert wa.resolve_deploy_folder_id(None) == 777
+        finally:
+            os.chdir(prev)
+
+
+def test_resolve_folder_id_errors_when_no_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            exited, code, err = _capture_stderr_exit(
+                lambda: wa.resolve_deploy_folder_id(None)
+            )
+            assert exited and code == 1
+            assert ".workatoenv" in err
+        finally:
+            os.chdir(prev)
+
+
+def test_resolve_folder_id_errors_when_non_int_in_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            (Path(d) / ".workatoenv").write_text(
+                json.dumps({"workspace_id": 1, "folder_id": "not-an-int"})
+            )
+            exited, code, err = _capture_stderr_exit(
+                lambda: wa.resolve_deploy_folder_id(None)
+            )
+            assert exited and code == 1
+            assert "folder_id" in err
+        finally:
+            os.chdir(prev)
+
+
+# ---------------------------------------------------------------------------
+# resolve_deploy_profiles — uses monkey-patched load_profiles / resolve_profile
+# ---------------------------------------------------------------------------
+
+
+def _with_profile_pool(profiles: dict, current_resolution: tuple[str, dict] | None):
+    """Return restore callable; patches load_profiles + resolve_profile."""
+    saved_load = wa.load_profiles
+    saved_resolve = wa.resolve_profile
+
+    def fake_load():
+        return {"profiles": profiles, "current_profile": None}
+
+    def fake_resolve(explicit):
+        if explicit is not None:
+            return explicit, profiles[explicit]
+        if current_resolution is None:
+            print(
+                "Error: fake resolve_profile called with no default set",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return current_resolution
+
+    wa.load_profiles = fake_load
+    wa.resolve_profile = fake_resolve
+
+    def restore():
+        wa.load_profiles = saved_load
+        wa.resolve_profile = saved_resolve
+
+    return restore
+
+
+def test_resolve_profiles_derives_target_from_source():
+    pool = {
+        "acme-dev": {"region_url": "https://dev.example"},
+        "acme-test": {"region_url": "https://test.example"},
+    }
+    restore = _with_profile_pool(pool, ("acme-dev", pool["acme-dev"]))
+    try:
+        (sn, sp), (tn, tp) = wa.resolve_deploy_profiles(
+            "dev", "test",
+            explicit_from=None, explicit_to=None, explicit_default=None,
+        )
+        assert sn == "acme-dev"
+        assert tn == "acme-test"
+        assert sp["region_url"].endswith("dev.example")
+        assert tp["region_url"].endswith("test.example")
+    finally:
+        restore()
+
+
+def test_resolve_profiles_explicit_overrides_both():
+    pool = {
+        "acme-dev": {"region_url": "u1"},
+        "acme-test": {"region_url": "u2"},
+        "foo-test": {"region_url": "u3"},
+    }
+    restore = _with_profile_pool(pool, ("acme-dev", pool["acme-dev"]))
+    try:
+        (sn, _), (tn, _) = wa.resolve_deploy_profiles(
+            "dev", "test",
+            explicit_from="acme-dev", explicit_to="foo-test",
+            explicit_default=None,
+        )
+        assert sn == "acme-dev"
+        assert tn == "foo-test"
+    finally:
+        restore()
+
+
+def test_resolve_profiles_errors_when_source_not_in_pool():
+    pool = {"acme-dev": {"region_url": "u1"}}
+    restore = _with_profile_pool(pool, ("acme-dev", pool["acme-dev"]))
+    try:
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.resolve_deploy_profiles(
+                "dev", "test",
+                explicit_from="missing-dev", explicit_to=None,
+                explicit_default=None,
+            )
+        )
+        assert exited and code == 1
+        assert "source profile" in err
+        assert "missing-dev" in err
+    finally:
+        restore()
+
+
+def test_resolve_profiles_errors_when_target_cannot_be_derived():
+    # Current profile doesn't follow <org>-<env>, so target cannot be derived
+    # and there's no --to-profile override.
+    pool = {"plainname": {"region_url": "u1"}}
+    restore = _with_profile_pool(pool, ("plainname", pool["plainname"]))
+    try:
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.resolve_deploy_profiles(
+                "dev", "test",
+                explicit_from=None, explicit_to=None,
+                explicit_default=None,
+            )
+        )
+        assert exited and code == 1
+        assert "cannot derive" in err
+        assert "--to-profile" in err
+    finally:
+        restore()
+
+
+def test_resolve_profiles_errors_when_derived_target_not_in_pool():
+    # Source resolves, derivation works, but `<org>-test` isn't configured.
+    pool = {"acme-dev": {"region_url": "u1"}}
+    restore = _with_profile_pool(pool, ("acme-dev", pool["acme-dev"]))
+    try:
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.resolve_deploy_profiles(
+                "dev", "test",
+                explicit_from=None, explicit_to=None,
+                explicit_default=None,
+            )
+        )
+        assert exited and code == 1
+        assert "target profile 'acme-test'" in err
+    finally:
+        restore()
+
+
+# ---------------------------------------------------------------------------
+# _summarize_assets
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_assets_groups_by_type():
+    assets = [
+        {"id": 1, "type": "recipe", "name": "A"},
+        {"id": 2, "type": "recipe", "name": "B"},
+        {"id": 3, "type": "connection", "name": "C"},
+    ]
+    assert wa._summarize_assets(assets) == {"recipe": 2, "connection": 1}
+
+
+def test_summarize_assets_handles_asset_type_alias():
+    assert wa._summarize_assets([{"asset_type": "lookup_table"}]) == {
+        "lookup_table": 1
+    }
+
+
+def test_summarize_assets_unknown_for_typeless():
+    assert wa._summarize_assets([{"id": 1}]) == {"unknown": 1}
+
+
+def test_summarize_assets_skips_non_dict():
+    assert wa._summarize_assets(["not a dict", None]) == {}  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# cmd_deploy_preview — guard runs BEFORE any API/profile work
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingAPI:
+    """If any method is called, the test fails — used to prove guards short-circuit."""
+
+    def __getattr__(self, name):
+        def boom(*_a, **_kw):
+            raise AssertionError(
+                f"_ExplodingAPI.{name} called — guard did not short-circuit"
+            )
+        return boom
+
+
+def test_cmd_deploy_preview_guard_short_circuits_dev_to_prod():
+    """Skip-tier transition must be refused before profile/token resolution."""
+    # Patch load_profiles + get_token + WorkatoAPI to blow up if reached
+    saved_load = wa.load_profiles
+    saved_token = wa.get_token
+    saved_api = wa.WorkatoAPI
+
+    def boom_load():
+        raise AssertionError("load_profiles called despite refused transition")
+
+    def boom_token(_n):
+        raise AssertionError("get_token called despite refused transition")
+
+    class BoomAPI:
+        def __init__(self, *a, **kw):
+            raise AssertionError("WorkatoAPI() constructed despite refused transition")
+
+    wa.load_profiles = boom_load
+    wa.get_token = boom_token
+    wa.WorkatoAPI = BoomAPI  # type: ignore[assignment]
+    try:
+        args = SimpleNamespace(
+            from_env="dev", to_env="prod",
+            folder_id=42, from_profile=None, to_profile=None,
+            profile=None,
+        )
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.cmd_deploy_preview(None, args)
+        )
+        assert exited and code == 1
+        assert "dev->prod" in err
+    finally:
+        wa.load_profiles = saved_load
+        wa.get_token = saved_token
+        wa.WorkatoAPI = saved_api  # type: ignore[assignment]
+
+
+def test_cmd_deploy_preview_end_to_end_dev_to_test():
+    """Happy path: dev->test renders the expected preview JSON shape."""
+    pool = {
+        "acme-dev": {"region_url": "https://dev.example.com"},
+        "acme-test": {"region_url": "https://test.example.com"},
+    }
+    saved_load = wa.load_profiles
+    saved_resolve = wa.resolve_profile
+    saved_token = wa.get_token
+    saved_api = wa.WorkatoAPI
+
+    def fake_load():
+        return {"profiles": pool, "current_profile": None}
+
+    def fake_resolve(explicit):
+        if explicit is not None:
+            return explicit, pool[explicit]
+        return "acme-dev", pool["acme-dev"]
+
+    def fake_token(name):
+        assert name == "acme-dev", f"expected source token only, got {name}"
+        return "fake-token"
+
+    class FakeAPI:
+        def __init__(self, base_url, token):
+            self.base_url = base_url
+            self.token = token
+            self._calls: list[tuple[int, ...]] = []
+
+        def deploy_folder_assets(self, folder_id):
+            self._calls.append(("folder_assets", folder_id))
+            return [
+                {"id": 1, "type": "recipe", "name": "R1"},
+                {"id": 2, "type": "connection", "name": "C1"},
+            ]
+
+    wa.load_profiles = fake_load
+    wa.resolve_profile = fake_resolve
+    wa.get_token = fake_token
+    wa.WorkatoAPI = FakeAPI  # type: ignore[assignment]
+    try:
+        args = SimpleNamespace(
+            from_env="dev", to_env="test",
+            folder_id=42, from_profile=None, to_profile=None,
+            profile=None,
+        )
+        out = _capture_stdout(lambda: wa.cmd_deploy_preview(None, args))
+        parsed = json.loads(out)
+        assert parsed["mode"] == "preview"
+        assert parsed["source"]["profile"] == "acme-dev"
+        assert parsed["source"]["env"] == "dev"
+        assert parsed["source"]["workspace_url"].endswith("dev.example.com")
+        assert parsed["target"]["profile"] == "acme-test"
+        assert parsed["target"]["env"] == "test"
+        assert parsed["target"]["workspace_url"].endswith("test.example.com")
+        assert parsed["folder_id"] == 42
+        assert parsed["asset_summary"] == {"recipe": 1, "connection": 1}
+        assert len(parsed["assets"]) == 2
+        assert any("No API writes" in n for n in parsed["notes"])
+    finally:
+        wa.load_profiles = saved_load
+        wa.resolve_profile = saved_resolve
+        wa.get_token = saved_token
+        wa.WorkatoAPI = saved_api  # type: ignore[assignment]
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -23,6 +23,11 @@ Usage:
      connector_id back to connectors/docs/<name>.md frontmatter)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
+  python3 scripts/workato-api.py deploy preview --from <env> --to <env>
+    [--folder-id <id>] [--from-profile <name>] [--to-profile <name>]
+    (read-only preview of the manifest that would be exported; runs the
+     same env-transition guards as a real deploy will. Real deploy
+     execution is tracked under Issue #160 PR-2b.)
   python3 scripts/workato-api.py profile show
 
 Global options:
@@ -42,9 +47,13 @@ Subcommand conventions (for contributors adding new subcommands):
     - provide --dry-run that prints the intended request without sending it
     - set epilog= with at least one --dry-run example as the first example
     - guard environment boundaries in code, not just docs:
-        * deploy commands: --from and --to required; refuse if
-          --to in {test,prod} and --from != dev
-        * --to prod additionally requires --yes (CI-friendly confirm)
+        * deploy commands: --from and --to required; the (from, to) pair
+          must be one of {(dev, test), (test, prod)} — skip-tier
+          (dev -> prod), backward (test -> dev, prod -> *), and same-env
+          transitions are refused
+        * execution deploys with --to prod additionally require --yes
+          (CI-friendly confirm); preview/read-only deploy commands do not
+          require --yes since they have no side effects
 
   Read-only subcommands (*list, *get, jobs list/get, profile show) do not
   need --dry-run or epilog, but still need help= and description=.
@@ -513,6 +522,167 @@ class WorkatoAPI:
             page += 1
         return all_recipes
 
+    # -- Deploy (Recipe Lifecycle Management) --
+
+    def deploy_folder_assets(self, folder_id: int) -> list:
+        """List assets in a folder that would be included in an export manifest.
+
+        Calls the read-only `GET /api/export_manifests/folder_assets`
+        endpoint. Returns the asset list as Workato reports it (each entry
+        carries id, type, name, and folder context). This drives the
+        preview output for `deploy preview`; the same data feeds the
+        manifest body used by `deploy run` (PR-2b).
+        """
+        result = self._request(
+            "/api/export_manifests/folder_assets",
+            params={"folder_id": folder_id},
+        )
+        if isinstance(result, dict):
+            data = result.get("result", result.get("data", result))
+            if isinstance(data, dict):
+                return data.get("assets", [])
+            if isinstance(data, list):
+                return data
+        return result if isinstance(result, list) else []
+
+
+# ---------------------------------------------------------------------------
+# Deploy helpers (environment guard + profile pair resolution)
+# ---------------------------------------------------------------------------
+
+
+DEPLOY_ENVS = ("dev", "test", "prod")
+ALLOWED_DEPLOY_TRANSITIONS = {("dev", "test"), ("test", "prod")}
+
+
+def check_deploy_transition(from_env: str, to_env: str) -> None:
+    """Refuse invalid (from, to) pairs before any API call or profile work.
+
+    Allowed: (dev, test), (test, prod). Everything else — skip-tier
+    (dev -> prod), backward (test -> dev, prod -> *), and same-env —
+    is rejected. See workato-deployment-flow.md.
+    """
+    if from_env == to_env:
+        print(
+            f"Error: --from and --to are both '{from_env}'. "
+            f"Deploy requires distinct source and target environments.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if (from_env, to_env) not in ALLOWED_DEPLOY_TRANSITIONS:
+        allowed = ", ".join(f"{a}->{b}" for a, b in sorted(ALLOWED_DEPLOY_TRANSITIONS))
+        print(
+            f"Error: deploy {from_env}->{to_env} is not allowed. "
+            f"Allowed transitions: {allowed}. "
+            f"Skip-tier (dev->prod), backward, and same-env transitions are "
+            f"refused (see workato-deployment-flow.md).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _strip_env_suffix(profile_name: str) -> str | None:
+    """Return the org prefix if profile_name follows `<org>-<env>`."""
+    for env in DEPLOY_ENVS:
+        suffix = f"-{env}"
+        if profile_name.endswith(suffix) and len(profile_name) > len(suffix):
+            return profile_name[: -len(suffix)]
+    return None
+
+
+def derive_sibling_profile(source_name: str, target_env: str) -> str | None:
+    """Given `<org>-<env>`, return `<org>-<target_env>` if pattern matches."""
+    org = _strip_env_suffix(source_name)
+    if org is None:
+        return None
+    return f"{org}-{target_env}"
+
+
+def resolve_deploy_profiles(
+    from_env: str,
+    to_env: str,
+    explicit_from: str | None,
+    explicit_to: str | None,
+    explicit_default: str | None,
+) -> tuple[tuple[str, dict], tuple[str, dict]]:
+    """Resolve source and target profiles for a deploy.
+
+    Resolution order:
+      Source: explicit --from-profile, else current resolved profile
+              (must follow `<org>-<from_env>` so the target can be derived).
+      Target: explicit --to-profile, else `<org>-<to_env>` derived from
+              the source profile name.
+
+    Exits with a clear error if any required profile cannot be resolved.
+    """
+    profiles_data = load_profiles()
+    profiles = profiles_data.get("profiles", {})
+
+    # Source profile
+    if explicit_from:
+        source_name = explicit_from
+    else:
+        source_name, _ = resolve_profile(explicit_default)
+    if source_name not in profiles:
+        print(
+            f"Error: source profile '{source_name}' not found in "
+            f"~/.workato/profiles.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    source_profile = profiles[source_name]
+
+    # Target profile
+    if explicit_to:
+        target_name = explicit_to
+    else:
+        derived = derive_sibling_profile(source_name, to_env)
+        if derived is None:
+            print(
+                f"Error: cannot derive target profile from "
+                f"'{source_name}'. Expected `<org>-{from_env}` naming so "
+                f"the target can be inferred as `<org>-{to_env}`. Pass "
+                f"--to-profile <name> to override.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        target_name = derived
+    if target_name not in profiles:
+        print(
+            f"Error: target profile '{target_name}' not found in "
+            f"~/.workato/profiles. Configure it with `workato init` or "
+            f"pass --to-profile <name>.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    target_profile = profiles[target_name]
+
+    return (source_name, source_profile), (target_name, target_profile)
+
+
+def resolve_deploy_folder_id(explicit_folder_id: int | None) -> int:
+    """Resolve folder_id from --folder-id or .workatoenv. Exit if neither."""
+    if explicit_folder_id is not None:
+        return explicit_folder_id
+    env_data = find_workatoenv()
+    if env_data is None:
+        print(
+            "Error: no --folder-id given and no .workatoenv found by "
+            "walking up from the current directory. Run from inside a "
+            "project, or pass --folder-id <id>.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    folder_id = env_data.get("folder_id")
+    if not isinstance(folder_id, int):
+        print(
+            "Error: .workatoenv was found but does not contain an "
+            "integer folder_id. Pass --folder-id <id> explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return folder_id
+
 
 # ---------------------------------------------------------------------------
 # CLI Commands
@@ -542,6 +712,74 @@ def cmd_connectors_list_custom(api: WorkatoAPI, args: argparse.Namespace):
 def cmd_recipes_list(api: WorkatoAPI, args: argparse.Namespace):
     recipes = api.recipes_list(args.folder_id)
     print(json.dumps(recipes, indent=2, ensure_ascii=False))
+
+
+def _summarize_assets(assets: list) -> dict:
+    """Group assets by `type` and return {type: count}."""
+    counts: dict = {}
+    for a in assets:
+        if not isinstance(a, dict):
+            continue
+        kind = a.get("type") or a.get("asset_type") or "unknown"
+        counts[kind] = counts.get(kind, 0) + 1
+    return counts
+
+
+def cmd_deploy_preview(_api: WorkatoAPI, args: argparse.Namespace):
+    """Read-only preview of what `deploy run` (PR-2b) would export.
+
+    Runs the env-transition guard, resolves source and target profiles,
+    resolves folder_id, then calls the source workspace's read-only
+    folder_assets endpoint and prints what would be packaged. Makes no
+    writes to either workspace.
+    """
+    check_deploy_transition(args.from_env, args.to_env)
+
+    (source_name, source_profile), (target_name, target_profile) = \
+        resolve_deploy_profiles(
+            args.from_env, args.to_env,
+            args.from_profile, args.to_profile,
+            args.profile,
+        )
+
+    folder_id = resolve_deploy_folder_id(args.folder_id)
+
+    source_region = source_profile.get("region_url", "")
+    if not source_region:
+        print(
+            f"Error: source profile '{source_name}' has no region_url.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    source_token = get_token(source_name)
+    source_api = WorkatoAPI(source_region, source_token)
+
+    assets = source_api.deploy_folder_assets(folder_id)
+    summary = _summarize_assets(assets)
+
+    output = {
+        "mode": "preview",
+        "source": {
+            "profile": source_name,
+            "workspace_url": source_region,
+            "env": args.from_env,
+        },
+        "target": {
+            "profile": target_name,
+            "workspace_url": target_profile.get("region_url", ""),
+            "env": args.to_env,
+        },
+        "folder_id": folder_id,
+        "asset_summary": summary,
+        "assets": assets,
+        "notes": [
+            "No API writes were performed; only the read-only "
+            "/api/export_manifests/folder_assets endpoint was called on the "
+            "source workspace.",
+            "Real deploy execution is tracked under Issue #160 PR-2b.",
+        ],
+    }
+    print(json.dumps(output, indent=2, ensure_ascii=False))
 
 
 def cmd_oauth_profiles_list(api: WorkatoAPI, args: argparse.Namespace):
@@ -1200,6 +1438,56 @@ def main():
         "--folder-id", type=int, default=None, help="Filter by folder ID"
     )
 
+    # -- deploy --
+    deploy_parser = subparsers.add_parser(
+        "deploy", help="Promote a project between environments (Recipe Lifecycle)"
+    )
+    deploy_sub = deploy_parser.add_subparsers(dest="deploy_command")
+
+    deploy_preview_p = deploy_sub.add_parser(
+        "preview",
+        help="Preview the manifest that would be exported",
+        description=(
+            "Preview what would be packaged for a deploy from --from to "
+            "--to, without writing to either workspace. Runs the same "
+            "(from, to) transition guards as a real deploy: only "
+            "dev->test and test->prod are allowed. Calls only the "
+            "read-only /api/export_manifests/folder_assets endpoint on "
+            "the source workspace."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Preview a dev -> test deploy of the current project\n"
+            "  python3 scripts/workato-api.py deploy preview --from dev --to test\n\n"
+            "  # Preview a test -> prod deploy with explicit folder and profiles\n"
+            "  python3 scripts/workato-api.py deploy preview --from test --to prod \\\n"
+            "      --folder-id 12345 --from-profile acme-test --to-profile acme-prod\n\n"
+            "  # Skip-tier (dev -> prod) is refused before any API call:\n"
+            "  python3 scripts/workato-api.py deploy preview --from dev --to prod\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    deploy_preview_p.add_argument(
+        "--from", dest="from_env", choices=DEPLOY_ENVS, required=True,
+        help="Source environment (dev/test/prod)",
+    )
+    deploy_preview_p.add_argument(
+        "--to", dest="to_env", choices=DEPLOY_ENVS, required=True,
+        help="Target environment (dev/test/prod)",
+    )
+    deploy_preview_p.add_argument(
+        "--folder-id", type=int, default=None,
+        help="Folder ID to export (default: from .workatoenv in cwd)",
+    )
+    deploy_preview_p.add_argument(
+        "--from-profile", default=None,
+        help="Source profile name (default: current resolved profile)",
+    )
+    deploy_preview_p.add_argument(
+        "--to-profile", default=None,
+        help="Target profile name (default: derive `<org>-<to>` from source)",
+    )
+
     # -- sdk --
     sdk_parser = subparsers.add_parser(
         "sdk", help="Connector SDK commands (uses Platform API token)"
@@ -1445,6 +1733,15 @@ def main():
     if args.command == "sdk" and getattr(args, "sdk_command", None) in ("decrypt", "edit"):
         handler = {"decrypt": cmd_sdk_decrypt, "edit": cmd_sdk_edit}[args.sdk_command]
         handler(None, args)
+        return
+
+    # deploy resolves source/target profiles independently of the global
+    # --profile flag, so it dispatches before the single-profile setup.
+    if args.command == "deploy":
+        if getattr(args, "deploy_command", None) == "preview":
+            cmd_deploy_preview(None, args)  # type: ignore[arg-type]
+        else:
+            deploy_parser.print_help()
         return
 
     # Resolve profile and create API client


### PR DESCRIPTION
## Summary

First slice of Issue #160 group B (deploy). This PR ships the safety/UX contract for project promotion as a **read-only preview command**; the real export → poll → download → import pipeline lands in **PR-2b**.

### New command

```bash
python3 scripts/workato-api.py deploy preview --from <env> --to <env> \
  [--folder-id <id>] [--from-profile <name>] [--to-profile <name>]
```

- Resolves source and target profiles independently of `--profile`.
- Calls **only** the read-only `GET /api/export_manifests/folder_assets` on the source workspace and prints what would be packaged. No writes to either workspace.

### Environment transition guard

Only `(dev, test)` and `(test, prod)` are allowed. Everything else — skip-tier (`dev → prod`), backward (`test → dev`, any `prod → *`), and same-env transitions — is refused **before any profile or token resolution runs**. Verified by a test that swaps `load_profiles` / `get_token` / `WorkatoAPI` for exploding stubs and confirms none are touched on a refused transition.

### Dual-profile resolution

- Source: `--from-profile` or the current resolved profile (must follow `<org>-<env>` if `--from-profile` is omitted, so the target can be derived).
- Target: `--to-profile` or derived as `<org>-<to>` from the source name. Clear error when derivation fails, with the override hint inline.

### Convention fix

PR #166 added the Subcommand Conventions docstring with this guard rule:

> refuse if `--to in {test,prod}` and `--from != dev`

That incorrectly blocks the canonical `test → prod` step. This PR corrects it to an explicit allow-list and clarifies that `--yes` for `--to prod` applies to **execution** commands only (preview is harmless).

### What's NOT in this PR

- `deploy run` (real export → poll → download → import): PR-2b
- Project-name → folder lookup: PR-2c (currently `--folder-id` or `.workatoenv`)
- Approval flow: out of scope; per kit policy, never scripted

## Test plan

- [x] `python3 scripts/tests/test_deploy_preview.py` — 30 new tests
  - 6 transition-guard cases (allow / refuse all directions)
  - 6 `<org>-<env>` name-substitution cases (incl. multi-dash org, missing suffix, suffix-only)
  - 4 `folder_id` resolution cases (explicit, `.workatoenv`, missing, non-int)
  - 5 dual-profile resolution cases (derive, explicit override, source missing, target underivable, derived target not configured)
  - 4 asset summarization cases
  - 1 end-to-end preview happy-path JSON shape assertion
  - 1 guard short-circuit assertion (explodes if `load_profiles`/`get_token`/`WorkatoAPI` is touched on a refused transition)
- [x] All 138 existing tests still pass (CI workflow `tests.yml` runs every `test_*.py` under `scripts/tests/`)
- [x] `--help` rendering verified (`deploy --help`, `deploy preview --help`)
- [ ] Reviewer sanity check on the convention text wording in the module docstring
- [ ] Reviewer check that the allow-list reflects `workato-deployment-flow.md` correctly

Refs #160 (PR-2a of B)