### PR TITLE
feat(jobs): add `jobs tail` and `jobs list --limit` (Issue #160 group D)

### DIFF
--- a/scripts/tests/test_jobs_tail.py
+++ b/scripts/tests/test_jobs_tail.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Tests for `jobs list --limit` and `jobs tail` in workato-api.py.
+
+Covers:
+  - cmd_jobs_list --limit caps client-side
+  - jobs_tail_loop: priming, new-job detection, max_iterations exit,
+    KeyboardInterrupt exit, chronological ordering, defensive handling
+    of malformed entries
+  - CLI argparse types for tail
+
+Run with:
+    python3 scripts/tests/test_jobs_tail.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+def _capture_stdout(fn):
+    saved = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        fn()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved
+
+
+# ---------------------------------------------------------------------------
+# cmd_jobs_list --limit
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedJobsAPI:
+    """Returns pre-recorded pages from jobs_list calls in order."""
+
+    def __init__(self, pages):
+        self._pages = list(pages)
+        self.call_count = 0
+
+    def jobs_list(self, _recipe_id, _status=None):
+        self.call_count += 1
+        if not self._pages:
+            return []
+        if len(self._pages) == 1:
+            return self._pages[0]
+        return self._pages.pop(0)
+
+
+def test_jobs_list_no_limit_returns_all():
+    api = _ScriptedJobsAPI([[{"id": i} for i in range(5)]])
+    args = SimpleNamespace(recipe_id=1, status=None, limit=None)
+    out = _capture_stdout(lambda: wa.cmd_jobs_list(api, args))
+    assert len(json.loads(out)) == 5
+
+
+def test_jobs_list_limit_caps_client_side():
+    api = _ScriptedJobsAPI([[{"id": i} for i in range(10)]])
+    args = SimpleNamespace(recipe_id=1, status=None, limit=3)
+    out = _capture_stdout(lambda: wa.cmd_jobs_list(api, args))
+    parsed = json.loads(out)
+    assert [r["id"] for r in parsed] == [0, 1, 2]
+
+
+def test_jobs_list_limit_zero_returns_empty():
+    api = _ScriptedJobsAPI([[{"id": 1}, {"id": 2}]])
+    args = SimpleNamespace(recipe_id=1, status=None, limit=0)
+    out = _capture_stdout(lambda: wa.cmd_jobs_list(api, args))
+    assert json.loads(out) == []
+
+
+# ---------------------------------------------------------------------------
+# jobs_tail_loop
+# ---------------------------------------------------------------------------
+
+
+def test_tail_does_not_emit_initial_backlog():
+    """The first fetch primes the seen-set; existing jobs must not print."""
+    api = _ScriptedJobsAPI([
+        [{"id": 1}, {"id": 2}],   # priming fetch
+        [{"id": 1}, {"id": 2}],   # iter 1 — same set, no new jobs
+    ])
+    emitted: list = []
+    iters = wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=1,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    assert iters == 1
+    assert emitted == []
+
+
+def test_tail_emits_new_jobs_only():
+    """New jobs that appear after the priming fetch are printed once."""
+    api = _ScriptedJobsAPI([
+        [{"id": 1}],                          # priming
+        [{"id": 2}, {"id": 1}],               # iter 1: 2 is new
+        [{"id": 3}, {"id": 2}, {"id": 1}],    # iter 2: 3 is new
+    ])
+    emitted: list = []
+    wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=2,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    parsed = [json.loads(line) for line in emitted]
+    assert [r["id"] for r in parsed] == [2, 3]
+
+
+def test_tail_emits_in_chronological_order_within_one_iter():
+    """Workato returns newest-first; tail reverses so output is oldest-first."""
+    api = _ScriptedJobsAPI([
+        [{"id": 1}],                          # priming
+        [{"id": 4}, {"id": 3}, {"id": 2}, {"id": 1}],  # iter: 4,3,2 all new
+    ])
+    emitted: list = []
+    wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=1,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    parsed = [json.loads(line) for line in emitted]
+    # Reversed from newest-first to oldest-first
+    assert [r["id"] for r in parsed] == [2, 3, 4]
+
+
+def test_tail_respects_max_iterations():
+    api = _ScriptedJobsAPI([
+        [],   # priming
+        [{"id": 1}],
+        [{"id": 2}, {"id": 1}],
+        [{"id": 3}, {"id": 2}, {"id": 1}],
+    ])
+    sleeps: list = []
+    iters = wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=2.0, max_iterations=2,
+        _sleep=lambda d: sleeps.append(d), _print=lambda _l: None,
+    )
+    assert iters == 2
+    assert sleeps == [2.0, 2.0]
+
+
+def test_tail_max_iterations_zero_does_no_polls():
+    """max_iterations=0 → loop returns immediately after priming."""
+    api = _ScriptedJobsAPI([[{"id": 1}]])
+    emitted: list = []
+    iters = wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=0,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    assert iters == 0
+    assert emitted == []
+    # Only the priming call should have happened.
+    assert api.call_count == 1
+
+
+def test_tail_keyboardinterrupt_exits_cleanly():
+    """KeyboardInterrupt during sleep returns the iteration count seen so far."""
+    api = _ScriptedJobsAPI([
+        [],            # priming
+        [{"id": 1}],   # iter 1: 1 new
+        # Sleep raises KeyboardInterrupt before iter 2 starts.
+    ])
+
+    call_count = [0]
+
+    def sleep_then_interrupt(_d):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            raise KeyboardInterrupt()
+
+    emitted: list = []
+    iters = wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.1, max_iterations=10,
+        _sleep=sleep_then_interrupt,
+        _print=lambda line: emitted.append(line),
+    )
+    # One full iteration before the interrupt fires on the second sleep.
+    assert iters == 1
+    assert len(emitted) == 1
+    assert json.loads(emitted[0])["id"] == 1
+
+
+def test_tail_status_filter_is_passed_to_api():
+    seen_status: list = []
+
+    class API:
+        def jobs_list(self, _r, status=None):
+            seen_status.append(status)
+            return []
+
+    wa.jobs_tail_loop(
+        API(), recipe_id=42, status_filter="failed",
+        interval_seconds=0.0, max_iterations=2,
+        _sleep=lambda d: None, _print=lambda _l: None,
+    )
+    # Priming + 2 iterations
+    assert seen_status == ["failed", "failed", "failed"]
+
+
+def test_tail_skips_non_dict_entries():
+    api = _ScriptedJobsAPI([
+        [],
+        ["not a dict", None, {"id": 7}],
+    ])
+    emitted: list = []
+    wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=1,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    parsed = [json.loads(line) for line in emitted]
+    assert [r["id"] for r in parsed] == [7]
+
+
+def test_tail_skips_entries_without_id():
+    """A job dict lacking `id` cannot be deduped, so we skip it for safety."""
+    api = _ScriptedJobsAPI([
+        [],
+        [{"id": 1}, {"status": "failed"}],  # second dict has no id
+    ])
+    emitted: list = []
+    wa.jobs_tail_loop(
+        api, recipe_id=42, status_filter=None,
+        interval_seconds=0.0, max_iterations=1,
+        _sleep=lambda d: None, _print=lambda line: emitted.append(line),
+    )
+    parsed = [json.loads(line) for line in emitted]
+    assert [r["id"] for r in parsed] == [1]
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse
+# ---------------------------------------------------------------------------
+
+
+def test_cli_argparse_tail_requires_recipe_id():
+    import subprocess
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "jobs", "tail"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "--recipe-id" in result.stderr
+
+
+def test_cli_argparse_tail_rejects_non_int_max_iterations():
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "jobs", "tail", "--recipe-id", "1",
+            "--max-iterations", "not-an-int",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -10,8 +10,11 @@ Authentication:
   so .workatoenv never needs to contain a profile name (Git-sharing safe).
 
 Usage:
