### PR TITLE
feat(sdk): `sdk pull-project` and `sdk diff-project` (Issue #160 A)

### DIFF
--- a/scripts/tests/test_sdk_project_pull_diff.py
+++ b/scripts/tests/test_sdk_project_pull_diff.py
@@ -69,14 +69,21 @@ def _capture_stdout_stderr_exit(fn):
         sys.stdout, sys.stderr = saved_out, saved_err
 
 
-def _make_project_dir(root: Path) -> Path:
+def _make_project_dir(root: Path, workspace_id: int = 1) -> Path:
     """Create a minimal project dir with .workatoenv."""
     (root / ".workatoenv").write_text(
-        json.dumps({"workspace_id": 1, "folder_id": 42})
+        json.dumps({"workspace_id": workspace_id, "folder_id": 42})
     )
     (root / "Recipes").mkdir()
     (root / "Recipes" / "a.recipe.json").write_text('{"name": "local"}')
     return root
+
+
+def _patch_profile_pool(pool: dict):
+    """Patch load_profiles to return a controlled set; returns restore callable."""
+    saved = wa.load_profiles
+    wa.load_profiles = lambda: {"profiles": pool, "current_profile": None}
+    return lambda: setattr(wa, "load_profiles", saved)
 
 
 # ---------------------------------------------------------------------------
@@ -160,89 +167,138 @@ def _patch_pull(rc=0, stdout="", stderr=""):
     return (lambda: setattr(wa, "_invoke_workato_pull", saved)), calls
 
 
-def test_pull_project_invokes_workato_with_resolved_profile():
+def test_pull_project_resolves_profile_from_project_workatoenv():
+    """workspace_id in the project's .workatoenv selects the right profile."""
     with tempfile.TemporaryDirectory() as d:
-        _make_project_dir(Path(d))
+        _make_project_dir(Path(d), workspace_id=42)
         prev = _chdir(Path(d))
         try:
-            restore, calls = _patch_pull(rc=0, stdout="ok\n", stderr="")
+            restore_pool = _patch_profile_pool({
+                "acme-dev": {"workspace_id": 1, "region_url": "u"},
+                "acme-test": {"workspace_id": 42, "region_url": "u"},
+            })
+            restore_pull, calls = _patch_pull(rc=0, stdout="ok\n", stderr="")
             try:
                 args = SimpleNamespace(
-                    project_dir=None,
-                    _resolved_profile_name="acme-test",
+                    project_dir=None, profile=None,
                 )
-                exited, code, out, err = _capture_stdout_stderr_exit(
+                exited, code, out, _ = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_pull_project(None, args)
                 )
                 assert exited and code == 0
                 assert calls == [("acme-test", Path(d).resolve())]
                 assert "ok" in out
             finally:
-                restore()
+                restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
 
-def test_pull_project_uses_explicit_project_dir():
+def test_pull_project_dir_resolves_against_target_workatoenv_not_cwd():
+    """P1 regression: --project-dir picks the profile from the *target* project,
+    not from cwd's .workatoenv. Run with cwd's .workatoenv pointing at one
+    workspace and --project-dir at another; the call must use the latter."""
     with tempfile.TemporaryDirectory() as outer:
-        proj = Path(outer) / "subproj"
-        proj.mkdir()
-        _make_project_dir(proj)
-        restore, calls = _patch_pull(rc=0)
+        cwd_proj = Path(outer) / "cwd_proj"
+        target_proj = Path(outer) / "target_proj"
+        cwd_proj.mkdir()
+        target_proj.mkdir()
+        _make_project_dir(cwd_proj, workspace_id=1)
+        _make_project_dir(target_proj, workspace_id=42)
+        prev = _chdir(cwd_proj)
         try:
-            args = SimpleNamespace(
-                project_dir=str(proj),
-                _resolved_profile_name="acme-dev",
-            )
-            exited, code, _, _ = _capture_stdout_stderr_exit(
-                lambda: wa.cmd_sdk_pull_project(None, args)
-            )
-            assert exited and code == 0
-            assert calls == [("acme-dev", proj.resolve())]
+            restore_pool = _patch_profile_pool({
+                "acme-dev": {"workspace_id": 1, "region_url": "u"},
+                "acme-test": {"workspace_id": 42, "region_url": "u"},
+            })
+            restore_pull, calls = _patch_pull(rc=0)
+            try:
+                args = SimpleNamespace(
+                    project_dir=str(target_proj), profile=None,
+                )
+                exited, code, _, _ = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 0
+                # Must use the target's profile (acme-test), NOT cwd's (acme-dev).
+                assert calls == [("acme-test", target_proj.resolve())]
+            finally:
+                restore_pull()
+                restore_pool()
         finally:
-            restore()
+            os.chdir(prev)
+
+
+def test_pull_project_explicit_profile_wins_over_workatoenv():
+    """--profile overrides workspace_id resolution from .workatoenv."""
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d), workspace_id=42)
+        prev = _chdir(Path(d))
+        try:
+            restore_pool = _patch_profile_pool({
+                "acme-dev": {"workspace_id": 1, "region_url": "u"},
+                "acme-test": {"workspace_id": 42, "region_url": "u"},
+            })
+            restore_pull, calls = _patch_pull(rc=0)
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, profile="acme-dev",
+                )
+                exited, code, _, _ = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 0
+                assert calls == [("acme-dev", Path(d).resolve())]
+            finally:
+                restore_pull()
+                restore_pool()
+        finally:
+            os.chdir(prev)
 
 
 def test_pull_project_propagates_non_zero_exit():
     with tempfile.TemporaryDirectory() as d:
-        _make_project_dir(Path(d))
+        _make_project_dir(Path(d), workspace_id=1)
         prev = _chdir(Path(d))
         try:
-            restore, _ = _patch_pull(rc=2, stdout="", stderr="auth failed\n")
+            restore_pool = _patch_profile_pool({
+                "acme-dev": {"workspace_id": 1, "region_url": "u"},
+            })
+            restore_pull, _ = _patch_pull(rc=2, stdout="", stderr="auth failed\n")
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, _out, err = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_pull_project(None, args)
                 )
                 assert exited and code == 2
                 assert "auth failed" in err
             finally:
