### PR TITLE
feat(recipes): start/stop + list --status (Issue #160 group C)

### DIFF
--- a/scripts/tests/test_recipes_operations.py
+++ b/scripts/tests/test_recipes_operations.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Tests for recipes start / stop / list --status in workato-api.py.
+
+Covers:
+  - require_dev_profile_for_mutation (refuses test/prod/None)
+  - cmd_recipes_start / cmd_recipes_stop env guard + --dry-run + happy path
+  - cmd_recipes_list --status running|stopped filter
+
+Run with:
+    python3 scripts/tests/test_recipes_operations.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _capture_stderr_exit(fn):
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    return exited, code, err
+
+
+def _capture_stdout(fn):
+    saved = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        fn()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved
+
+
+# ---------------------------------------------------------------------------
+# require_dev_profile_for_mutation
+# ---------------------------------------------------------------------------
+
+
+def test_require_dev_allows_dev_profile():
+    # Should not raise / exit
+    wa.require_dev_profile_for_mutation("acme-dev", "start recipe 1")
+
+
+def test_require_dev_refuses_test_profile():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.require_dev_profile_for_mutation("acme-test", "start recipe 1")
+    )
+    assert exited and code == 1
+    assert "test" in err
+    assert "deploy run" in err
+
+
+def test_require_dev_refuses_prod_profile():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.require_dev_profile_for_mutation("acme-prod", "stop recipe 99")
+    )
+    assert exited and code == 1
+    assert "prod" in err
+
+
+def test_require_dev_refuses_unparseable_profile():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.require_dev_profile_for_mutation("plain", "start recipe 1")
+    )
+    assert exited and code == 1
+    assert "<org>-dev" in err
+    assert "cannot prove" in err
+
+
+def test_require_dev_error_includes_operation_label():
+    """The operation label flows through so the user can tell what was refused."""
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.require_dev_profile_for_mutation("acme-prod", "start recipe 777")
+    )
+    assert exited and code == 1
+    assert "start recipe 777" in err
+
+
+# ---------------------------------------------------------------------------
+# cmd_recipes_start — guard + --dry-run + real PUT
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAPI:
+    def __init__(self, base_url="https://workato.example.com"):
+        self.base_url = base_url
+        self.calls: list = []
+
+    def recipe_start(self, recipe_id):
+        self.calls.append(("start", recipe_id))
+        return {"id": recipe_id, "running": True}
+
+    def recipe_stop(self, recipe_id):
+        self.calls.append(("stop", recipe_id))
+        return {"id": recipe_id, "running": False}
+
+
+class _ExplodingAPI:
+    base_url = "https://workato.example.com"
+
+    def recipe_start(self, *_a, **_kw):
+        raise AssertionError("recipe_start called despite guard refusal")
+
+    def recipe_stop(self, *_a, **_kw):
+        raise AssertionError("recipe_stop called despite guard refusal")
+
+
+def test_start_refuses_when_profile_is_test():
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        recipe_id=1, dry_run=False, _resolved_profile_name="acme-test",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_recipes_start(api, args)
+    )
+    assert exited and code == 1
+    assert "test" in err
+
+
+def test_stop_refuses_when_profile_is_prod():
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        recipe_id=1, dry_run=False, _resolved_profile_name="acme-prod",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_recipes_stop(api, args)
+    )
+    assert exited and code == 1
+    assert "prod" in err
+
+
+def test_start_dry_run_does_not_call_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        recipe_id=42, dry_run=True, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_recipes_start(api, args))
+    parsed = json.loads(out)
+    assert parsed["mode"] == "dry-run"
+    assert parsed["would_call"]["method"] == "PUT"
+    assert parsed["would_call"]["url"].endswith("/api/recipes/42/start")
+    assert parsed["profile"] == "acme-dev"
+    assert api.calls == []
+
+
+def test_stop_dry_run_does_not_call_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        recipe_id=7, dry_run=True, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_recipes_stop(api, args))
+    parsed = json.loads(out)
+    assert parsed["mode"] == "dry-run"
+    assert parsed["would_call"]["url"].endswith("/api/recipes/7/stop")
+    assert api.calls == []
+
+
+def test_start_happy_path_invokes_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        recipe_id=100, dry_run=False, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_recipes_start(api, args))
+    parsed = json.loads(out)
+    assert parsed == {"id": 100, "running": True}
+    assert api.calls == [("start", 100)]
+
+
+def test_stop_happy_path_invokes_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        recipe_id=200, dry_run=False, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_recipes_stop(api, args))
+    parsed = json.loads(out)
+    assert parsed == {"id": 200, "running": False}
+    assert api.calls == [("stop", 200)]
+
+
+# ---------------------------------------------------------------------------
+# cmd_recipes_list --status
+# ---------------------------------------------------------------------------
+
+
+class _ListAPI:
+    def __init__(self, recipes):
+        self._recipes = recipes
+
+    def recipes_list(self, _folder_id):
+        return self._recipes
+
+
+def test_list_no_status_returns_all():
+    api = _ListAPI([
+        {"id": 1, "running": True},
+        {"id": 2, "running": False},
+    ])
+    args = SimpleNamespace(folder_id=None, status=None)
+    out = _capture_stdout(lambda: wa.cmd_recipes_list(api, args))
+    parsed = json.loads(out)
+    assert len(parsed) == 2
+
+
+def test_list_status_running_filters_to_running():
+    api = _ListAPI([
+        {"id": 1, "running": True, "name": "A"},
+        {"id": 2, "running": False, "name": "B"},
+        {"id": 3, "running": True, "name": "C"},
+    ])
+    args = SimpleNamespace(folder_id=None, status="running")
+    out = _capture_stdout(lambda: wa.cmd_recipes_list(api, args))
+    parsed = json.loads(out)
+    assert [r["id"] for r in parsed] == [1, 3]
+
+
+def test_list_status_stopped_filters_to_stopped():
+    api = _ListAPI([
+        {"id": 1, "running": True},
+        {"id": 2, "running": False},
+        {"id": 3, "running": False},
+    ])
+    args = SimpleNamespace(folder_id=None, status="stopped")
+    out = _capture_stdout(lambda: wa.cmd_recipes_list(api, args))
+    parsed = json.loads(out)
+    assert [r["id"] for r in parsed] == [2, 3]
+
+
+def test_list_status_treats_missing_running_field_as_stopped():
+    """Recipes without a `running` field should be treated as not-running."""
+    api = _ListAPI([
+        {"id": 1, "running": True},
+        {"id": 2},  # no `running` field
+    ])
+    args_running = SimpleNamespace(folder_id=None, status="running")
+    out_running = _capture_stdout(lambda: wa.cmd_recipes_list(api, args_running))
+    assert [r["id"] for r in json.loads(out_running)] == [1]
+
+    args_stopped = SimpleNamespace(folder_id=None, status="stopped")
+    out_stopped = _capture_stdout(lambda: wa.cmd_recipes_list(api, args_stopped))
+    assert [r["id"] for r in json.loads(out_stopped)] == [2]
+
+
+def test_list_status_skips_non_dict_entries():
+    """Defensive: a malformed list entry must not break the filter."""
+    api = _ListAPI([
+        {"id": 1, "running": True},
+        "not a dict",
+        None,
+    ])
+    args = SimpleNamespace(folder_id=None, status="running")
+    out = _capture_stdout(lambda: wa.cmd_recipes_list(api, args))
+    assert [r["id"] for r in json.loads(out)] == [1]
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse — --status choices, recipe_id type
+# ---------------------------------------------------------------------------
+
+
+def test_cli_argparse_refuses_invalid_status():
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "recipes", "list",
+            "--status", "paused",  # not in {running, stopped}
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "invalid choice" in result.stderr
+
+
+def test_cli_argparse_refuses_non_int_recipe_id():
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "recipes", "start", "not-an-int",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -15,6 +15,11 @@ Usage:
   python3 scripts/workato-api.py connectors list-platform [--provider <name>]
   python3 scripts/workato-api.py connectors list-custom
   python3 scripts/workato-api.py recipes list [--folder-id <id>]