-  python3 scripts/workato-api.py jobs list --recipe-id <id> [--status <status>]
+  python3 scripts/workato-api.py jobs list --recipe-id <id>
+    [--status <status>] [--limit <N>]
   python3 scripts/workato-api.py jobs get --recipe-id <id> --job-id <id>
+  python3 scripts/workato-api.py jobs tail --recipe-id <id>
+    [--status <status>] [--interval <sec>] [--max-iterations <N>]
   python3 scripts/workato-api.py connectors list-platform [--provider <name>]
   python3 scripts/workato-api.py connectors list-custom
   python3 scripts/workato-api.py recipes list [--folder-id <id>]
@@ -829,12 +832,83 @@ def poll_deployment(
 
 def cmd_jobs_list(api: WorkatoAPI, args: argparse.Namespace):
     jobs = api.jobs_list(args.recipe_id, args.status)
+    if args.limit is not None and args.limit >= 0:
+        jobs = jobs[: args.limit]
     print(json.dumps(jobs, indent=2, ensure_ascii=False))
 
 
 def cmd_jobs_get(api: WorkatoAPI, args: argparse.Namespace):
     job = api.jobs_get(args.recipe_id, args.job_id)
     print(json.dumps(job, indent=2, ensure_ascii=False))
+
+
+def jobs_tail_loop(
+    api: WorkatoAPI,
+    recipe_id: int,
+    status_filter: str | None,
+    interval_seconds: float,
+    max_iterations: int | None,
+    _sleep=None,
+    _print=print,
+) -> int:
+    """Poll `jobs_list` and print only newly-seen jobs each iteration.
+
+    Returns the number of poll iterations completed (after the priming
+    fetch). max_iterations=None means run until KeyboardInterrupt;
+    tests pass a finite value plus an injected `_sleep` so the suite
+    does not actually wait.
+
+    `_print` is injected so tests can capture per-iteration emissions.
+    """
+    import time
+    sleep = _sleep if _sleep is not None else time.sleep
+
+    # Prime the seen-set with whatever exists right now — we only want
+    # to stream NEW jobs from this point forward, not the backlog.
+    initial = api.jobs_list(recipe_id, status_filter)
+    seen: set = {
+        j.get("id") for j in initial
+        if isinstance(j, dict) and j.get("id") is not None
+    }
+
+    iterations = 0
+    try:
+        while True:
+            if max_iterations is not None and iterations >= max_iterations:
+                return iterations
+            sleep(interval_seconds)
+            iterations += 1
+            page = api.jobs_list(recipe_id, status_filter)
+            new_jobs = []
+            for j in page:
+                if not isinstance(j, dict):
+                    continue
+                jid = j.get("id")
+                if jid is None or jid in seen:
+                    continue
+                seen.add(jid)
+                new_jobs.append(j)
+            # Workato returns jobs newest-first; reverse so the tail
+            # reads top-to-bottom by time, matching `tail -f` semantics.
+            for j in reversed(new_jobs):
+                _print(json.dumps(j, ensure_ascii=False))
+    except KeyboardInterrupt:
+        return iterations
+
+
+def cmd_jobs_tail(api: WorkatoAPI, args: argparse.Namespace):
+    """Stream new jobs for a recipe, one JSON object per line.
+
+    Read-only; no env or dev-profile guard. Polling interval defaults
+    to 5 seconds. Without --max-iterations, runs until Ctrl+C.
+    """
+    jobs_tail_loop(
+        api,
+        recipe_id=args.recipe_id,
+        status_filter=args.status,
+        interval_seconds=args.interval,
+        max_iterations=args.max_iterations,
+    )
 
 
 def cmd_connectors_list_platform(api: WorkatoAPI, args: argparse.Namespace):
@@ -1650,11 +1724,16 @@ def main():
         help="List jobs for a recipe",
         description=(
             "List jobs for a recipe in reverse-chronological order. "
-            "Optionally filter by status (e.g. failed, success). Read-only."
+            "Optionally filter by status (e.g. failed, success). "
+            "--limit caps the output client-side. Read-only."
         ),
     )
     jobs_list_p.add_argument("--recipe-id", type=int, required=True)
     jobs_list_p.add_argument("--status", default=None, help="Filter by status")