-                restore()
+                restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
 
 def test_pull_project_refuses_missing_workatoenv():
     with tempfile.TemporaryDirectory() as d:
-        # No .workatoenv created
         prev = _chdir(Path(d))
         try:
-            restore, calls = _patch_pull(rc=0)
+            restore_pool = _patch_profile_pool({
+                "acme-dev": {"workspace_id": 1, "region_url": "u"},
+            })
+            restore_pull, calls = _patch_pull(rc=0)
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, _, err = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_pull_project(None, args)
                 )
                 assert exited and code == 1
                 assert ".workatoenv" in err
-                # workato pull must NOT have been invoked
                 assert calls == []
             finally:
-                restore()
+                restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
@@ -264,29 +320,31 @@ def _patch_diff(rc=0, stdout="", stderr=""):
     return (lambda: setattr(wa, "_run_diff", saved)), calls
 
 
+_DEFAULT_POOL = {"acme-dev": {"workspace_id": 1, "region_url": "u"}}
+
+
 def test_diff_project_identical_returns_zero():
     """diff -ru exit 0 → diff-project also exits 0."""
     with tempfile.TemporaryDirectory() as d:
         _make_project_dir(Path(d))
         prev = _chdir(Path(d))
         try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
             restore_pull, _ = _patch_pull(rc=0)
             restore_diff, calls = _patch_diff(rc=0, stdout="")
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, out, _ = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_diff_project(None, args)
                 )
                 assert exited and code == 0
                 assert out == ""
                 assert len(calls) == 1
-                # local arg is the resolved project dir
                 assert calls[0][0] == Path(d).resolve()
             finally:
                 restore_diff()
                 restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
@@ -296,15 +354,14 @@ def test_diff_project_differs_returns_one_and_prints_diff():
         _make_project_dir(Path(d))
         prev = _chdir(Path(d))
         try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
             restore_pull, _ = _patch_pull(rc=0)
             restore_diff, _ = _patch_diff(
                 rc=1,
                 stdout="diff -ru ./Recipes/a.recipe.json ./pulled/...",
             )
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, out, _ = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_diff_project(None, args)
                 )
@@ -313,6 +370,7 @@ def test_diff_project_differs_returns_one_and_prints_diff():
             finally:
                 restore_diff()
                 restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
@@ -322,23 +380,22 @@ def test_diff_project_pull_failure_returns_two():
         _make_project_dir(Path(d))
         prev = _chdir(Path(d))
         try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
             restore_pull, _ = _patch_pull(rc=3, stderr="auth boom\n")
             restore_diff, calls = _patch_diff(rc=0)
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, _out, err = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_diff_project(None, args)
                 )
                 assert exited and code == 2
                 assert "workato pull" in err
                 assert "auth boom" in err
-                # diff must NOT have been called
                 assert calls == []
             finally:
                 restore_diff()
                 restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
@@ -349,12 +406,11 @@ def test_diff_project_diff_failure_returns_two():
         _make_project_dir(Path(d))
         prev = _chdir(Path(d))
         try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
             restore_pull, _ = _patch_pull(rc=0)
             restore_diff, _ = _patch_diff(rc=2, stderr="cannot read\n")
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 exited, code, _, err = _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_diff_project(None, args)
                 )
@@ -363,6 +419,7 @@ def test_diff_project_diff_failure_returns_two():
             finally:
                 restore_diff()
                 restore_pull()
+                restore_pool()
         finally:
             os.chdir(prev)
 
@@ -376,9 +433,8 @@ def test_diff_project_does_not_modify_original_dir():
 
         prev = _chdir(Path(d))
         try:
-            # Patch pull to *modify* the temp copy (simulating a real pull
-            # overwriting a file). This proves the helper isolates that
-            # mutation to the temp dir.
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
+
             def writing_pull(profile, cwd, _runner=None):
                 target = Path(cwd) / "Recipes" / "a.recipe.json"
                 if target.exists():
@@ -389,19 +445,44 @@ def test_diff_project_does_not_modify_original_dir():
             wa._invoke_workato_pull = writing_pull
             restore_diff, _ = _patch_diff(rc=0, stdout="")
             try:
-                args = SimpleNamespace(
-                    project_dir=None, _resolved_profile_name="acme-dev",
-                )
+                args = SimpleNamespace(project_dir=None, profile=None)
                 _capture_stdout_stderr_exit(
                     lambda: wa.cmd_sdk_diff_project(None, args)
                 )
-                # The original must be untouched.
                 assert original_file.read_text() == original_text
             finally:
                 restore_diff()
                 wa._invoke_workato_pull = saved_pull
+                restore_pool()
         finally:
             os.chdir(prev)
+
+
+# ---------------------------------------------------------------------------
+# Exclusion-set consistency (P2 fix from the Codex review)
+# ---------------------------------------------------------------------------
+
+
+def test_diff_argv_excludes_match_project_exclude_patterns():
+    """diff -ru must exclude the same patterns copytree's ignore drops.
+
+    Otherwise a local-only `.venv` / `node_modules` would always show
+    as "only in local" and diff-project would exit 1 even when the
+    Workato-managed assets are identical.
+    """
+    argv = wa._diff_argv(Path("/a"), Path("/b"))
+    excludes = [
+        argv[i + 1] for i, tok in enumerate(argv) if tok == "--exclude"
+    ]
+    for pattern in wa.PROJECT_EXCLUDE_PATTERNS:
+        assert pattern in excludes, f"missing --exclude {pattern}"
+
+
+def test_diff_argv_minimal_shape():
+    argv = wa._diff_argv(Path("/x"), Path("/y"))
+    assert argv[0] == "diff"
+    assert "-ru" in argv
+    assert argv[-2:] == ["/x", "/y"]
 
 
 def main() -> int:

--- a/scripts/tests/test_sdk_project_pull_diff.py
+++ b/scripts/tests/test_sdk_project_pull_diff.py
@@ -485,6 +485,93 @@ def test_diff_argv_minimal_shape():
     assert argv[-2:] == ["/x", "/y"]
 
 
+# ---------------------------------------------------------------------------
+# Missing-binary handling (FileNotFoundError → clean rc + message)
+# ---------------------------------------------------------------------------
+
+
+def _patch_subprocess_run_to_raise():
+    """Make subprocess.run raise FileNotFoundError. Returns restore callable."""
+    import subprocess as _sp
+    saved = _sp.run
+
+    def boom(*_a, **_kw):
+        raise FileNotFoundError("no such binary")
+
+    _sp.run = boom
+    return lambda: setattr(_sp, "run", saved)
+
+
+def test_invoke_workato_pull_returns_127_when_workato_missing():
+    restore = _patch_subprocess_run_to_raise()
+    try:
+        rc, _out, err = wa._invoke_workato_pull(
+            "acme-dev", Path("/tmp"),  # _runner=None — exercises subprocess path
+        )
+        assert rc == 127
+        assert "workato" in err
+        assert "PATH" in err
+    finally:
+        restore()
+
+
+def test_run_diff_returns_2_when_diff_missing():
+    restore = _patch_subprocess_run_to_raise()
+    try:
+        rc, _out, err = wa._run_diff(Path("/a"), Path("/b"))
+        assert rc == 2
+        assert "diff" in err
+        assert "PATH" in err
+    finally:
+        restore()
+
+
+def test_pull_project_exits_127_when_workato_missing():
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
+            restore_sp = _patch_subprocess_run_to_raise()
+            try:
+                args = SimpleNamespace(project_dir=None, profile=None)
+                exited, code, _out, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 127
+                assert "workato" in err
+            finally:
+                restore_sp()
+                restore_pool()
+        finally:
+            os.chdir(prev)
+
+
+def test_diff_project_exits_2_when_diff_missing_after_pull_succeeds():
+    """Pull succeeds (mocked), then diff binary is missing → rc 2."""
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pool = _patch_profile_pool(_DEFAULT_POOL)
+            restore_pull, _ = _patch_pull(rc=0)
+            # subprocess.run will raise only for diff (pull is patched)
+            restore_sp = _patch_subprocess_run_to_raise()
+            try:
+                args = SimpleNamespace(project_dir=None, profile=None)
+                exited, code, _, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                assert exited and code == 2
+                assert "diff" in err
+            finally:
+                restore_sp()
+                restore_pull()
+                restore_pool()
+        finally:
+            os.chdir(prev)
+
+
 def main() -> int:
     tests = [(name, obj) for name, obj in sorted(globals().items())
              if name.startswith("test_") and callable(obj)]

