### PR TITLE
feat(retrofit): apply dev-guard + --dry-run to sdk push and oauth-profiles (Issue #160)

### DIFF
--- a/scripts/tests/test_retrofit_mutations.py
+++ b/scripts/tests/test_retrofit_mutations.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Tests for the retrofit of sdk push + oauth-profiles create/update/delete.
+
+Each command now:
+  - calls require_dev_profile_for_mutation before doing anything else
+  - honors --dry-run by emitting the intended request and skipping the API
+  - redacts secrets in dry-run output (oauth-profiles)
+
+Run with:
+    python3 scripts/tests/test_retrofit_mutations.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+def _capture_stderr_exit(fn):
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    return exited, code, err
+
+
+def _capture_stdout(fn):
+    saved = sys.stdout
+    sys.stdout = io.StringIO()
+    saved_err = sys.stderr
+    sys.stderr = io.StringIO()  # silence informational stderr
+    try:
+        fn()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved
+        sys.stderr = saved_err
+
+
+class _ExplodingAPI:
+    base_url = "https://workato.example.com"
+
+    def __getattr__(self, name):
+        def boom(*_a, **_kw):
+            raise AssertionError(f"_ExplodingAPI.{name} called despite guard")
+        return boom
+
+
+class _RecordingAPI:
+    def __init__(self, base_url="https://workato.example.com"):
+        self.base_url = base_url
+        self.calls: list = []
+
+    def sdk_push(self, **kwargs):
+        self.calls.append(("sdk_push", kwargs))
+        return {"id": 99, "title": kwargs.get("title", "X")}
+
+    def oauth_profiles_create(self, **kwargs):
+        self.calls.append(("create", kwargs))
+        return {"id": 1, "name": kwargs.get("name")}
+
+    def oauth_profiles_update(self, **kwargs):
+        self.calls.append(("update", kwargs))
+        return {"id": kwargs["profile_id"], "name": kwargs.get("name")}
+
+    def oauth_profiles_delete(self, profile_id):
+        self.calls.append(("delete", profile_id))
+        return {"success": True}
+
+
+# ---------------------------------------------------------------------------
+# _redact_oauth_body
+# ---------------------------------------------------------------------------
+
+
+def test_redact_masks_client_secret():
+    body = {"data": {"client_id": "id", "client_secret": "sekret"}}
+    out = wa._redact_oauth_body(body)
+    assert out["data"]["client_secret"] == "***REDACTED***"
+    assert out["data"]["client_id"] == "id"
+
+
+def test_redact_masks_token():
+    body = {"data": {"token": "xoxb-1234"}}
+    out = wa._redact_oauth_body(body)
+    assert out["data"]["token"] == "***REDACTED***"
+
+
+def test_redact_leaves_input_untouched():
+    """Defense-in-depth: original dict must not be mutated."""
+    body = {"data": {"client_secret": "sekret"}}
+    wa._redact_oauth_body(body)
+    assert body["data"]["client_secret"] == "sekret"
+
+
+def test_redact_handles_missing_data_key():
+    """Body without `data` should be returned without crashing."""
+    assert wa._redact_oauth_body({}) == {}
+
+
+def test_redact_handles_none_token():
+    """A token field that is None should not become '***REDACTED***'."""
+    body = {"data": {"token": None, "client_secret": "x"}}
+    out = wa._redact_oauth_body(body)
+    assert out["data"]["token"] is None
+    assert out["data"]["client_secret"] == "***REDACTED***"
+
+
+# ---------------------------------------------------------------------------
+# cmd_oauth_profiles_create — guard + --dry-run + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_create_refuses_non_dev():
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        name="x", provider="slack", client_id="id", client_secret="sek",
+        token=None, dry_run=False, _resolved_profile_name="acme-prod",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_oauth_profiles_create(api, args)
+    )
+    assert exited and code == 1
+    assert "prod" in err
+
+
+def test_oauth_create_dry_run_does_not_call_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        name="x", provider="slack", client_id="id", client_secret="sek",
+        token="xoxb-tok", dry_run=True, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_oauth_profiles_create(api, args))
+    parsed = json.loads(out)
+    assert parsed["mode"] == "dry-run"
+    assert parsed["would_call"]["method"] == "POST"
+    assert parsed["would_call"]["url"].endswith("/api/custom_oauth_profiles")
+    body = parsed["would_call"]["body"]
+    assert body["data"]["client_secret"] == "***REDACTED***"
+    assert body["data"]["token"] == "***REDACTED***"
+    assert body["data"]["client_id"] == "id"
+    assert api.calls == []
+
+
+def test_oauth_create_happy_path_invokes_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        name="x", provider="slack", client_id="id", client_secret="sek",
+        token=None, dry_run=False, _resolved_profile_name="acme-dev",
+    )
+    _capture_stdout(lambda: wa.cmd_oauth_profiles_create(api, args))
+    assert len(api.calls) == 1
+    assert api.calls[0][0] == "create"
+
+
+# ---------------------------------------------------------------------------
+# cmd_oauth_profiles_update — guard + --dry-run + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_update_refuses_non_dev():
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        id=42, name="x", provider="slack",
+        client_id="id", client_secret="sek", token=None,
+        dry_run=False, _resolved_profile_name="acme-test",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_oauth_profiles_update(api, args)
+    )
+    assert exited and code == 1
+    assert "test" in err
+
+
+def test_oauth_update_dry_run_redacts_secrets():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        id=42, name="x", provider="slack",
+        client_id="id", client_secret="sek", token=None,
+        dry_run=True, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_oauth_profiles_update(api, args))
+    parsed = json.loads(out)
+    assert parsed["would_call"]["method"] == "PUT"
+    assert parsed["would_call"]["url"].endswith("/api/custom_oauth_profiles/42")
+    assert parsed["would_call"]["body"]["data"]["client_secret"] == "***REDACTED***"
+    assert api.calls == []
+
+
+def test_oauth_update_happy_path_invokes_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        id=42, name="x", provider="slack",
+        client_id="id", client_secret="sek", token=None,
+        dry_run=False, _resolved_profile_name="acme-dev",
+    )
+    _capture_stdout(lambda: wa.cmd_oauth_profiles_update(api, args))
+    assert api.calls[0][0] == "update"
+    assert api.calls[0][1]["profile_id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# cmd_oauth_profiles_delete — guard + --dry-run + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_delete_refuses_non_dev():
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        id=99, dry_run=False, _resolved_profile_name="acme-prod",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_oauth_profiles_delete(api, args)
+    )
+    assert exited and code == 1
+    assert "prod" in err
+
+
+def test_oauth_delete_dry_run_does_not_call_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        id=99, dry_run=True, _resolved_profile_name="acme-dev",
+    )
+    out = _capture_stdout(lambda: wa.cmd_oauth_profiles_delete(api, args))
+    parsed = json.loads(out)
+    assert parsed["would_call"]["method"] == "DELETE"
+    assert parsed["would_call"]["url"].endswith("/api/custom_oauth_profiles/99")
+    assert parsed["would_call"]["body"] is None
+    assert api.calls == []
+
+
+def test_oauth_delete_happy_path_invokes_api():
+    api = _RecordingAPI()
+    args = SimpleNamespace(
+        id=99, dry_run=False, _resolved_profile_name="acme-dev",
+    )
+    _capture_stdout(lambda: wa.cmd_oauth_profiles_delete(api, args))
+    assert api.calls == [("delete", 99)]
+
+
+# ---------------------------------------------------------------------------
+# cmd_sdk_push — guard + --dry-run + happy path
+# ---------------------------------------------------------------------------
+
+
+def _chdir(target: Path) -> Path:
+    prev = Path.cwd()
+    os.chdir(target)
+    return prev
+
+
+def _make_connector_dir(root: Path, name: str = "foo",
+                        with_id: int | None = None) -> Path:
+    """Create connectors/<name>/connector.rb and (optionally) the docs file
+    with `connector_id: <with_id>` in its frontmatter."""
+    cdir = root / "connectors" / name
+    cdir.mkdir(parents=True)
+    (cdir / "connector.rb").write_text("{ title: 'Foo' }\n")
+    if with_id is not None:
+        docs = root / "connectors" / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        (docs / f"{name}.md").write_text(
+            f"---\nconnector_id: {with_id}\n---\n# {name}\n"
+        )
+    return cdir / "connector.rb"
+
+
+def test_sdk_push_refuses_non_dev():
+    api = _ExplodingAPI()
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            cpath = _make_connector_dir(Path(d), with_id=42)
+            args = SimpleNamespace(
+                connector=str(cpath), title=None, connector_id=None,
+                description=None, notes=None, no_release=False,
+                skip_save_id=True, dry_run=False,
+                _resolved_profile_name="acme-prod",
+            )
+            exited, code, err = _capture_stderr_exit(
+                lambda: wa.cmd_sdk_push(api, args)
+            )
+            assert exited and code == 1
+            assert "prod" in err
+        finally:
+            os.chdir(prev)
+
+
+def test_sdk_push_dry_run_update_path():
+    api = _RecordingAPI()
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            cpath = _make_connector_dir(Path(d), with_id=42)
+            args = SimpleNamespace(
+                connector=str(cpath), title=None, connector_id=None,
+                description=None, notes=None, no_release=False,
+                skip_save_id=True, dry_run=True,
+                _resolved_profile_name="acme-dev",
+            )
+            out = _capture_stdout(lambda: wa.cmd_sdk_push(api, args))
+            parsed = json.loads(out)
+            assert parsed["mode"] == "dry-run"
+            assert parsed["is_update"] is True
+            assert parsed["would_call"]["method"] == "PUT"
+            assert parsed["would_call"]["url"].endswith("/api/custom_connectors/42")
+            assert parsed["would_call"]["body_summary"]["title"] == "Foo"
+            assert parsed["would_call"]["body_summary"]["code_length"] > 0
+            assert parsed["would_release"] is True
+            assert api.calls == []
+        finally:
+            os.chdir(prev)
+
+
+def test_sdk_push_dry_run_create_path():
+    """No existing docs frontmatter → would POST to /api/custom_connectors."""
+    api = _RecordingAPI()
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            cpath = _make_connector_dir(Path(d), with_id=None)
+            args = SimpleNamespace(
+                connector=str(cpath), title=None, connector_id=None,
+                description=None, notes=None, no_release=False,
+                skip_save_id=True, dry_run=True,
+                _resolved_profile_name="acme-dev",
+            )
+            out = _capture_stdout(lambda: wa.cmd_sdk_push(api, args))
+            parsed = json.loads(out)
+            assert parsed["is_update"] is False
+            assert parsed["would_call"]["method"] == "POST"
+            assert parsed["would_call"]["url"].endswith("/api/custom_connectors")
+            assert api.calls == []
+        finally:
+            os.chdir(prev)
+
+
+def test_sdk_push_dry_run_no_release_flag():
+    api = _RecordingAPI()
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            cpath = _make_connector_dir(Path(d), with_id=7)
+            args = SimpleNamespace(
+                connector=str(cpath), title=None, connector_id=None,
+                description=None, notes=None, no_release=True,
+                skip_save_id=True, dry_run=True,
+                _resolved_profile_name="acme-dev",
+            )
+            out = _capture_stdout(lambda: wa.cmd_sdk_push(api, args))
+            parsed = json.loads(out)
+            assert parsed["would_release"] is False
+        finally:
+            os.chdir(prev)
+
+
+def test_sdk_push_happy_path_invokes_api():
+    api = _RecordingAPI()
+    with tempfile.TemporaryDirectory() as d:
+        prev = _chdir(Path(d))
+        try:
+            cpath = _make_connector_dir(Path(d), with_id=42)
+            args = SimpleNamespace(
+                connector=str(cpath), title=None, connector_id=None,
+                description=None, notes=None, no_release=False,
+                skip_save_id=True, dry_run=False,
+                _resolved_profile_name="acme-dev",
+            )
+            _capture_stdout(lambda: wa.cmd_sdk_push(api, args))
+            assert len(api.calls) == 1
+            assert api.calls[0][0] == "sdk_push"
+            assert api.calls[0][1]["connector_id"] == 42
+        finally:
+            os.chdir(prev)
+
+
+def test_sdk_push_guard_runs_before_file_read():
+    """A non-dev profile should fail before the connector file is even read."""
+    api = _ExplodingAPI()
+    args = SimpleNamespace(
+        connector="/nonexistent/path/connector.rb",
+        title=None, connector_id=None,
+        description=None, notes=None, no_release=False,
+        skip_save_id=True, dry_run=True,
+        _resolved_profile_name="acme-test",
+    )
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa.cmd_sdk_push(api, args)
+    )
+    assert exited and code == 1
+    # The error must be about the profile, not "File not found".
+    assert "test" in err
+    assert "File not found" not in err
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -83,11 +83,6 @@ Subcommand conventions (for contributors adding new subcommands):
   Read-only subcommands (*list, *get, jobs list/get, profile show) do not
   need --dry-run or epilog, but still need help= and description=.
 