+    [--status running|stopped]
+  python3 scripts/workato-api.py recipes start <id> [--dry-run]
+    (PUT /api/recipes/:id/start; requires <org>-dev profile)
+  python3 scripts/workato-api.py recipes stop <id> [--dry-run]
+    (PUT /api/recipes/:id/stop; requires <org>-dev profile)
   python3 scripts/workato-api.py sdk push --connector <path> [--title <t>]
     (auto-detects new vs. update by reading connector_id from
      connectors/docs/<name>.md frontmatter; saves ID back after initial create)
@@ -64,6 +69,13 @@ Subcommand conventions (for contributors adding new subcommands):
         * execution deploys with --to prod additionally require --yes
           (CI-friendly confirm); preview commands do not require --yes
           since they have no side effects.
+        * Non-deploy state-mutation commands that target a workspace
+          (recipes start/stop, and the sdk push / oauth-profiles
+          create-update-delete retrofits) refuse unless the resolved
+          profile is `<org>-dev`. Direct mutations against test/prod
+          workspaces violate the deploy-only promotion policy — those
+          changes must arrive via `deploy run`. See
+          workato-deployment-flow.md.
 
   Read-only subcommands (*list, *get, jobs list/get, profile show) do not
   need --dry-run or epilog, but still need help= and description=.