--- a/scripts/tests/test_sdk_project_pull_diff.py
+++ b/scripts/tests/test_sdk_project_pull_diff.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Tests for `sdk pull-project` and `sdk diff-project`.
+
+Both commands shell out to `workato` and `diff`; the tests inject a
+runner so they assert command construction and exit-code handling
+without invoking real subprocesses.
+
+Run with:
+    python3 scripts/tests/test_sdk_project_pull_diff.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+def _chdir(target: Path) -> Path:
+    prev = Path.cwd()
+    os.chdir(target)
+    return prev
+
+
+def _capture_stderr_exit(fn):
+    saved = sys.stderr
+    sys.stderr = io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stderr = saved
+    return exited, code, err
+
+
+def _capture_stdout_stderr_exit(fn):
+    saved_out, saved_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        return exited, code, sys.stdout.getvalue(), sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err
+
+
+def _make_project_dir(root: Path) -> Path:
+    """Create a minimal project dir with .workatoenv."""
+    (root / ".workatoenv").write_text(
+        json.dumps({"workspace_id": 1, "folder_id": 42})
+    )
+    (root / "Recipes").mkdir()
+    (root / "Recipes" / "a.recipe.json").write_text('{"name": "local"}')
+    return root
+
+
+# ---------------------------------------------------------------------------
+# _invoke_workato_pull — command construction
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_workato_pull_builds_expected_command():
+    captured: list = []
+
+    def runner(cmd, cwd):
+        captured.append((list(cmd), cwd))
+        return 0, "pulled\n", ""
+
+    rc, out, err = wa._invoke_workato_pull(
+        "acme-dev", Path("/tmp/proj"), _runner=runner,
+    )
+    assert rc == 0
+    assert out == "pulled\n"
+    assert err == ""
+    assert captured == [
+        (["workato", "--profile", "acme-dev", "pull"], Path("/tmp/proj")),
+    ]
+
+
+def test_invoke_workato_pull_propagates_non_zero():
+    def runner(_cmd, _cwd):
+        return 3, "", "boom\n"
+
+    rc, _, err = wa._invoke_workato_pull(
+        "acme-dev", Path("/tmp/x"), _runner=runner,
+    )
+    assert rc == 3
+    assert err == "boom\n"
+
+
+# ---------------------------------------------------------------------------
+# _validate_project_dir
+# ---------------------------------------------------------------------------
+
+
+def test_validate_project_dir_refuses_nonexistent():
+    exited, code, err = _capture_stderr_exit(
+        lambda: wa._validate_project_dir(Path("/nonexistent-XYZ-test"))
+    )
+    assert exited and code == 1
+    assert "does not exist" in err
+
+
+def test_validate_project_dir_refuses_missing_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        exited, code, err = _capture_stderr_exit(
+            lambda: wa._validate_project_dir(Path(d))
+        )
+        assert exited and code == 1
+        assert ".workatoenv" in err
+
+
+def test_validate_project_dir_passes_when_workatoenv_present():
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / ".workatoenv").write_text("{}")
+        # Should not exit
+        wa._validate_project_dir(Path(d))
+
+
+# ---------------------------------------------------------------------------
+# cmd_sdk_pull_project — wraps workato pull
+# ---------------------------------------------------------------------------
+
+
+def _patch_pull(rc=0, stdout="", stderr=""):
+    """Patch _invoke_workato_pull. Returns (restore_callable, calls list)."""
+    calls: list = []
+    saved = wa._invoke_workato_pull
+
+    def fake(profile, cwd, _runner=None):
+        calls.append((profile, cwd))
+        return rc, stdout, stderr
+
+    wa._invoke_workato_pull = fake
+    return (lambda: setattr(wa, "_invoke_workato_pull", saved)), calls
+
+
+def test_pull_project_invokes_workato_with_resolved_profile():
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore, calls = _patch_pull(rc=0, stdout="ok\n", stderr="")
+            try:
+                args = SimpleNamespace(
+                    project_dir=None,
+                    _resolved_profile_name="acme-test",
+                )
+                exited, code, out, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 0
+                assert calls == [("acme-test", Path(d).resolve())]
+                assert "ok" in out
+            finally:
+                restore()
+        finally:
+            os.chdir(prev)
+
+
+def test_pull_project_uses_explicit_project_dir():
+    with tempfile.TemporaryDirectory() as outer:
+        proj = Path(outer) / "subproj"
+        proj.mkdir()
+        _make_project_dir(proj)
+        restore, calls = _patch_pull(rc=0)
+        try:
+            args = SimpleNamespace(
+                project_dir=str(proj),
+                _resolved_profile_name="acme-dev",
+            )
+            exited, code, _, _ = _capture_stdout_stderr_exit(
+                lambda: wa.cmd_sdk_pull_project(None, args)
+            )
+            assert exited and code == 0
+            assert calls == [("acme-dev", proj.resolve())]
+        finally:
+            restore()
+
+
+def test_pull_project_propagates_non_zero_exit():
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore, _ = _patch_pull(rc=2, stdout="", stderr="auth failed\n")
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, _out, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 2
+                assert "auth failed" in err
+            finally:
+                restore()
+        finally:
+            os.chdir(prev)
+
+
+def test_pull_project_refuses_missing_workatoenv():
+    with tempfile.TemporaryDirectory() as d:
+        # No .workatoenv created
+        prev = _chdir(Path(d))
+        try:
+            restore, calls = _patch_pull(rc=0)
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, _, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_pull_project(None, args)
+                )
+                assert exited and code == 1
+                assert ".workatoenv" in err
+                # workato pull must NOT have been invoked
+                assert calls == []
+            finally:
+                restore()
+        finally:
+            os.chdir(prev)
+
+
+# ---------------------------------------------------------------------------
+# cmd_sdk_diff_project — copy + pull-in-copy + diff
+# ---------------------------------------------------------------------------
+
+
+def _patch_diff(rc=0, stdout="", stderr=""):
+    saved = wa._run_diff
+    calls: list = []
+
+    def fake(local, pulled, _runner=None):
+        calls.append((local, pulled))
+        return rc, stdout, stderr
+
+    wa._run_diff = fake
+    return (lambda: setattr(wa, "_run_diff", saved)), calls
+
+
+def test_diff_project_identical_returns_zero():
+    """diff -ru exit 0 → diff-project also exits 0."""
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pull, _ = _patch_pull(rc=0)
+            restore_diff, calls = _patch_diff(rc=0, stdout="")
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, out, _ = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                assert exited and code == 0
+                assert out == ""
+                assert len(calls) == 1
+                # local arg is the resolved project dir
+                assert calls[0][0] == Path(d).resolve()
+            finally:
+                restore_diff()
+                restore_pull()
+        finally:
+            os.chdir(prev)
+
+
+def test_diff_project_differs_returns_one_and_prints_diff():
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pull, _ = _patch_pull(rc=0)
+            restore_diff, _ = _patch_diff(
+                rc=1,
+                stdout="diff -ru ./Recipes/a.recipe.json ./pulled/...",
+            )
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, out, _ = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                assert exited and code == 1
+                assert "Recipes/a.recipe.json" in out
+            finally:
+                restore_diff()
+                restore_pull()
+        finally:
+            os.chdir(prev)
+
+
+def test_diff_project_pull_failure_returns_two():
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pull, _ = _patch_pull(rc=3, stderr="auth boom\n")
+            restore_diff, calls = _patch_diff(rc=0)
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, _out, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                assert exited and code == 2
+                assert "workato pull" in err
+                assert "auth boom" in err
+                # diff must NOT have been called
+                assert calls == []
+            finally:
+                restore_diff()
+                restore_pull()
+        finally:
+            os.chdir(prev)
+
+
+def test_diff_project_diff_failure_returns_two():
+    """diff exit 2 (e.g. permission error) bubbles up as 2."""
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        prev = _chdir(Path(d))
+        try:
+            restore_pull, _ = _patch_pull(rc=0)
+            restore_diff, _ = _patch_diff(rc=2, stderr="cannot read\n")
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                exited, code, _, err = _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                assert exited and code == 2
+                assert "diff" in err
+            finally:
+                restore_diff()
+                restore_pull()
+        finally:
+            os.chdir(prev)
+
+
+def test_diff_project_does_not_modify_original_dir():
+    """The local project files must be unchanged after diff-project runs."""
+    with tempfile.TemporaryDirectory() as d:
+        _make_project_dir(Path(d))
+        original_file = Path(d) / "Recipes" / "a.recipe.json"
+        original_text = original_file.read_text()
+
+        prev = _chdir(Path(d))
+        try:
+            # Patch pull to *modify* the temp copy (simulating a real pull
+            # overwriting a file). This proves the helper isolates that
+            # mutation to the temp dir.
+            def writing_pull(profile, cwd, _runner=None):
+                target = Path(cwd) / "Recipes" / "a.recipe.json"
+                if target.exists():
+                    target.write_text('{"name": "REMOTE"}')
+                return 0, "", ""
+
+            saved_pull = wa._invoke_workato_pull
+            wa._invoke_workato_pull = writing_pull
+            restore_diff, _ = _patch_diff(rc=0, stdout="")
+            try:
+                args = SimpleNamespace(
+                    project_dir=None, _resolved_profile_name="acme-dev",
+                )
+                _capture_stdout_stderr_exit(
+                    lambda: wa.cmd_sdk_diff_project(None, args)
+                )
+                # The original must be untouched.
+                assert original_file.read_text() == original_text
+            finally:
+                restore_diff()
+                wa._invoke_workato_pull = saved_pull
+        finally:
+            os.chdir(prev)
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -1495,17 +1495,27 @@ def _invoke_workato_pull(
 ) -> tuple[int, str, str]:
     """Invoke `workato --profile <name> pull` in `cwd`.
 
-    Returns (returncode, stdout, stderr). Never raises; callers decide
-    how to surface failures. `_runner` is an injection point for tests
-    (a callable taking (cmd_list, cwd) and returning (rc, stdout, stderr)).
+    Returns (returncode, stdout, stderr). Never raises — including when
+    the `workato` binary itself is missing; in that case we return rc
+    127 with a clear message so callers can surface a controlled error
+    instead of an opaque FileNotFoundError traceback. `_runner` is an
+    injection point for tests (a callable taking (cmd_list, cwd) and
+    returning (rc, stdout, stderr)).
     """
     if _runner is not None:
         return _runner(["workato", "--profile", profile_name, "pull"], cwd)
