### PR TITLE
feat(deploy): Projects-API deploy preview/run/status (supersedes #167, refs #160)

### DIFF
--- a/scripts/tests/test_deploy_projects.py
+++ b/scripts/tests/test_deploy_projects.py
@@ -174,9 +174,14 @@ def test_resolve_project_ref_uses_explicit_folder_id():
     assert wa.resolve_project_ref(None, 88) == "f88"
 
 
-def test_resolve_project_ref_prefers_project_id_over_folder():
-    # When both are given, project_id wins (it is the unambiguous form).
-    assert wa.resolve_project_ref(1, 2) == "1"
+def test_resolve_project_ref_refuses_both_at_once():
+    # Defense-in-depth: even if a direct caller bypasses the argparse
+    # mutex (e.g. constructs args by hand), the helper refuses.
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.resolve_project_ref(1, 2)
+    )
+    assert exited and code == 1
+    assert "mutually exclusive" in err
 
 
 def test_resolve_project_ref_reads_workatoenv():
@@ -189,6 +194,45 @@ def test_resolve_project_ref_reads_workatoenv():
             assert wa.resolve_project_ref(None, None) == "f777"
         finally:
             os.chdir(prev)
+
+
+def test_cli_argparse_refuses_both_project_and_folder_id():
+    """argparse mutex group: passing both should exit with code 2."""
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "deploy", "preview",
+            "--to", "test",
+            "--project-id", "1",
+            "--folder-id", "2",
+        ],
+        capture_output=True, text=True,
+    )
+    # argparse uses exit code 2 for argument errors.
+    assert result.returncode == 2, (
+        f"expected exit 2 from argparse, got {result.returncode}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "not allowed with" in result.stderr or "mutually exclusive" in result.stderr
+
+
+def test_cli_argparse_refuses_both_for_run_subcommand():
+    """Mutex group is shared by `deploy run` too."""
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "deploy", "run",
+            "--to", "test",
+            "--project-id", "1",
+            "--folder-id", "2",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 from argparse, got {result.returncode}"
+    )
 
 
 def test_resolve_project_ref_errors_when_nothing_resolves():