-  Pre-existing side-effect commands without --dry-run (sdk push,
-  oauth-profiles create/update/delete) are tracked under Issue #160 for
-  retrofit alongside the new feature work; new commands must comply from
-  the start.
-
   See workato-deployment-flow.md for the dev->test->prod policy that the
   environment guards enforce at the CLI level.
 """
@@ -1136,7 +1131,53 @@ def cmd_oauth_profiles_get(api: WorkatoAPI, args: argparse.Namespace):
     print(json.dumps(profile, indent=2, ensure_ascii=False))
 
 
+def _redact_oauth_body(body: dict) -> dict:
+    """Return a deep-copied body with secrets masked for dry-run output.
+
+    --dry-run writes to stdout, which CI logs and `tee` will capture.
+    The CLI already accepted the secret in argv, so we are not creating
+    a new exposure, but emitting the secret a second time in pipeline
+    logs is unnecessary. Mask `data.client_secret` and `data.token`.
+    """
+    safe = json.loads(json.dumps(body))
+    data = safe.get("data") if isinstance(safe, dict) else None
+    if isinstance(data, dict):
+        for key in ("client_secret", "token"):
+            if key in data and data[key] is not None:
+                data[key] = "***REDACTED***"
+    return safe
+
+
+def _oauth_dry_run_output(method: str, path: str, body: dict | None,
+                           profile_name: str, base_url: str) -> dict:
+    payload = {
+        "mode": "dry-run",
+        "would_call": {
+            "method": method,
+            "url": f"{base_url.rstrip('/')}{path}",
+            "body": _redact_oauth_body(body) if body is not None else None,
+        },
+        "profile": profile_name,
+    }
+    return payload
+
+
 def cmd_oauth_profiles_create(api: WorkatoAPI, args: argparse.Namespace):
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"create OAuth profile '{args.name}'",
+    )
+    body: dict = {
+        "name": args.name, "provider": args.provider,
+        "data": {"client_id": args.client_id, "client_secret": args.client_secret},
+    }
+    if args.token is not None:
+        body["data"]["token"] = args.token
+    if args.dry_run:
+        print(json.dumps(_oauth_dry_run_output(
+            "POST", "/api/custom_oauth_profiles", body,
+            args._resolved_profile_name, api.base_url,
+        ), indent=2, ensure_ascii=False))
+        return
     result = api.oauth_profiles_create(
         name=args.name, provider=args.provider,
         client_id=args.client_id, client_secret=args.client_secret,
@@ -1147,6 +1188,21 @@ def cmd_oauth_profiles_create(api: WorkatoAPI, args: argparse.Namespace):
 
 
 def cmd_oauth_profiles_update(api: WorkatoAPI, args: argparse.Namespace):
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"update OAuth profile id={args.id}",
+    )
+    body: dict = {
+        "name": args.name, "provider": args.provider,
+        "data": {"client_id": args.client_id, "client_secret": args.client_secret},
+    }
+    if args.token is not None:
+        body["data"]["token"] = args.token
+    if args.dry_run:
+        print(json.dumps(_oauth_dry_run_output(
+            "PUT", f"/api/custom_oauth_profiles/{args.id}", body,
+            args._resolved_profile_name, api.base_url,
+        ), indent=2, ensure_ascii=False))
+        return
     result = api.oauth_profiles_update(
         profile_id=args.id, name=args.name, provider=args.provider,
         client_id=args.client_id, client_secret=args.client_secret,
@@ -1157,6 +1213,15 @@ def cmd_oauth_profiles_update(api: WorkatoAPI, args: argparse.Namespace):
 
 
 def cmd_oauth_profiles_delete(api: WorkatoAPI, args: argparse.Namespace):
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"delete OAuth profile id={args.id}",
+    )
+    if args.dry_run:
+        print(json.dumps(_oauth_dry_run_output(
+            "DELETE", f"/api/custom_oauth_profiles/{args.id}", None,
+            args._resolved_profile_name, api.base_url,
+        ), indent=2, ensure_ascii=False))
+        return
     result = api.oauth_profiles_delete(args.id)
     print(json.dumps(result, indent=2, ensure_ascii=False))
     print(f"\nDeleted OAuth profile id={args.id}", file=sys.stderr)
@@ -1528,6 +1593,10 @@ def cmd_sdk_pull(api: WorkatoAPI, args: argparse.Namespace):
 
 
 def cmd_sdk_push(api: WorkatoAPI, args: argparse.Namespace):
+    require_dev_profile_for_mutation(
+        args._resolved_profile_name, f"push connector {args.connector}",
+    )
+
     connector_path = Path(args.connector)
     if not connector_path.exists():
         print(f"Error: File not found: {connector_path}", file=sys.stderr)
@@ -1564,6 +1633,34 @@ def cmd_sdk_push(api: WorkatoAPI, args: argparse.Namespace):
             f"(no connector_id found in {display_docs})",
             file=sys.stderr,
         )
+
+    if args.dry_run:
+        # Show what would be sent without calling the API. The source
+        # code can be large, so emit a summary (length + title) rather
+        # than the full body. The release follow-up is reported
+        # explicitly so users know what they're authorizing.
+        if is_update:
+            method, path = "PUT", f"/api/custom_connectors/{resolved_id}"
+        else:
+            method, path = "POST", "/api/custom_connectors"
+        print(json.dumps({
+            "mode": "dry-run",
+            "would_call": {
+                "method": method,
+                "url": f"{api.base_url.rstrip('/')}{path}",
+                "body_summary": {
+                    "code_length": len(source_code),
+                    "title": title,
+                    "description_set": bool(args.description),
+                    "notes_set": bool(args.notes),
+                },
+            },
+            "would_release": not args.no_release,
+            "profile": args._resolved_profile_name,
+            "docs_path": str(docs_path),
+            "is_update": is_update,
+        }, indent=2, ensure_ascii=False))
+        return
 
     result = api.sdk_push(
         source_code=source_code,
@@ -2051,10 +2148,14 @@ def main():
             "Push connector source to Workato as a new version and release "
             "it. Auto-detects create vs. update from the connector_id stored "
             "in connectors/docs/<name>.md frontmatter, and saves the ID back "
-            "after an initial create. Writes to the connected workspace."
+            "after an initial create. Refuses unless the resolved profile is "
+            "`<org>-dev` — direct mutations against test/prod must go via "
+            "`deploy run` instead."
         ),
         epilog=(
             "Examples:\n"
+            "  # Dry run: print intended URL + body summary, no API call\n"
+            "  python3 scripts/workato-api.py sdk push --connector connectors/foo/connector.rb --dry-run\n\n"
             "  # Update an existing connector (ID auto-resolved from docs frontmatter)\n"
             "  python3 scripts/workato-api.py sdk push --connector connectors/foo/connector.rb\n\n"
             "  # First-time push (creates the connector, then saves the new ID)\n"
@@ -2083,6 +2184,10 @@ def main():
         "--skip-save-id", action="store_true",
         help="Don't persist the returned connector_id to "
              "connectors/docs/<name>.md frontmatter",
+    )
+    sdk_push_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print intended POST/PUT (and release follow-up) without sending",
     )
 
     sdk_pull_p = sdk_sub.add_parser(
@@ -2197,10 +2302,16 @@ def main():
         help="Create OAuth profile",
         description=(
             "Create a new custom OAuth profile in the connected workspace. "
+            "Refuses unless the resolved profile is `<org>-dev` — direct "
+            "mutations against test/prod must go via `deploy run` instead. "
             "Writes to Workato."
         ),
         epilog=(
             "Examples:\n"
+            "  # Dry run: print intended POST with secrets redacted\n"
+            "  python3 scripts/workato-api.py oauth-profiles create --dry-run \\\n"
+            "      --name \"My App\" --provider slack \\\n"
+            "      --client-id <id> --client-secret <secret>\n\n"
             "  python3 scripts/workato-api.py oauth-profiles create \\\n"
             "      --name \"My App\" --provider slack \\\n"
             "      --client-id <id> --client-secret <secret>\n"
@@ -2212,17 +2323,27 @@ def main():
     oauth_create_p.add_argument("--client-id", required=True)
     oauth_create_p.add_argument("--client-secret", required=True)
     oauth_create_p.add_argument("--token", default=None, help="Token (Slack only)")
+    oauth_create_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print intended POST (secrets redacted) without sending it",
+    )
 
     oauth_update_p = oauth_sub.add_parser(
         "update",
         help="Update OAuth profile",
         description=(
             "Update a custom OAuth profile by ID. All identifying fields are "
-            "required (name, provider, client_id, client_secret). Writes to "
+            "required (name, provider, client_id, client_secret). Refuses "
+            "unless the resolved profile is `<org>-dev` — direct mutations "
+            "against test/prod must go via `deploy run` instead. Writes to "
             "Workato."
         ),
         epilog=(
             "Examples:\n"
+            "  # Dry run: print intended PUT with secrets redacted\n"
+            "  python3 scripts/workato-api.py oauth-profiles update --id 123 --dry-run \\\n"
+            "      --name \"My App\" --provider slack \\\n"
+            "      --client-id <id> --client-secret <secret>\n\n"
             "  python3 scripts/workato-api.py oauth-profiles update --id 123 \\\n"
             "      --name \"My App\" --provider slack \\\n"
             "      --client-id <id> --client-secret <secret>\n"
@@ -2235,21 +2356,32 @@ def main():
     oauth_update_p.add_argument("--client-id", required=True)
     oauth_update_p.add_argument("--client-secret", required=True)
     oauth_update_p.add_argument("--token", default=None, help="Token (Slack only)")
+    oauth_update_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print intended PUT (secrets redacted) without sending it",
+    )
 
     oauth_delete_p = oauth_sub.add_parser(
         "delete",
         help="Delete OAuth profile",
         description=(
             "Delete a custom OAuth profile by ID. Destructive; the profile "
-            "is removed from the connected workspace."
+            "is removed from the connected workspace. Refuses unless the "
+            "resolved profile is `<org>-dev`."
         ),
         epilog=(
             "Examples:\n"
+            "  # Dry run: print the DELETE that would be sent\n"
+            "  python3 scripts/workato-api.py oauth-profiles delete --id 123 --dry-run\n\n"
             "  python3 scripts/workato-api.py oauth-profiles delete --id 123\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     oauth_delete_p.add_argument("--id", type=int, required=True)
+    oauth_delete_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the intended DELETE request without sending it",
+    )
 
     # -- profile --
     profile_parser = subparsers.add_parser(


### PR DESCRIPTION
## Summary

Retrofits the four pre-existing side-effect commands the convention docstring tracked as deferred:

- `sdk push`
- `oauth-profiles create`
- `oauth-profiles update`
- `oauth-profiles delete`

Each now: (1) runs `require_dev_profile_for_mutation` before any work, (2) honors `--dry-run` by emitting the intended request and skipping the API. After this PR, the convention rule "every side-effect command has `--dry-run` and the dev guard" is **uniformly enforced** across the helper.

### Secret redaction in dry-run output

`oauth-profiles` dry-run output passes the body through a new `_redact_oauth_body()` helper that deep-copies the dict and masks `data.client_secret` and `data.token` as `***REDACTED***`. Rationale: dry-run stdout is commonly piped to CI logs or `tee`, and there is no reason to re-emit the secret there even though the CLI already accepted it via argv.

`sdk push` dry-run emits a `body_summary` (`code_length`, `title`, flags) rather than the full source code — keeps the planning view readable for large connectors.

### Convention docstring

Removes the "Pre-existing side-effect commands without --dry-run (sdk push, oauth-profiles create/update/delete) are tracked under Issue #160 for retrofit" paragraph. With this PR the carve-out is no longer needed.

### Help / epilog

All four commands now lead their epilog with a `--dry-run` example, per the convention's "first example" requirement for side-effect commands.

## Test plan

20 new tests in `scripts/tests/test_retrofit_mutations.py` (now 198 across the full suite):

- [x] 5 × `_redact_oauth_body` (masks `client_secret`, masks `token`, leaves input untouched, handles missing `data` key, leaves `None` token alone)
- [x] 9 × `oauth-profiles create/update/delete` (each: refuses non-dev, --dry-run skips API + correct URL + secrets redacted, happy-path invokes API)
- [x] 6 × `sdk push` (refuses non-dev, --dry-run update path emits PUT with `code_length`, --dry-run create path emits POST, `--no-release` flips `would_release`, happy-path invokes API, guard runs **before** file read — a non-dev profile + nonexistent file path still errors on the profile, not on the missing file)
- [x] All 198 existing tests still pass
- [x] Pre-push Codex review on clean worktree: no defects flagged

Refs #160 (retrofit). Remaining for Issue #160: A (`sdk pull <project>` / `sdk diff <project>`), E (`connector test`).