-    result = subprocess.run(
-        ["workato", "--profile", profile_name, "pull"],
-        cwd=str(cwd),
-        capture_output=True, text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["workato", "--profile", profile_name, "pull"],
+            cwd=str(cwd),
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError:
+        return 127, "", (
+            "Error: `workato` not found on PATH. Install the Workato "
+            "Platform CLI before running `sdk pull-project` / "
+            "`sdk diff-project`.\n"
+        )
     return result.returncode, result.stdout, result.stderr
 
 
@@ -1587,12 +1597,21 @@ def _diff_argv(local: Path, pulled: Path) -> list[str]:
 def _run_diff(local: Path, pulled: Path, _runner=None) -> tuple[int, str, str]:
     """Invoke `diff -ru` between two directories. Returns (rc, stdout, stderr).
 
-    diff's exit codes: 0 = identical, 1 = differ, 2 = error.
+    diff's exit codes: 0 = identical, 1 = differ, 2 = error. If the
+    `diff` binary itself is missing we return rc 2 with a clear message
+    so the caller can surface a controlled error instead of an opaque
+    FileNotFoundError traceback.
     """
     argv = _diff_argv(local, pulled)
     if _runner is not None:
         return _runner(argv, None)
-    result = subprocess.run(argv, capture_output=True, text=True)
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError:
+        return 2, "", (
+            "Error: `diff` not found on PATH. Install diffutils to run "
+            "`sdk diff-project`.\n"
+        )
     return result.returncode, result.stdout, result.stderr
 
 

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -2633,9 +2633,19 @@ def main():
             profile_parser.print_help()
         return
 
-    if args.command == "sdk" and getattr(args, "sdk_command", None) in ("decrypt", "edit"):
-        handler = {"decrypt": cmd_sdk_decrypt, "edit": cmd_sdk_edit}[args.sdk_command]
-        handler(None, args)
+    # These sdk subcommands do not touch the Workato API directly:
+    # decrypt/edit operate on local .enc files, and pull-project/diff-project
+    # shell out to `workato pull`. Dispatch before the main() profile-and-token
+    # bootstrap so keyring problems do not block workflows that don't need a
+    # Python-side token.
+    _sdk_pre_api = {
+        "decrypt": cmd_sdk_decrypt,
+        "edit": cmd_sdk_edit,
+        "pull-project": cmd_sdk_pull_project,
+        "diff-project": cmd_sdk_diff_project,
+    }
+    if args.command == "sdk" and getattr(args, "sdk_command", None) in _sdk_pre_api:
+        _sdk_pre_api[args.sdk_command](None, args)
         return
 
     # deploy handlers manage their own profile/token resolution so they
@@ -2681,8 +2691,6 @@ def main():
         ("recipes", "stop"): cmd_recipes_stop,
         ("sdk", "push"): cmd_sdk_push,
         ("sdk", "pull"): cmd_sdk_pull,
-        ("sdk", "pull-project"): cmd_sdk_pull_project,
-        ("sdk", "diff-project"): cmd_sdk_diff_project,
         ("sdk", "generate-schema"): cmd_sdk_generate_schema,
         ("oauth-profiles", "list"): cmd_oauth_profiles_list,
         ("oauth-profiles", "get"): cmd_oauth_profiles_get,

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -29,6 +29,10 @@ Usage:
   python3 scripts/workato-api.py sdk pull (--connector-id <id> | --name <name>)
     (downloads connector source to connectors/<name>/connector.rb and saves
      connector_id back to connectors/docs/<name>.md frontmatter)
+  python3 scripts/workato-api.py sdk pull-project [--project-dir <path>]
+    (wraps `workato pull` in the project directory)
+  python3 scripts/workato-api.py sdk diff-project [--project-dir <path>]
+    (pulls to a temp dir and diffs against the project directory)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
   python3 scripts/workato-api.py deploy preview --to <test|prod>
@@ -1472,6 +1476,132 @@ def _connector_slug(record: dict, fallback: str | None = None) -> str:
     return slug or (str(record.get("id")) if isinstance(record, dict) else "connector")
 
 
+def _invoke_workato_pull(
+    profile_name: str, cwd: Path,
+    _runner=None,
+) -> tuple[int, str, str]:
+    """Invoke `workato --profile <name> pull` in `cwd`.
+
+    Returns (returncode, stdout, stderr). Never raises; callers decide
+    how to surface failures. `_runner` is an injection point for tests
+    (a callable taking (cmd_list, cwd) and returning (rc, stdout, stderr)).
+    """
+    if _runner is not None:
+        return _runner(["workato", "--profile", profile_name, "pull"], cwd)
+    result = subprocess.run(
+        ["workato", "--profile", profile_name, "pull"],
+        cwd=str(cwd),
+        capture_output=True, text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _validate_project_dir(project_dir: Path) -> None:
+    """Refuse if project_dir lacks .workatoenv (workato pull would fail)."""
+    if not project_dir.is_dir():
+        print(
+            f"Error: project dir '{project_dir}' does not exist.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not (project_dir / ".workatoenv").exists():
+        print(
+            f"Error: '{project_dir}' has no .workatoenv. `workato pull` "
+            f"reads the workspace/folder from .workatoenv, so it must "
+            f"be run from inside a project directory.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def cmd_sdk_pull_project(_api: WorkatoAPI | None, args: argparse.Namespace):
+    """Pull project assets from the resolved Workato workspace.
+
+    Thin wrapper around `workato --profile <name> pull` that adds
+    profile auto-resolution from .workatoenv. Read-only against
+    Workato (only modifies local files in `--project-dir`, default
+    cwd). No env-transition guard — pull is allowed against any
+    profile per workato-deployment-flow.md.
+    """
+    project_dir = Path(args.project_dir).resolve() if args.project_dir else Path.cwd()
+    _validate_project_dir(project_dir)
+    rc, out, err = _invoke_workato_pull(args._resolved_profile_name, project_dir)
+    if out:
+        sys.stdout.write(out)
+        if not out.endswith("\n"):
+            sys.stdout.write("\n")
+    if err:
+        sys.stderr.write(err)
+        if not err.endswith("\n"):
+            sys.stderr.write("\n")
+    sys.exit(rc)
+
+
+def _run_diff(local: Path, pulled: Path, _runner=None) -> tuple[int, str, str]:
+    """Invoke `diff -ru` between two directories. Returns (rc, stdout, stderr).
+
+    diff's exit codes: 0 = identical, 1 = differ, 2 = error.
+    """
+    if _runner is not None:
+        return _runner(
+            ["diff", "-ru", "--exclude=.git", str(local), str(pulled)],
+            None,
+        )
+    result = subprocess.run(
+        ["diff", "-ru", "--exclude=.git", str(local), str(pulled)],
+        capture_output=True, text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def cmd_sdk_diff_project(_api: WorkatoAPI | None, args: argparse.Namespace):
+    """Show diff between local project and dev workspace state.
+
+    Copies the project directory to a temp dir (excluding .git), runs
+    `workato pull` in the copy so the temp tree reflects the remote
+    state, then runs `diff -ru` between the local project and the
+    pulled copy. Read-only — the original project directory is never
+    modified.
+
+    Exit codes mirror diff(1): 0 = identical, 1 = differences printed,
+    2 = the pull or the diff itself failed.
+    """
+    import shutil
+    project_dir = Path(args.project_dir).resolve() if args.project_dir else Path.cwd()
+    _validate_project_dir(project_dir)
+
+    with tempfile.TemporaryDirectory(prefix="kit-sdk-diff-") as tmp:
+        pulled_root = Path(tmp) / "pulled"
+        # Copy the project to a temp dir; exclude VCS and bulky local
+        # directories so the pull does not waste time on irrelevant files.
+        ignore = shutil.ignore_patterns(
+            ".git", ".venv", "node_modules", "__pycache__",
+        )
+        shutil.copytree(project_dir, pulled_root, ignore=ignore)
+
+        rc, _out, err = _invoke_workato_pull(
+            args._resolved_profile_name, pulled_root,
+        )
+        if rc != 0:
+            sys.stderr.write(
+                f"Error: `workato pull` failed in temp copy "
+                f"(exit {rc}). stderr:\n{err}"
+            )
+            sys.exit(2)
+
+        diff_rc, diff_out, diff_err = _run_diff(project_dir, pulled_root)
+        if diff_out:
+            sys.stdout.write(diff_out)
+            if not diff_out.endswith("\n"):
+                sys.stdout.write("\n")
+        if diff_rc == 2:
+            sys.stderr.write(
+                f"Error: `diff -ru` failed (exit 2). stderr:\n{diff_err}"
+            )
+            sys.exit(2)
+        sys.exit(diff_rc)
+
+
 def cmd_sdk_pull(api: WorkatoAPI, args: argparse.Namespace):
     """Pull a custom connector's source from Workato to the local filesystem."""
     if args.connector_id is None and not args.name:
@@ -2229,6 +2359,55 @@ def main():
         help="Don't persist connector_id to connectors/docs/<name>.md frontmatter",
     )
 
+    sdk_pull_project_p = sdk_sub.add_parser(
+        "pull-project",
+        help="Pull all project assets via `workato pull`",
+        description=(
+            "Pull project assets (recipes, connections, lookup tables, "
+            "etc.) from the resolved Workato workspace by invoking "
+            "`workato --profile <name> pull` in the project directory. "
+            "Thin wrapper: profile is auto-resolved from .workatoenv. "
+            "Read-only against Workato; only local files are modified."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Pull into the current project directory\n"
+            "  python3 scripts/workato-api.py sdk pull-project\n\n"
+            "  # Pull into an explicit project directory\n"
+            "  python3 scripts/workato-api.py sdk pull-project --project-dir projects/my-app\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sdk_pull_project_p.add_argument(
+        "--project-dir", default=None,
+        help="Project directory to pull into (default: cwd). Must contain .workatoenv.",
+    )
+
+    sdk_diff_project_p = sdk_sub.add_parser(
+        "diff-project",
+        help="Diff local project against dev workspace",
+        description=(
+            "Show differences between the local project and the "
+            "resolved Workato workspace. Copies the project to a temp "
+            "dir, runs `workato pull` in the copy so it reflects the "
+            "remote state, then `diff -ru` between local and pulled. "
+            "Read-only — does not modify the original project directory. "
+            "Exit code: 0 = identical, 1 = differences printed, 2 = error."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Diff the current project against dev\n"
+            "  python3 scripts/workato-api.py sdk diff-project\n\n"
+            "  # Diff an explicit project directory\n"
+            "  python3 scripts/workato-api.py sdk diff-project --project-dir projects/my-app\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sdk_diff_project_p.add_argument(
+        "--project-dir", default=None,
+        help="Project directory to diff (default: cwd). Must contain .workatoenv.",
+    )
+
     sdk_decrypt_p = sdk_sub.add_parser(
         "decrypt",
         help="Decrypt a .enc file and print to stdout",
@@ -2460,6 +2639,8 @@ def main():
         ("recipes", "stop"): cmd_recipes_stop,
         ("sdk", "push"): cmd_sdk_push,
         ("sdk", "pull"): cmd_sdk_pull,
+        ("sdk", "pull-project"): cmd_sdk_pull_project,
+        ("sdk", "diff-project"): cmd_sdk_diff_project,
         ("sdk", "generate-schema"): cmd_sdk_generate_schema,
         ("oauth-profiles", "list"): cmd_oauth_profiles_list,
         ("oauth-profiles", "get"): cmd_oauth_profiles_get,

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -125,9 +125,14 @@ def load_profiles() -> dict:
         return json.load(f)
 
 
-def find_workatoenv() -> dict | None:
-    """Walk up from cwd to find .workatoenv and return its contents."""
-    current = Path.cwd()
+def find_workatoenv(start_dir: Path | None = None) -> dict | None:
+    """Walk up from `start_dir` (default cwd) to find .workatoenv.
+
+    `start_dir` lets project-aware commands like `sdk pull-project
+    --project-dir <path>` resolve the workspace from the *target*
+    project, not from the shell's cwd.
+    """
+    current = start_dir if start_dir is not None else Path.cwd()
     while True:
         candidate = current / ".workatoenv"
         if candidate.exists():
@@ -140,13 +145,21 @@ def find_workatoenv() -> dict | None:
     return None
 
 
-def resolve_profile(explicit_profile: str | None) -> tuple[str, dict]:
+def resolve_profile(
+    explicit_profile: str | None,
+    start_dir: Path | None = None,
+) -> tuple[str, dict]:
     """Resolve which profile to use.
 
     Resolution order:
       1. --profile <name> explicitly given
-      2. .workatoenv workspace_id -> match against all profiles
+      2. .workatoenv workspace_id (walking up from `start_dir`, default cwd)
+         -> match against all profiles
       3. current_profile from ~/.workato/profiles
+
+    `start_dir` is forwarded to find_workatoenv() so callers that
+    operate on a specific project directory (e.g. sdk pull-project
+    --project-dir) resolve relative to that directory, not cwd.
 
     Returns (profile_name, profile_dict).
     """
@@ -169,7 +182,7 @@ def resolve_profile(explicit_profile: str | None) -> tuple[str, dict]:
         return explicit_profile, profiles[explicit_profile]
 
     # 2. workspace_id from .workatoenv
-    env = find_workatoenv()
+    env = find_workatoenv(start_dir)
     if env and "workspace_id" in env and env["workspace_id"] is not None:
         target_ws = str(env["workspace_id"])
         for name, prof in profiles.items():
@@ -1514,18 +1527,36 @@ def _validate_project_dir(project_dir: Path) -> None:
         sys.exit(1)
 
 
+PROJECT_EXCLUDE_PATTERNS = (".git", ".venv", "node_modules", "__pycache__")
+
+
+def _resolve_project_profile(
+    explicit_profile: str | None, project_dir: Path,
+) -> str:
+    """Resolve the profile name from the *target* project directory.
+
+    `args._resolved_profile_name` is set by main() from cwd's
+    .workatoenv; when --project-dir points elsewhere, that name can
+    select the wrong workspace. Re-resolve relative to project_dir so
+    the workspace matches the project being pulled / diffed.
+    """
+    name, _ = resolve_profile(explicit_profile, start_dir=project_dir)
+    return name
+
+
 def cmd_sdk_pull_project(_api: WorkatoAPI | None, args: argparse.Namespace):
     """Pull project assets from the resolved Workato workspace.
 
     Thin wrapper around `workato --profile <name> pull` that adds
-    profile auto-resolution from .workatoenv. Read-only against
-    Workato (only modifies local files in `--project-dir`, default
-    cwd). No env-transition guard — pull is allowed against any
-    profile per workato-deployment-flow.md.
+    profile auto-resolution from the target project's .workatoenv.
+    Read-only against Workato (only modifies local files in
+    `--project-dir`, default cwd). No env-transition guard — pull is
+    allowed against any profile per workato-deployment-flow.md.
     """
     project_dir = Path(args.project_dir).resolve() if args.project_dir else Path.cwd()
     _validate_project_dir(project_dir)
-    rc, out, err = _invoke_workato_pull(args._resolved_profile_name, project_dir)
+    profile_name = _resolve_project_profile(args.profile, project_dir)
+    rc, out, err = _invoke_workato_pull(profile_name, project_dir)
     if out:
         sys.stdout.write(out)
         if not out.endswith("\n"):
@@ -1537,31 +1568,43 @@ def cmd_sdk_pull_project(_api: WorkatoAPI | None, args: argparse.Namespace):
     sys.exit(rc)
 
 
+def _diff_argv(local: Path, pulled: Path) -> list[str]:
+    """Build the `diff -ru` argv with exclusions matching copytree's ignore set.
+
+    The exclude list MUST mirror PROJECT_EXCLUDE_PATTERNS so the temp
+    copy and the local tree are compared on the same surface; otherwise
+    a local-only `.venv` would always register as "only in local" and
+    diff-project would exit 1 even when Workato-managed assets are
+    identical.
+    """
+    argv = ["diff", "-ru"]
+    for pattern in PROJECT_EXCLUDE_PATTERNS:
+        argv.extend(["--exclude", pattern])
+    argv.extend([str(local), str(pulled)])
+    return argv
+
+
 def _run_diff(local: Path, pulled: Path, _runner=None) -> tuple[int, str, str]:
     """Invoke `diff -ru` between two directories. Returns (rc, stdout, stderr).
 
     diff's exit codes: 0 = identical, 1 = differ, 2 = error.
     """
+    argv = _diff_argv(local, pulled)
     if _runner is not None:
-        return _runner(
-            ["diff", "-ru", "--exclude=.git", str(local), str(pulled)],
-            None,
-        )
-    result = subprocess.run(
-        ["diff", "-ru", "--exclude=.git", str(local), str(pulled)],
-        capture_output=True, text=True,
-    )
+        return _runner(argv, None)
+    result = subprocess.run(argv, capture_output=True, text=True)
     return result.returncode, result.stdout, result.stderr
 
 
 def cmd_sdk_diff_project(_api: WorkatoAPI | None, args: argparse.Namespace):
     """Show diff between local project and dev workspace state.
 
-    Copies the project directory to a temp dir (excluding .git), runs
+    Copies the project directory to a temp dir (excluding bulky local
+    dirs like .git / .venv / node_modules / __pycache__), runs
     `workato pull` in the copy so the temp tree reflects the remote
     state, then runs `diff -ru` between the local project and the
-    pulled copy. Read-only — the original project directory is never
-    modified.
+    pulled copy using the same exclude set. Read-only — the original
+    project directory is never modified.
 
     Exit codes mirror diff(1): 0 = identical, 1 = differences printed,
     2 = the pull or the diff itself failed.
@@ -1569,19 +1612,18 @@ def cmd_sdk_diff_project(_api: WorkatoAPI | None, args: argparse.Namespace):
     import shutil
     project_dir = Path(args.project_dir).resolve() if args.project_dir else Path.cwd()
     _validate_project_dir(project_dir)
+    profile_name = _resolve_project_profile(args.profile, project_dir)
 
     with tempfile.TemporaryDirectory(prefix="kit-sdk-diff-") as tmp:
         pulled_root = Path(tmp) / "pulled"
         # Copy the project to a temp dir; exclude VCS and bulky local
-        # directories so the pull does not waste time on irrelevant files.
-        ignore = shutil.ignore_patterns(
-            ".git", ".venv", "node_modules", "__pycache__",
-        )
+        # directories so the pull does not waste time on irrelevant
+        # files. The same exclude set is passed to `diff -ru` below
+        # (see _diff_argv) so the comparison surface matches.
+        ignore = shutil.ignore_patterns(*PROJECT_EXCLUDE_PATTERNS)
         shutil.copytree(project_dir, pulled_root, ignore=ignore)
 
-        rc, _out, err = _invoke_workato_pull(
-            args._resolved_profile_name, pulled_root,
-        )
+        rc, _out, err = _invoke_workato_pull(profile_name, pulled_root)
         if rc != 0:
             sys.stderr.write(
                 f"Error: `workato pull` failed in temp copy "


### PR DESCRIPTION
## Summary

Implements Issue #160 group A by wrapping the Workato Platform CLI (`workato pull`) for project-level operations.

### New commands

```bash
sdk pull-project [--project-dir <path>]
  # `workato --profile <resolved> pull` in the project directory.

sdk diff-project [--project-dir <path>]
  # Copies project to a temp dir, pulls in the copy, diffs against
  # the local project. Exit codes mirror diff(1): 0 identical,
  # 1 differs, 2 error.
```

### Why wrap and not reimplement

`workato pull` already knows the project's serialization format (recipes, connections, lookup tables, properties, etc.). Reimplementing that would be a multi-thousand-line liability. The helper's value-add is removing the manual profile plumbing and giving diff a single-step command.

### Safety contract

| Check | Behavior |
|---|---|
| Profile resolved from **target project's** `.workatoenv` | `--project-dir projects/foo` from repo root resolves the workspace from `projects/foo/.workatoenv`, not from cwd. |
| `.workatoenv` required | If missing, `_validate_project_dir` exits early with a precise message — no opaque `workato pull` failure. |
| diff exclusion set matches copytree exclude | `PROJECT_EXCLUDE_PATTERNS` (.git, .venv, node_modules, __pycache__) is the single source of truth, used by both `shutil.ignore_patterns(*)` and `diff -ru --exclude=*`. |
| Original project dir never modified | All pull-side writes go into a `TemporaryDirectory` that is cleaned up on exit. |
| Pre-API dispatch | Both commands skip main()'s keyring + WorkatoAPI setup (same fast path as `sdk decrypt/edit`) since they shell out to `workato pull` which handles its own auth. |
| Missing binaries handled cleanly | `workato` not on PATH → exits 127 with a clear message. `diff` not on PATH → exits 2. |

### Pre-push Codex review

This PR went through four pre-push Codex review passes. Findings addressed in order:

1. **[P1] Profile resolved against cwd, not `--project-dir`** — added `start_dir` to `find_workatoenv()` / `resolve_profile()` and re-resolve inside the project commands via `_resolve_project_profile()`.
2. **[P2] diff --exclude not synced with copytree ignore** — unified through `PROJECT_EXCLUDE_PATTERNS` constant and `_diff_argv()` helper.
3. **[P2] Commands dispatched after keyring/WorkatoAPI setup** — moved to the pre-API dispatch group alongside `sdk decrypt/edit`.
4. **[P2] Missing `workato`/`diff` binaries raised uncaught `FileNotFoundError`** — wrapped in try/except, return clean rc + message (127 for workato, 2 for diff).
5. Final Codex pass: no findings.

## Test plan

21 tests in `scripts/tests/test_sdk_project_pull_diff.py` (now 219 across the suite):

- [x] `_invoke_workato_pull` argv shape, non-zero propagation, **127 on missing `workato`**
- [x] `_validate_project_dir` refuses nonexistent / missing `.workatoenv` / passes when present
- [x] `sdk pull-project`: workspace_id resolution from project, `--project-dir` regression test (target's workatoenv beats cwd's), `--profile` override, non-zero exit propagation, missing `.workatoenv` refused, **127 on missing `workato`**
- [x] `sdk diff-project`: identical exits 0, differs exits 1 with diff printed, pull-failure exits 2, diff-failure exits 2, regression test that original dir is byte-identical after a simulated remote-overwrite, **2 on missing `diff`**
- [x] `_diff_argv` includes every `PROJECT_EXCLUDE_PATTERNS` member
- [x] All 219 existing tests pass

Refs #160 (group A). Remaining for Issue #160 after this PR: E (`connector test`).