+    jobs_list_p.add_argument(
+        "--limit", type=int, default=None,
+        help="Cap the number of jobs returned (client-side)",
+    )
 
     jobs_get_p = jobs_sub.add_parser(
         "get",
@@ -1666,6 +1745,41 @@ def main():
     )
     jobs_get_p.add_argument("--recipe-id", type=int, required=True)
     jobs_get_p.add_argument("--job-id", type=str, required=True)
+
+    jobs_tail_p = jobs_sub.add_parser(
+        "tail",
+        help="Stream new jobs as they appear",
+        description=(
+            "Poll the jobs endpoint and print only newly-seen jobs each "
+            "iteration, one JSON object per line. Read-only. The initial "
+            "fetch is used to prime the seen-set, so existing jobs are "
+            "NOT printed — only ones that appear after the command starts. "
+            "Default interval is 5 seconds; without --max-iterations the "
+            "command runs until Ctrl+C."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Tail failed jobs for a recipe, refreshing every 10s\n"
+            "  python3 scripts/workato-api.py jobs tail --recipe-id 12345 \\\n"
+            "      --status failed --interval 10\n\n"
+            "  # Tail for at most 6 polling iterations (e.g. ~30s at 5s interval)\n"
+            "  python3 scripts/workato-api.py jobs tail --recipe-id 12345 \\\n"
+            "      --max-iterations 6\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    jobs_tail_p.add_argument("--recipe-id", type=int, required=True)
+    jobs_tail_p.add_argument(
+        "--status", default=None, help="Filter by status (e.g. failed)",
+    )
+    jobs_tail_p.add_argument(
+        "--interval", type=float, default=5.0,
+        help="Polling interval in seconds (default: 5.0)",
+    )
+    jobs_tail_p.add_argument(
+        "--max-iterations", dest="max_iterations", type=int, default=None,
+        help="Stop after N polling iterations (default: run until Ctrl+C)",
+    )
 
     # -- connectors --
     conn_parser = subparsers.add_parser("connectors", help="Manage connectors")
@@ -2206,6 +2320,7 @@ def main():
     commands = {
         ("jobs", "list"): cmd_jobs_list,
         ("jobs", "get"): cmd_jobs_get,
+        ("jobs", "tail"): cmd_jobs_tail,
         ("connectors", "list-platform"): cmd_connectors_list_platform,
         ("connectors", "list-custom"): cmd_connectors_list_custom,
         ("recipes", "list"): cmd_recipes_list,


### PR DESCRIPTION
## Summary

Completes Issue #160 group D (job observability): adds a polling stream for new jobs plus a client-side `--limit` cap on the existing list command.

### New behavior

```bash
jobs list --recipe-id <id> [--status filter] [--limit N]
jobs tail --recipe-id <id> [--status filter]
                           [--interval SEC] [--max-iterations N]
```

- `jobs list --limit` caps the response client-side; existing behavior is otherwise unchanged.
- `jobs tail` polls `/api/recipes/:id/jobs` at the interval and prints only newly-seen jobs as one JSON object per line. **The initial fetch primes the seen-set** so the existing backlog is not printed — you only see jobs that appear after the command starts.

### Implementation notes

- Polling logic factored into `jobs_tail_loop` so it is testable without sleeping or real HTTP.
- `_sleep` / `_print` injection points; the test suite uses `lambda d: None` and a list-appending print to stay fast.
- `KeyboardInterrupt` during sleep is caught and the loop returns cleanly with the iteration count.
- Workato returns newest-first; the loop reverses new-job batches so the tail reads oldest-first within each iteration (matches `tail -f` ordering).
- Defensive: non-dict and id-less entries are skipped (they can't be deduped safely).

## Test plan

14 new tests in `scripts/tests/test_jobs_tail.py` (178 across the full suite):

- [x] 3 × `jobs list --limit` (no-limit, --limit caps, --limit 0 returns empty)
- [x] 9 × `jobs_tail_loop` (priming suppresses backlog, new-job emission across iterations, oldest-first ordering, --max-iterations stops at N and =0 does no polls, KeyboardInterrupt mid-sleep, --status passes through to every fetch, non-dict skipped, id-less skipped)
- [x] 2 × subprocess CLI argparse (--recipe-id required, non-int --max-iterations rejected with exit 2)
- [x] All 178 existing tests still pass
- [x] Pre-push Codex review on clean worktree: no defects flagged

Refs #160 (group D).

Remaining for Issue #160 after this PR:
- A: `sdk pull <project>` / `sdk diff <project>`
- E: `connector test <path>`
- Retrofit: `--dry-run` + dev-profile guard on `sdk push`, `oauth-profiles create/update/delete`