--- a/scripts/tests/test_deploy_projects.py
+++ b/scripts/tests/test_deploy_projects.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Tests for the Projects-API-based deploy commands in workato-api.py.
+
+Covers:
+  - infer_profile_env
+  - check_deploy_transition (allow-list, refusal categories)
+  - resolve_project_ref (--project-id, --folder-id, .workatoenv, missing)
+  - poll_deployment (terminal exit, timeout exit, sleep injection)
+  - cmd_deploy_run --yes gate for prod
+  - cmd_deploy_run env-guard short-circuits before any API call
+  - cmd_deploy_run --wait happy path / non-success exit code
+  - cmd_deploy_preview happy path
+
+Run with:
+    python3 scripts/tests/test_deploy_projects.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chdir(target: Path) -> Path:
+    prev = Path.cwd()
+    os.chdir(target)
+    return prev
+
+
+def _capture_stderr_exit(fn):
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    return exited, code, err
+
+
+def _capture_stdout(fn):
+    saved = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        fn()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved
+
+
+# ---------------------------------------------------------------------------
+# infer_profile_env
+# ---------------------------------------------------------------------------
+
+
+def test_infer_env_dev():
+    assert wa.infer_profile_env("acme-dev") == "dev"
+
+
+def test_infer_env_test():
+    assert wa.infer_profile_env("acme-test") == "test"
+
+
+def test_infer_env_prod():
+    assert wa.infer_profile_env("acme-prod") == "prod"
+
+
+def test_infer_env_multi_dash_org():
+    assert wa.infer_profile_env("my-corp-dev") == "dev"
+
+
+def test_infer_env_missing_returns_none():
+    assert wa.infer_profile_env("plain") is None
+
+
+def test_infer_env_just_suffix_returns_none():
+    # The suffix alone (empty org prefix) does not count as a match.
+    assert wa.infer_profile_env("-dev") is None
+
+
+# ---------------------------------------------------------------------------
+# check_deploy_transition — allow-list and refusals
+# ---------------------------------------------------------------------------
+
+
+def test_transition_allows_dev_to_test():
+    wa.check_deploy_transition("dev", "test")  # no exit
+
+
+def test_transition_allows_test_to_prod():
+    wa.check_deploy_transition("test", "prod")
+
+
+def test_transition_refuses_dev_to_prod_skip_tier():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.check_deploy_transition("dev", "prod")
+    )
+    assert exited and code == 1
+    assert "dev->prod" in err
+    assert "not allowed" in err
+
+
+def test_transition_refuses_test_to_dev_backward():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.check_deploy_transition("test", "dev")
+    )
+    assert exited and code == 1
+    assert "test->dev" in err
+
+
+def test_transition_refuses_prod_as_source():
+    for to_env in ("dev", "test", "prod"):
+        exited, code, _ = _capture_stderr_exit(
+            lambda te=to_env: wa.check_deploy_transition("prod", te)
+        )
+        assert exited and code == 1, f"prod->{to_env} should be refused"
+
+
+def test_transition_refuses_same_env():
+    for env in ("dev", "test", "prod"):
+        exited, code, err = _capture_stderr_exit(
+            lambda e=env: wa.check_deploy_transition(e, e)
+        )
+        assert exited and code == 1
+        assert env in err
+
+
+def test_transition_refuses_when_source_is_none():
+    """Profile name didn't follow `<org>-<env>` → infer returns None → refuse."""
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.check_deploy_transition(None, "test")
+    )
+    assert exited and code == 1
+    assert "infer source environment" in err
+    assert "<org>-<env>" in err
+
+
+# ---------------------------------------------------------------------------
+# resolve_project_ref
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_project_ref_uses_explicit_project_id():
+    assert wa.resolve_project_ref(42, None) == "42"
+
+
+def test_resolve_project_ref_uses_explicit_folder_id():
+    assert wa.resolve_project_ref(None, 88) == "f88"
+
+
+def test_resolve_project_ref_prefers_project_id_over_folder():
+    # When both are given, project_id wins (it is the unambiguous form).
+    assert wa.resolve_project_ref(1, 2) == "1"
+
+
+def test_resolve_project_ref_reads_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            (Path(d) / ".workatoenv").write_text(
+                json.dumps({"workspace_id": 1, "folder_id": 777})
+            )
+            assert wa.resolve_project_ref(None, None) == "f777"
+        finally:
+            os.chdir(prev)
+
+
+def test_resolve_project_ref_errors_when_nothing_resolves():
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            exited, code, err = _capture_stderr_exit(
+                lambda: wa.resolve_project_ref(None, None)
+            )
+            assert exited and code == 1
+            assert "--project-id" in err and "--folder-id" in err
+        finally:
+            os.chdir(prev)
+
+
+# ---------------------------------------------------------------------------
+# poll_deployment — injected sleep and clock
+# ---------------------------------------------------------------------------
+
+
+class _PollFakeAPI:
+    def __init__(self, states: list[str]):
+        self._states = states
+        self.calls = 0
+
+    def deployment_get(self, _id):
+        s = self._states[min(self.calls, len(self._states) - 1)]
+        self.calls += 1
+        return {"id": 1, "state": s}
+
+
+def test_poll_returns_on_first_terminal_state():
+    api = _PollFakeAPI(["success"])
+    sleeps: list[float] = []
+    t = [0.0]
+
+    def sleep(d):
+        sleeps.append(d)
+        t[0] += d
+
+    def now():
+        return t[0]
+
+    result = wa.poll_deployment(
+        api, 1, timeout_seconds=10, poll_interval_seconds=2.0,
+        _sleep=sleep, _now=now,
+    )
+    assert result["state"] == "success"
+    assert api.calls == 1
+    assert sleeps == []  # no sleep needed when first state is terminal
+
+
+def test_poll_iterates_until_terminal():
+    api = _PollFakeAPI(["pending", "pending", "success"])
+    sleeps: list[float] = []
+    t = [0.0]
+    wa.poll_deployment(
+        api, 1, timeout_seconds=10, poll_interval_seconds=2.0,
+        _sleep=lambda d: (sleeps.append(d), t.__setitem__(0, t[0] + d)),
+        _now=lambda: t[0],
+    )
+    assert api.calls == 3
+    assert sleeps == [2.0, 2.0]
+
+
+def test_poll_exits_on_timeout():
+    api = _PollFakeAPI(["pending"])  # never reaches terminal
+    t = [0.0]
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.poll_deployment(
+            api, 1, timeout_seconds=5, poll_interval_seconds=2.0,
+            _sleep=lambda d: t.__setitem__(0, t[0] + d),
+            _now=lambda: t[0],
+        )
+    )
+    assert exited and code == 1
+    assert "did not reach a terminal state" in err
+    assert "5s" in err
+
+
+def test_poll_recognizes_failed_state_as_terminal():
+    api = _PollFakeAPI(["failed"])
+    result = wa.poll_deployment(
+        api, 1, timeout_seconds=10, poll_interval_seconds=2.0,
+        _sleep=lambda d: None, _now=lambda: 0.0,
+    )
+    assert result["state"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# cmd_deploy_run — env guard short-circuits + --yes prod gate
+# ---------------------------------------------------------------------------
+
+
+def _patch_profile(name: str, region_url: str = "https://example.com"):
+    """Patch resolve_profile + get_token + load_profiles to return a single profile.
+
+    Returns a restore callable.
+    """
+    saved_load = wa.load_profiles
+    saved_resolve = wa.resolve_profile
+    saved_token = wa.get_token
+
+    pool = {name: {"region_url": region_url, "workspace_id": 1}}
+
+    wa.load_profiles = lambda: {"profiles": pool, "current_profile": name}
+    wa.resolve_profile = lambda explicit: (
+        (explicit, pool[explicit]) if explicit else (name, pool[name])
+    )
+    wa.get_token = lambda _n: "fake-token"
+
+    def restore():
+        wa.load_profiles = saved_load
+        wa.resolve_profile = saved_resolve
+        wa.get_token = saved_token
+
+    return restore
+
+
+def _patch_api(fake_api_cls):
+    saved = wa.WorkatoAPI
+    wa.WorkatoAPI = fake_api_cls  # type: ignore[assignment]
+    return lambda: setattr(wa, "WorkatoAPI", saved)
+
+
+def test_run_short_circuits_on_bad_transition_dev_to_prod():
+    """Dev profile + --to prod must be refused before any API call."""
+    restore_p = _patch_profile("acme-dev")
+
+    class BoomAPI:
+        def __init__(self, *_a, **_kw):
+            raise AssertionError("WorkatoAPI was constructed despite refused transition")
+
+    # WorkatoAPI IS constructed in _deploy_resolve_profile_and_api before the
+    # guard runs (we need the client to make API calls if the guard passes).
+    # Re-architecting to defer construction would require larger changes; the
+    # important guarantee is that no HTTP call is made. So we patch the actual
+    # API methods to explode instead of the constructor.
+    class ExplodingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, *_a, **_kw):
+            raise AssertionError(
+                "project_deploy was called despite refused transition"
+            )
+
+        def deployment_get(self, *_a, **_kw):
+            raise AssertionError(
+                "deployment_get was called despite refused transition"
+            )
+
+    restore_api = _patch_api(ExplodingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="prod",
+            project_id=42, folder_id=None,
+            description=None, yes=True, wait=False, timeout=30,
+        )
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.cmd_deploy_run(None, args)
+        )
+        assert exited and code == 1
+        assert "dev->prod" in err
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_run_refuses_prod_without_yes():
+    """Test->prod is an allowed transition, but --yes is required."""
+    restore_p = _patch_profile("acme-test")
+
+    class ExplodingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, *_a, **_kw):
+            raise AssertionError("project_deploy called without --yes")
+
+    restore_api = _patch_api(ExplodingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="prod",
+            project_id=42, folder_id=None,
+            description=None, yes=False, wait=False, timeout=30,
+        )
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.cmd_deploy_run(None, args)
+        )
+        assert exited and code == 1
+        assert "--yes" in err
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_run_allows_test_to_prod_with_yes_no_wait():
+    restore_p = _patch_profile("acme-test")
+    calls: list[tuple] = []
+
+    class RecordingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, project_ref, environment_type, description):
+            calls.append(("project_deploy", project_ref, environment_type, description))
+            return {"id": 999, "state": "pending"}
+
+    restore_api = _patch_api(RecordingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="prod",
+            project_id=42, folder_id=None,
+            description="Release X", yes=True, wait=False, timeout=30,
+        )
+        out = _capture_stdout(lambda: wa.cmd_deploy_run(None, args))
+        parsed = json.loads(out)
+        assert parsed["id"] == 999
+        assert parsed["state"] == "pending"
+        assert calls == [("project_deploy", "42", "prod", "Release X")]
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_run_dev_to_test_with_folder_id_becomes_f_prefix():
+    restore_p = _patch_profile("acme-dev")
+    seen: list[str] = []
+
+    class RecordingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, project_ref, environment_type, description):
+            seen.append(project_ref)
+            return {"id": 1, "state": "pending"}
+
+    restore_api = _patch_api(RecordingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="test",
+            project_id=None, folder_id=12345,
+            description=None, yes=False, wait=False, timeout=30,
+        )
+        _capture_stdout(lambda: wa.cmd_deploy_run(None, args))
+        assert seen == ["f12345"]
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_run_wait_exits_nonzero_when_state_failed():
+    restore_p = _patch_profile("acme-dev")
+
+    class RecordingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, project_ref, environment_type, description):
+            return {"id": 777, "state": "pending"}
+
+        def deployment_get(self, _id):
+            return {"id": 777, "state": "failed", "error": "boom"}
+
+    restore_api = _patch_api(RecordingAPI)
+    saved_poll = wa.poll_deployment
+
+    # Inject sleep/now so the test does not actually wait.
+    def fast_poll(api, did, timeout_seconds, poll_interval_seconds=2.0, _sleep=None, _now=None):
+        return saved_poll(
+            api, did, timeout_seconds, poll_interval_seconds,
+            _sleep=lambda d: None, _now=lambda: 0.0,
+        )
+
+    wa.poll_deployment = fast_poll
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="test",
+            project_id=42, folder_id=None,
+            description=None, yes=False, wait=True, timeout=30,
+        )
+        saved_out = sys.stdout
+        sys.stdout = io.StringIO()
+        exited = False
+        code = 0
+        try:
+            try:
+                wa.cmd_deploy_run(None, args)
+            except SystemExit as e:
+                exited = True
+                code = int(e.code) if isinstance(e.code, int) else 1
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdout = saved_out
+        assert exited and code == 1
+        parsed = json.loads(out)
+        assert parsed["state"] == "failed"
+    finally:
+        wa.poll_deployment = saved_poll
+        restore_api()
+        restore_p()
+
+
+def test_run_wait_zero_exit_on_success():
+    restore_p = _patch_profile("acme-dev")
+
+    class RecordingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def project_deploy(self, *_a, **_kw):
+            return {"id": 100, "state": "pending"}
+
+        def deployment_get(self, _id):
+            return {"id": 100, "state": "success"}
+
+    restore_api = _patch_api(RecordingAPI)
+    saved_poll = wa.poll_deployment
+
+    def fast_poll(api, did, ts, pi=2.0, _sleep=None, _now=None):
+        return saved_poll(
+            api, did, ts, pi, _sleep=lambda d: None, _now=lambda: 0.0,
+        )
+
+    wa.poll_deployment = fast_poll
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="test",
+            project_id=42, folder_id=None,
+            description=None, yes=False, wait=True, timeout=30,
+        )
+        # Should NOT raise SystemExit on success.
+        out = _capture_stdout(lambda: wa.cmd_deploy_run(None, args))
+        parsed = json.loads(out)
+        assert parsed["state"] == "success"
+    finally:
+        wa.poll_deployment = saved_poll
+        restore_api()
+        restore_p()
+
+
+# ---------------------------------------------------------------------------
+# cmd_deploy_preview happy path
+# ---------------------------------------------------------------------------
+
+
+def test_preview_dev_to_test_emits_expected_shape():
+    restore_p = _patch_profile("acme-dev", region_url="https://dev.example.com")
+
+    class RecordingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def recipes_list(self, _folder_id):
+            return [{"id": 5, "name": "R1", "running": False}]
+
+        def project_deploy(self, *_a, **_kw):
+            raise AssertionError("project_deploy must not be called in preview")
+
+    restore_api = _patch_api(RecordingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="test",
+            project_id=None, folder_id=42,
+            description="planned",
+        )
+        out = _capture_stdout(lambda: wa.cmd_deploy_preview(None, args))
+        parsed = json.loads(out)
+        assert parsed["mode"] == "preview"
+        assert parsed["profile"] == "acme-dev"
+        assert parsed["source_env"] == "dev"
+        assert parsed["target_env"] == "test"
+        assert parsed["project_ref"] == "f42"
+        assert parsed["would_call"]["method"] == "POST"
+        assert "environment_type=test" in parsed["would_call"]["url"]
+        assert parsed["would_call"]["url"].startswith(
+            "https://dev.example.com/api/projects/f42/deploy"
+        )
+        assert parsed["would_call"]["body"] == {"description": "planned"}
+        assert parsed["recipes_in_folder"] == [
+            {"id": 5, "name": "R1", "running": False}
+        ]
+        assert any("No API writes" in n for n in parsed["notes"])
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_preview_short_circuits_on_bad_transition():
+    restore_p = _patch_profile("acme-dev")
+
+    class ExplodingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def recipes_list(self, *_a, **_kw):
+            raise AssertionError("recipes_list called despite refused transition")
+
+    restore_api = _patch_api(ExplodingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="prod",   # dev->prod skip-tier
+            project_id=42, folder_id=None,
+            description=None,
+        )
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.cmd_deploy_preview(None, args)
+        )
+        assert exited and code == 1
+        assert "dev->prod" in err
+    finally:
+        restore_api()
+        restore_p()
+
+
+def test_preview_refuses_when_profile_name_unparseable():
+    restore_p = _patch_profile("plainname")
+
+    class ExplodingAPI:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def recipes_list(self, *_a, **_kw):
+            raise AssertionError("recipes_list called despite refused transition")
+
+    restore_api = _patch_api(ExplodingAPI)
+    try:
+        args = SimpleNamespace(
+            profile=None, to_env="test",
+            project_id=42, folder_id=None,
+            description=None,
+        )
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa.cmd_deploy_preview(None, args)
+        )
+        assert exited and code == 1
+        assert "infer source environment" in err
+    finally:
+        restore_api()
+        restore_p()
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -643,8 +643,18 @@ def resolve_project_ref(
       1. --project-id <int>
       2. --folder-id <int>
       3. .workatoenv folder_id (walking up from cwd)
-    Exits with a clear error if none of these resolves.
+    Exits with a clear error if none of these resolves, or if both
+    --project-id and --folder-id are passed (the CLI also enforces the
+    mutex via argparse, but a defense-in-depth check here keeps the
+    helper safe for direct callers).
     """
+    if explicit_project_id is not None and explicit_folder_id is not None:
+        print(
+            "Error: --project-id and --folder-id are mutually exclusive; "
+            "pass exactly one.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if explicit_project_id is not None:
         return str(explicit_project_id)
     if explicit_folder_id is not None:
@@ -1538,13 +1548,19 @@ def main():
             "--to", dest="to_env", choices=DEPLOY_TARGET_ENVS, required=True,
             help="Target environment (test or prod)",
         )
-        p.add_argument(
+        # --project-id and --folder-id are alternate ways to name the
+        # deploy target; passing both at once is an error (argparse
+        # enforces this — silent precedence would be a footgun for a
+        # state-changing command).
+        target_group = p.add_mutually_exclusive_group()
+        target_group.add_argument(
             "--project-id", type=int, default=None,
             help="Project ID (mutually exclusive with --folder-id)",
         )
-        p.add_argument(
+        target_group.add_argument(
             "--folder-id", type=int, default=None,
-            help="Folder ID (becomes `f<id>` in the deploy URL). "
+            help="Folder ID (becomes `f<id>` in the deploy URL; "
+                 "mutually exclusive with --project-id). "
                  "Default: folder_id from .workatoenv in cwd.",
         )
         if with_description:

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -23,6 +23,14 @@ Usage:
      connector_id back to connectors/docs/<name>.md frontmatter)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
+  python3 scripts/workato-api.py deploy preview --to <test|prod>
+    [--project-id <id> | --folder-id <id>]
+    (read-only preview: same env guard as deploy run, but no API write)
+  python3 scripts/workato-api.py deploy run --to <test|prod>
+    [--project-id <id> | --folder-id <id>] [--description <text>]
+    [--yes] [--wait] [--timeout <sec>]
+    (--yes required when --to prod; --wait polls until success/failed)
+  python3 scripts/workato-api.py deploy status <deployment-id>
   python3 scripts/workato-api.py profile show
 
 Global options:
@@ -40,11 +48,19 @@ Subcommand conventions (for contributors adding new subcommands):
   changes state in Workato — push, deploy, recipe start/stop, oauth-profiles
   create/update/delete, etc.) additionally MUST:
     - provide --dry-run that prints the intended request without sending it
-    - set epilog= with at least one --dry-run example as the first example
+      (or ship a sibling `preview` subcommand that fulfills the same role —
+      see deploy preview)
+    - set epilog= with at least one --dry-run / preview example
     - guard environment boundaries in code, not just docs:
-        * deploy commands: --from and --to required; refuse if
-          --to in {test,prod} and --from != dev
-        * --to prod additionally requires --yes (CI-friendly confirm)
+        * deploy commands: --to is the only env flag; the source
+          environment is inferred from the resolved profile's
+          `<org>-<env>` suffix. The (source, --to) pair must be one of
+          {(dev, test), (test, prod)} — skip-tier (dev->prod), backward
+          (test->dev, prod->*), and same-env transitions are refused
+          before any API call.
+        * execution deploys with --to prod additionally require --yes
+          (CI-friendly confirm); preview commands do not require --yes
+          since they have no side effects.
 
   Read-only subcommands (*list, *get, jobs list/get, profile show) do not
   need --dry-run or epilog, but still need help= and description=.
@@ -513,6 +529,176 @@ class WorkatoAPI:
             page += 1
         return all_recipes
 
+    # -- Projects API: deploy --
+
+    def project_deploy(
+        self,
+        project_ref: str,
+        environment_type: str,
+        description: str | None = None,
+    ) -> dict:
+        """Deploy a project to test or prod via the Projects API.
+
+        POST /api/projects/:id/deploy?environment_type=test|prod
+        :id accepts either a numeric project_id or `f{folder_id}` (per
+        the Workato docs). Returns the Deployment object; state will
+        typically be `pending` and require polling via deployment_get().
+        """
+        body: dict = {}
+        if description is not None:
+            body["description"] = description
+        result = self._request(
+            f"/api/projects/{project_ref}/deploy",
+            params={"environment_type": environment_type},
+            method="POST",
+            body=body if body else None,
+        )
+        if isinstance(result, dict):
+            return result.get("data", result.get("result", result))
+        return result  # type: ignore[return-value]
+
+    def deployment_get(self, deployment_id: int | str) -> dict:
+        """GET /api/deployments/:id — fetch a single deployment record."""
+        result = self._request(f"/api/deployments/{deployment_id}")
+        if isinstance(result, dict):
+            return result.get("data", result.get("result", result))
+        return result  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Deploy helpers (env guard + profile env inference + polling)
+# ---------------------------------------------------------------------------
+
+
+DEPLOY_SOURCE_ENVS = ("dev", "test")
+DEPLOY_TARGET_ENVS = ("test", "prod")
+ALLOWED_DEPLOY_TRANSITIONS = {("dev", "test"), ("test", "prod")}
+DEPLOYMENT_TERMINAL_STATES = {"success", "failed", "succeeded", "failure"}
+
+
+def infer_profile_env(profile_name: str) -> str | None:
+    """Return `dev`, `test`, or `prod` if profile_name ends with `-<env>`.
+
+    Used to derive the source environment from the resolved profile, since
+    the Projects deploy API does not take a `--from` flag. Profile names
+    that do not follow the `<org>-<env>` convention return None and force
+    the caller to explain the constraint.
+    """
+    for env in ("dev", "test", "prod"):
+        suffix = f"-{env}"
+        if profile_name.endswith(suffix) and len(profile_name) > len(suffix):
+            return env
+    return None
+
+
+def check_deploy_transition(source_env: str | None, target_env: str) -> None:
+    """Refuse invalid (source, target) pairs before any API call.
+
+    Allowed: (dev, test), (test, prod). source_env=None means the profile
+    name did not follow the `<org>-<env>` convention; in that case we
+    cannot prove the transition is safe, so refuse with a clear message
+    about the naming requirement.
+    """
+    if source_env is None:
+        print(
+            "Error: cannot infer source environment from the resolved "
+            "profile name. The deploy guard requires the profile to "
+            "follow `<org>-<env>` (e.g. acme-dev, acme-test) so the "
+            "(source, --to) pair can be validated. Rename the profile "
+            "or use --profile <name> to select one that follows the "
+            "convention.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if source_env == target_env:
+        print(
+            f"Error: source profile is `{source_env}` and --to is "
+            f"`{target_env}`. Deploy requires distinct source and target "
+            f"environments.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if (source_env, target_env) not in ALLOWED_DEPLOY_TRANSITIONS:
+        allowed = ", ".join(
+            f"{a}->{b}" for a, b in sorted(ALLOWED_DEPLOY_TRANSITIONS)
+        )
+        print(
+            f"Error: deploy {source_env}->{target_env} is not allowed. "
+            f"Allowed transitions: {allowed}. Skip-tier (dev->prod), "
+            f"backward, and same-env transitions are refused (see "
+            f"workato-deployment-flow.md).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def resolve_project_ref(
+    explicit_project_id: int | None,
+    explicit_folder_id: int | None,
+) -> str:
+    """Return the `:id` path segment for /api/projects/:id/deploy.
+
+    Workato accepts either a numeric project_id or `f{folder_id}`.
+    Resolution order:
+      1. --project-id <int>
+      2. --folder-id <int>
+      3. .workatoenv folder_id (walking up from cwd)
+    Exits with a clear error if none of these resolves.
+    """
+    if explicit_project_id is not None:
+        return str(explicit_project_id)
+    if explicit_folder_id is not None:
+        return f"f{explicit_folder_id}"
+    env_data = find_workatoenv()
+    if env_data is not None:
+        folder_id = env_data.get("folder_id")
+        if isinstance(folder_id, int):
+            return f"f{folder_id}"
+    print(
+        "Error: no --project-id or --folder-id given and no usable "
+        "folder_id found in .workatoenv. Run from inside a project, "
+        "or pass one of --project-id <id> / --folder-id <id>.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def poll_deployment(
+    api: "WorkatoAPI",
+    deployment_id: int | str,
+    timeout_seconds: int,
+    poll_interval_seconds: float = 2.0,
+    _sleep=None,
+    _now=None,
+) -> dict:
+    """Poll GET /api/deployments/:id until state is terminal or timeout hits.
+
+    Returns the final deployment dict. Exits with a clear error if the
+    timeout expires before a terminal state is observed. _sleep and _now
+    are injection points for tests.
+    """
+    import time
+    sleep = _sleep if _sleep is not None else time.sleep
+    now = _now if _now is not None else time.monotonic
+
+    deadline = now() + timeout_seconds
+    while True:
+        record = api.deployment_get(deployment_id)
+        state = (record.get("state") or "").lower() if isinstance(record, dict) else ""
+        if state in DEPLOYMENT_TERMINAL_STATES:
+            return record
+        if now() >= deadline:
+            print(
+                f"Error: deployment {deployment_id} did not reach a "
+                f"terminal state within {timeout_seconds}s "
+                f"(last state: {state or 'unknown'}). The deployment "
+                f"may still complete server-side; check "
+                f"`deploy status {deployment_id}` later.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        sleep(poll_interval_seconds)
+
 
 # ---------------------------------------------------------------------------
 # CLI Commands
@@ -542,6 +728,146 @@ def cmd_connectors_list_custom(api: WorkatoAPI, args: argparse.Namespace):
 def cmd_recipes_list(api: WorkatoAPI, args: argparse.Namespace):
     recipes = api.recipes_list(args.folder_id)
     print(json.dumps(recipes, indent=2, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# deploy preview / run / status (Projects API)
+# ---------------------------------------------------------------------------
+
+
+def _deploy_resolve_profile_and_api(args: argparse.Namespace) -> tuple[str, dict, WorkatoAPI]:
+    """Resolve the single source profile, build a WorkatoAPI client.
+
+    Used by all deploy subcommands. Returns (profile_name, profile,
+    api). The same workspace token that authenticates the API call is
+    the source workspace for the deploy.
+    """
+    profile_name, profile = resolve_profile(args.profile)
+    region_url = profile.get("region_url", "")
+    if not region_url:
+        print(
+            f"Error: profile '{profile_name}' has no region_url.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    token = get_token(profile_name)
+    return profile_name, profile, WorkatoAPI(region_url, token)
+
+
+def cmd_deploy_preview(_unused: WorkatoAPI | None, args: argparse.Namespace):
+    """Print what `deploy run` would call against, without writing.
+
+    Same env-transition guard as `deploy run`. The Projects API has no
+    dedicated preview endpoint, so the preview is a planning summary:
+    resolved profile, source/target env, project reference, target URL,
+    and (when a folder_id is in play) the recipes currently in that
+    folder via the read-only /api/recipes endpoint.
+    """
+    profile_name, profile, api = _deploy_resolve_profile_and_api(args)
+    source_env = infer_profile_env(profile_name)
+    check_deploy_transition(source_env, args.to_env)
+
+    project_ref = resolve_project_ref(args.project_id, args.folder_id)
+
+    folder_id_for_listing: int | None = None
+    if args.folder_id is not None:
+        folder_id_for_listing = args.folder_id
+    elif args.project_id is None:
+        env_data = find_workatoenv()
+        if env_data is not None and isinstance(env_data.get("folder_id"), int):
+            folder_id_for_listing = env_data["folder_id"]
+
+    recipes_preview: list = []
+    if folder_id_for_listing is not None:
+        recipes_preview = api.recipes_list(folder_id_for_listing)
+
+    region_url = profile.get("region_url", "")
+    target_url = (
+        f"{region_url.rstrip('/')}/api/projects/{project_ref}/deploy"
+        f"?environment_type={args.to_env}"
+    )
+    output = {
+        "mode": "preview",
+        "profile": profile_name,
+        "workspace_url": region_url,
+        "source_env": source_env,
+        "target_env": args.to_env,
+        "project_ref": project_ref,
+        "would_call": {
+            "method": "POST",
+            "url": target_url,
+            "body": {"description": args.description} if args.description else {},
+        },
+        "recipes_in_folder": [
+            {"id": r.get("id"), "name": r.get("name"), "running": r.get("running")}
+            for r in recipes_preview
+            if isinstance(r, dict)
+        ],
+        "notes": [
+            "No API writes were performed.",
+            "Run `deploy run` with the same arguments to execute (requires "
+            "--yes when --to prod).",
+        ],
+    }
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+
+def cmd_deploy_run(_unused: WorkatoAPI | None, args: argparse.Namespace):
+    """Execute a deploy via POST /api/projects/:id/deploy.
+
+    Runs the same env guard as preview, refuses --to prod without
+    --yes, then POSTs the deploy. With --wait, polls
+    GET /api/deployments/:id until state is terminal or --timeout
+    seconds elapse. Without --wait, returns immediately with the
+    pending Deployment record.
+    """
+    profile_name, _profile, api = _deploy_resolve_profile_and_api(args)
+    source_env = infer_profile_env(profile_name)
+    check_deploy_transition(source_env, args.to_env)
+
+    if args.to_env == "prod" and not args.yes:
+        print(
+            "Error: `deploy run --to prod` is destructive and requires "
+            "--yes to confirm. Re-run with --yes (typically after a "
+            "successful test deploy and release-manager sign-off).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    project_ref = resolve_project_ref(args.project_id, args.folder_id)
+
+    record = api.project_deploy(
+        project_ref=project_ref,
+        environment_type=args.to_env,
+        description=args.description,
+    )
+
+    if not args.wait:
+        print(json.dumps(record, indent=2, ensure_ascii=False))
+        return
+
+    deployment_id = record.get("id") if isinstance(record, dict) else None
+    if deployment_id is None:
+        print(
+            "Error: deploy POST succeeded but the response did not "
+            "include a deployment id; cannot poll.",
+            file=sys.stderr,
+        )
+        print(json.dumps(record, indent=2, ensure_ascii=False))
+        sys.exit(1)
+
+    final = poll_deployment(api, deployment_id, args.timeout)
+    print(json.dumps(final, indent=2, ensure_ascii=False))
+    state = (final.get("state") or "").lower() if isinstance(final, dict) else ""
+    if state not in ("success", "succeeded"):
+        sys.exit(1)
+
+
+def cmd_deploy_status(_unused: WorkatoAPI | None, args: argparse.Namespace):
+    """Fetch a single deployment record by id (read-only)."""
+    _, _, api = _deploy_resolve_profile_and_api(args)
+    record = api.deployment_get(args.deployment_id)
+    print(json.dumps(record, indent=2, ensure_ascii=False))
 
 
 def cmd_oauth_profiles_list(api: WorkatoAPI, args: argparse.Namespace):
@@ -1200,6 +1526,109 @@ def main():
         "--folder-id", type=int, default=None, help="Filter by folder ID"
     )
 
+    # -- deploy (Projects API) --
+    deploy_parser = subparsers.add_parser(
+        "deploy",
+        help="Promote a project from dev->test or test->prod",
+    )
+    deploy_sub = deploy_parser.add_subparsers(dest="deploy_command")
+
+    def _add_deploy_common(p: argparse.ArgumentParser, with_description: bool):
+        p.add_argument(
+            "--to", dest="to_env", choices=DEPLOY_TARGET_ENVS, required=True,
+            help="Target environment (test or prod)",
+        )
+        p.add_argument(
+            "--project-id", type=int, default=None,
+            help="Project ID (mutually exclusive with --folder-id)",
+        )
+        p.add_argument(
+            "--folder-id", type=int, default=None,
+            help="Folder ID (becomes `f<id>` in the deploy URL). "
+                 "Default: folder_id from .workatoenv in cwd.",
+        )
+        if with_description:
+            p.add_argument(
+                "--description", default=None,
+                help="Optional deployment description (for audit log)",
+            )
+
+    deploy_preview_p = deploy_sub.add_parser(
+        "preview",
+        help="Preview what `deploy run` would call",
+        description=(
+            "Print what `deploy run` would call against, without writing "
+            "to the workspace. Runs the same env-transition guard as "
+            "`deploy run`: the source environment is inferred from the "
+            "resolved profile's `<org>-<env>` suffix, and only "
+            "(dev, test) and (test, prod) are allowed. Lists recipes in "
+            "the resolved folder for context when a folder_id is in play."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Preview a dev -> test deploy (folder_id from .workatoenv)\n"
+            "  python3 scripts/workato-api.py deploy preview --to test\n\n"
+            "  # Preview a test -> prod deploy with an explicit folder\n"
+            "  python3 scripts/workato-api.py deploy preview --to prod \\\n"
+            "      --folder-id 12345 --profile acme-test\n\n"
+            "  # Skip-tier (dev profile -> --to prod) is refused before any API call.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_deploy_common(deploy_preview_p, with_description=True)
+
+    deploy_run_p = deploy_sub.add_parser(
+        "run",
+        help="Execute a deploy (POST /api/projects/:id/deploy)",
+        description=(
+            "Execute a deploy from the connected workspace to the --to "
+            "environment via the Projects API. Refuses unsafe transitions "
+            "(only dev->test and test->prod are allowed). --to prod also "
+            "requires --yes. With --wait, polls the deployment until "
+            "state becomes terminal or --timeout seconds elapse."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Preview first (read-only, no API write):\n"
+            "  python3 scripts/workato-api.py deploy preview --to test\n\n"
+            "  # Execute a dev -> test deploy and wait for it to finish:\n"
+            "  python3 scripts/workato-api.py deploy run --to test --wait\n\n"
+            "  # Execute a test -> prod deploy (--yes is required):\n"
+            "  python3 scripts/workato-api.py deploy run --to prod --yes --wait \\\n"
+            "      --description \"Release 2026-06-02\" --profile acme-test\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_deploy_common(deploy_run_p, with_description=True)
+    deploy_run_p.add_argument(
+        "--yes", action="store_true",
+        help="Required confirmation when --to prod (CI-friendly)",
+    )
+    deploy_run_p.add_argument(
+        "--wait", action="store_true",
+        help="Poll until the deployment reaches a terminal state",
+    )
+    deploy_run_p.add_argument(
+        "--timeout", type=int, default=300,
+        help="Polling timeout in seconds (default: 300)",
+    )
+
+    deploy_status_p = deploy_sub.add_parser(
+        "status",
+        help="Get a single deployment's state",
+        description=(
+            "Fetch and print a single deployment record by ID "
+            "(GET /api/deployments/:id). Read-only. The profile must "
+            "point at the workspace that owns the deployment "
+            "(typically the target workspace, e.g. test for a "
+            "dev->test deploy)."
+        ),
+    )
+    deploy_status_p.add_argument(
+        "deployment_id", type=int,
+        help="Deployment ID returned by `deploy run`",
+    )
+
     # -- sdk --
     sdk_parser = subparsers.add_parser(
         "sdk", help="Connector SDK commands (uses Platform API token)"
@@ -1445,6 +1874,21 @@ def main():
     if args.command == "sdk" and getattr(args, "sdk_command", None) in ("decrypt", "edit"):
         handler = {"decrypt": cmd_sdk_decrypt, "edit": cmd_sdk_edit}[args.sdk_command]
         handler(None, args)
+        return
+
+    # deploy handlers manage their own profile/token resolution so they
+    # can run the env-transition guard before any API client is built.
+    if args.command == "deploy":
+        deploy_handlers = {
+            "preview": cmd_deploy_preview,
+            "run": cmd_deploy_run,
+            "status": cmd_deploy_status,
+        }
+        sub = getattr(args, "deploy_command", None)
+        if sub in deploy_handlers:
+            deploy_handlers[sub](None, args)
+        else:
+            deploy_parser.print_help()
         return
 
     # Resolve profile and create API client


### PR DESCRIPTION
## Summary

Issue #160 group B (deploy) on the simpler [Projects API](https://docs.workato.com/ja/workato-api/projects#deploy-a-project) — supersedes the closed #167 which used the wrong (RLCM export-manifests) endpoint.

Single source-workspace token, single async op + polling, no dual-profile resolution.

### New commands

```bash
deploy preview --to <test|prod> [--project-id|--folder-id] [--description]
deploy run     --to <test|prod> [--project-id|--folder-id] [--description]
                                [--yes] [--wait] [--timeout]
deploy status  <deployment_id>
```

### Safety contract (enforced in code, not just docs)

| Check | Behavior |
|---|---|
| Source env from profile `<org>-<env>` suffix | Refuse with clear naming-requirement message if the suffix is missing |
| `(source, --to)` allow-list `{(dev,test), (test,prod)}` | Refuse skip-tier (dev→prod), backward (test→dev), `prod → *`, and same-env before any API call |
| `--to prod` requires `--yes` | CI-friendly confirm; `preview` is exempt since it has no side effects |
| `--wait` polling | Recognises `success/succeeded/failed/failure` as terminal; non-success exits non-zero so CI fails loudly |
| `--timeout` exhaustion | Exits with hint to check `deploy status <id>` later |

### Convention update in the module docstring

The convention text added in PR #166 said:

> refuse if `--to in {test,prod}` and `--from != dev`

That was wrong in two ways: (a) it blocked the canonical `test→prod` step, and (b) it assumed a `--from` flag that does not exist in the Projects API. This PR replaces the rule with the explicit allow-list and clarifies that source is inferred from the profile suffix. Also adds a carve-out: a `preview` subcommand satisfies the `--dry-run` requirement.

### What's NOT in this PR

- `deploy list` (history admin): separate PR
- Project-name → folder lookup (currently `--project-id` / `--folder-id` / `.workatoenv`): separate PR
- Approval flow: out of scope; per kit policy, never scripted

## Test plan

31 new tests in `scripts/tests/test_deploy_projects.py`:

- 6 × `infer_profile_env` (dev/test/prod/multi-dash/missing/suffix-only)
- 7 × `check_deploy_transition` (allow pairs + every refusal category, including `None` source)
- 5 × `resolve_project_ref` (project_id, folder_id, project_id wins, .workatoenv, missing-all)
- 4 × `poll_deployment` (terminal-on-first, iterate, timeout, `failed` recognised). Injected `_sleep`/`_now` — the suite never actually waits.
- 6 × `cmd_deploy_run` (guard short-circuit, --yes prod gate, --yes prod allowed, f-prefix from folder_id, --wait fails → non-zero, --wait success → zero)
- 3 × `cmd_deploy_preview` (happy-path JSON shape, guard short-circuit, unparseable profile name)

- [x] `python3 scripts/tests/test_deploy_projects.py` — 31/31 pass
- [x] All 139 existing tests still pass (CI workflow runs every `test_*.py`)
- [x] `--help` rendering verified for `deploy / deploy preview / deploy run / deploy status`
- [x] Pre-push Codex review on the diff (clean worktree, no untracked-file noise): no defects flagged
- [ ] Reviewer sanity check on the convention text wording and the polling termination logic

Refs #160 (PR-2a' of B). Supersedes #167.