@@ -532,6 +544,32 @@ class WorkatoAPI:
             page += 1
         return all_recipes
 
+    def recipe_start(self, recipe_id: int) -> dict:
+        """PUT /api/recipes/:id/start — start a recipe.
+
+        State-changing; the caller must enforce the dev-profile
+        constraint (require_dev_profile_for_mutation) before invoking.
+        """
+        result = self._request(
+            f"/api/recipes/{recipe_id}/start", method="PUT",
+        )
+        if isinstance(result, dict):
+            return result.get("data", result.get("result", result))
+        return result  # type: ignore[return-value]
+
+    def recipe_stop(self, recipe_id: int) -> dict:
+        """PUT /api/recipes/:id/stop — stop a recipe.
+
+        State-changing; the caller must enforce the dev-profile
+        constraint (require_dev_profile_for_mutation) before invoking.
+        """
+        result = self._request(
+            f"/api/recipes/{recipe_id}/stop", method="PUT",
+        )
+        if isinstance(result, dict):
+            return result.get("data", result.get("result", result))
+        return result  # type: ignore[return-value]
+
     # -- Projects API: deploy --
 
     def project_deploy(
@@ -627,6 +665,42 @@ def infer_profile_env(profile_name: str) -> str | None:
         if profile_name.endswith(suffix) and len(profile_name) > len(suffix):
             return env
     return None
+
+
+def require_dev_profile_for_mutation(profile_name: str, operation: str) -> None:
+    """Refuse a non-deploy state mutation unless the profile is <org>-dev.
+
+    Used by commands like `recipes start` / `recipes stop` that mutate
+    Workato state directly. The deploy-only promotion policy in
+    workato-deployment-flow.md forbids such mutations against
+    test/prod workspaces — those changes must arrive via `deploy run`.
+
+    Refuses with a clear message when:
+      - the profile name does not follow `<org>-<env>` (cannot prove dev), or
+      - the inferred env is anything other than `dev`.
+    """
+    env = infer_profile_env(profile_name)
+    if env == "dev":
+        return
+    if env is None:
+        print(
+            f"Error: refusing to {operation} — cannot prove the resolved "
+            f"profile '{profile_name}' targets a dev workspace. The "
+            f"safety guard requires `<org>-dev` naming (e.g. acme-dev). "
+            f"Rename the profile or pass --profile <name> to select one "
+            f"that follows the convention.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(
+        f"Error: refusing to {operation} against `{env}` workspace "
+        f"(profile '{profile_name}'). Direct state mutations are "
+        f"allowed only on `<org>-dev` profiles; promote changes to "
+        f"test/prod via `deploy run` instead. See "
+        f"workato-deployment-flow.md.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def check_deploy_transition(source_env: str | None, target_env: str) -> None:
@@ -775,7 +849,47 @@ def cmd_connectors_list_custom(api: WorkatoAPI, args: argparse.Namespace):
 
 def cmd_recipes_list(api: WorkatoAPI, args: argparse.Namespace):
     recipes = api.recipes_list(args.folder_id)
+    if args.status is not None:
+        want_running = (args.status == "running")
+        recipes = [
+            r for r in recipes
+            if isinstance(r, dict) and bool(r.get("running")) is want_running
+        ]
     print(json.dumps(recipes, indent=2, ensure_ascii=False))
+
+
+def cmd_recipes_start(api: WorkatoAPI, args: argparse.Namespace):
+    """Start a recipe by ID. Refuses against non-`<org>-dev` profiles."""
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"start recipe {args.recipe_id}",
+    )
+    if args.dry_run:
+        url = f"{api.base_url}/api/recipes/{args.recipe_id}/start"
+        print(json.dumps({
+            "mode": "dry-run",
+            "would_call": {"method": "PUT", "url": url, "body": None},
+            "profile": args._resolved_profile_name,
+        }, indent=2, ensure_ascii=False))
+        return
+    result = api.recipe_start(args.recipe_id)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def cmd_recipes_stop(api: WorkatoAPI, args: argparse.Namespace):
+    """Stop a recipe by ID. Refuses against non-`<org>-dev` profiles."""
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"stop recipe {args.recipe_id}",
+    )
+    if args.dry_run:
+        url = f"{api.base_url}/api/recipes/{args.recipe_id}/stop"
+        print(json.dumps({
+            "mode": "dry-run",
+            "would_call": {"method": "PUT", "url": url, "body": None},
+            "profile": args._resolved_profile_name,
+        }, indent=2, ensure_ascii=False))
+        return
+    result = api.recipe_stop(args.recipe_id)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
 
 
 # ---------------------------------------------------------------------------
@@ -1587,11 +1701,65 @@ def main():
         help="List recipes (JSON)",
         description=(
             "List recipes in the connected workspace as JSON, with "
-            "pagination. Optionally filter by folder. Read-only."
+            "pagination. Optionally filter by folder, and by run state "
+            "(running/stopped, filtered client-side on the `running` "
+            "field). Read-only."
         ),
     )
     recipes_list_p.add_argument(
         "--folder-id", type=int, default=None, help="Filter by folder ID"
+    )
+    recipes_list_p.add_argument(
+        "--status", choices=("running", "stopped"), default=None,
+        help="Filter by run state (client-side filter on the `running` field)",
+    )
+
+    recipes_start_p = recipes_sub.add_parser(
+        "start",
+        help="Start a recipe (PUT /api/recipes/:id/start)",
+        description=(
+            "Start a recipe by numeric ID. Refuses unless the resolved "
+            "profile is `<org>-dev` — direct mutations against test/prod "
+            "violate the deploy-only promotion policy. Use --dry-run to "
+            "print the intended request without sending it."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Dry run: print the URL that would be called\n"
+            "  python3 scripts/workato-api.py recipes start 12345 --dry-run\n\n"
+            "  # Start a recipe in the dev workspace\n"
+            "  python3 scripts/workato-api.py recipes start 12345\n\n"
+            "  # Refused: profile is not `<org>-dev`\n"
+            "  python3 scripts/workato-api.py recipes start 12345 --profile acme-prod\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    recipes_start_p.add_argument("recipe_id", type=int, help="Recipe ID")
+    recipes_start_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the intended PUT request without sending it",
+    )
+
+    recipes_stop_p = recipes_sub.add_parser(
+        "stop",
+        help="Stop a recipe (PUT /api/recipes/:id/stop)",
+        description=(
+            "Stop a recipe by numeric ID. Refuses unless the resolved "
+            "profile is `<org>-dev` — direct mutations against test/prod "
+            "violate the deploy-only promotion policy. Use --dry-run to "
+            "print the intended request without sending it."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/workato-api.py recipes stop 12345 --dry-run\n"
+            "  python3 scripts/workato-api.py recipes stop 12345\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    recipes_stop_p.add_argument("recipe_id", type=int, help="Recipe ID")
+    recipes_stop_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the intended PUT request without sending it",
     )
 
     # -- deploy (Projects API) --
@@ -2030,6 +2198,9 @@ def main():
 
     token = get_token(profile_name)
     api = WorkatoAPI(region_url, token)
+    # Make the resolved profile name visible to handlers that need to
+    # apply env-aware guards (e.g. recipes start/stop's dev-only check).
+    args._resolved_profile_name = profile_name
 
     # Dispatch
     commands = {
@@ -2038,6 +2209,8 @@ def main():
         ("connectors", "list-platform"): cmd_connectors_list_platform,
         ("connectors", "list-custom"): cmd_connectors_list_custom,
         ("recipes", "list"): cmd_recipes_list,
+        ("recipes", "start"): cmd_recipes_start,
+        ("recipes", "stop"): cmd_recipes_stop,
         ("sdk", "push"): cmd_sdk_push,
         ("sdk", "pull"): cmd_sdk_pull,
         ("sdk", "generate-schema"): cmd_sdk_generate_schema,


### PR DESCRIPTION
## Summary

Adds the recipe-operations command family for Issue #160 group C. Encapsulates the deploy-only promotion policy from `workato-deployment-flow.md` as a reusable code-level guard.

### New commands

```bash
recipes start <id> [--dry-run]   # PUT /api/recipes/:id/start
recipes stop  <id> [--dry-run]   # PUT /api/recipes/:id/stop
recipes list  [--folder-id <id>] [--status running|stopped]
```

### Safety contract (enforced in code)

| Check | Behavior |
|---|---|
| Dev profile required for state mutations | `recipes start` / `recipes stop` refuse unless the resolved profile is `<org>-dev`. test/prod and unparseable profile names → exit 1 with a message that names the refused operation and points at `workato-deployment-flow.md`. |
| `--dry-run` skips API | Prints intended PUT (method, URL, profile) and exits. The guard runs *before* the dry-run output, so a refused profile fails before the URL is even printed. |
| `--status` filter | Client-side on the `running` bool field. Missing field treated as stopped (matches UI). Non-dict entries skipped defensively. |

### Convention docstring update

Previously the env guards in the Subcommand Conventions section enumerated only the deploy family. Adds a third bullet for **non-deploy state-mutation commands** (recipes start/stop now, sdk push / oauth-profiles create-update-delete retrofits later) refusing on non-dev profiles, with a pointer to `workato-deployment-flow.md` for the underlying policy.

### `require_dev_profile_for_mutation` helper

Single reusable helper that the future sdk push / oauth-profiles retrofits will share — keeping the guard message and code path consistent across every state-mutation command.

### main() dispatch change

Attaches the resolved profile name to `args._resolved_profile_name` so handlers can apply env-aware guards without re-resolving the profile.

## Test plan

18 new tests in `scripts/tests/test_recipes_operations.py` (now 164 across the full suite):

- [x] 5 × `require_dev_profile_for_mutation` (allows dev, refuses test/prod/unparseable, error includes operation label)
- [x] 6 × `cmd_recipes_start` / `cmd_recipes_stop` (guard short-circuits, --dry-run skips API, happy-path PUT)
- [x] 5 × `cmd_recipes_list --status` (no-filter, running, stopped, missing-field-is-stopped, non-dict-skipped)
- [x] 2 × subprocess CLI tests for argparse rejection (invalid --status, non-int recipe_id)
- [x] All 164 existing tests still pass
- [x] Pre-push Codex review on clean worktree: no defects flagged

Refs #160 (group C).