### PR TITLE
feat(sdk): `sdk test` local connector lint — closes Issue #160 E

### DIFF
--- a/scripts/tests/test_sdk_test.py
+++ b/scripts/tests/test_sdk_test.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Tests for `sdk test` (local connector lint).
+
+Covers:
+  - _ruby_syntax_check: rc passthrough, missing binary → 127
+  - _inspect_connector_structure: detects top-level keys, ignores
+    comments, ignores deeply-indented keys
+  - cmd_sdk_test: file missing → 1, syntax OK → 0, syntax error → 1,
+    missing ruby → 127, warning when title/connection absent
+
+Run with:
+    python3 scripts/tests/test_sdk_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "workato-api.py"
+
+spec = importlib.util.spec_from_file_location("workato_api", SCRIPT)
+wa = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(wa)
+
+
+def _capture_stdout_stderr_exit(fn):
+    saved_out, saved_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+    exited = False
+    code = 0
+    try:
+        try:
+            fn()
+        except SystemExit as e:
+            exited = True
+            code = int(e.code) if isinstance(e.code, int) else 1
+        return exited, code, sys.stdout.getvalue(), sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err
+
+
+def _patch_subprocess_run_to_raise():
+    import subprocess as _sp
+    saved = _sp.run
+
+    def boom(*_a, **_kw):
+        raise FileNotFoundError("no ruby")
+
+    _sp.run = boom
+    return lambda: setattr(_sp, "run", saved)
+
+
+# ---------------------------------------------------------------------------
+# _ruby_syntax_check
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_check_returns_127_when_ruby_missing():
+    restore = _patch_subprocess_run_to_raise()
+    try:
+        rc, _out, err = wa._ruby_syntax_check(Path("/tmp/x.rb"))
+        assert rc == 127
+        assert "ruby" in err
+        assert "PATH" in err
+    finally:
+        restore()
+
+
+def test_ruby_check_runner_injection_passes_argv():
+    captured: list = []
+
+    def runner(argv, _cwd):
+        captured.append(list(argv))
+        return 0, "", ""
+
+    rc, _, _ = wa._ruby_syntax_check(Path("/path/foo.rb"), _runner=runner)
+    assert rc == 0
+    assert captured == [["ruby", "-c", "/path/foo.rb"]]
+
+
+# ---------------------------------------------------------------------------
+# _inspect_connector_structure
+# ---------------------------------------------------------------------------
+
+
+def test_structure_detects_top_level_keys():
+    src = """{
+  title: 'Foo',
+  connection: {
+    fields: [],
+  },
+  actions: {
+    create_thing: {
+      ...
+    }
+  },
+  triggers: {},
+  methods: {},
+}
+"""
+    s = wa._inspect_connector_structure(src)
+    assert "title" in s["found"]
+    assert "connection" in s["found"]
+    assert "actions" in s["found"]
+    assert "triggers" in s["found"]
+    assert "methods" in s["found"]
+    assert "object_definitions" in s["missing"]
+    assert "pick_lists" in s["missing"]
+
+
+def test_structure_ignores_comments():
+    """A `# connection: ...` comment must NOT count as a found key."""
+    src = """{
+  title: 'X',
+  # connection: would-be commented-out
+  # actions: not-real-actions
+}
+"""
+    s = wa._inspect_connector_structure(src)
+    assert "title" in s["found"]
+    assert "connection" in s["missing"]
+    assert "actions" in s["missing"]
+
+
+def test_structure_ignores_deeply_indented_keys():
+    """A nested `actions:` inside connection should NOT register as
+    a top-level actions block."""
+    src = """{
+  title: 'X',
+  connection: {
+    fields: [],
+    authorization: {
+      type: 'custom_auth',
+        actions: 'fake-nested',
+    },
+  },
+}
+"""
+    s = wa._inspect_connector_structure(src)
+    assert "title" in s["found"]
+    assert "connection" in s["found"]
+    assert "actions" in s["missing"]
+
+
+def test_structure_recognises_quoted_keys():
+    """Workato examples occasionally use string keys: 'title': 'X'."""
+    src = """{
+  'title': 'X',
+  "connection": {},
+}
+"""
+    s = wa._inspect_connector_structure(src)
+    assert "title" in s["found"]
+    assert "connection" in s["found"]
+
+
+def test_structure_empty_source_returns_all_missing():
+    s = wa._inspect_connector_structure("")
+    assert s["found"] == []
+    assert set(s["missing"]) == set(wa.CONNECTOR_TOP_LEVEL_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# cmd_sdk_test
+# ---------------------------------------------------------------------------
+
+
+def _patch_ruby_check(rc=0, stdout="", stderr=""):
+    saved = wa._ruby_syntax_check
+
+    def fake(_path, _runner=None):
+        return rc, stdout, stderr
+
+    wa._ruby_syntax_check = fake
+    return lambda: setattr(wa, "_ruby_syntax_check", saved)
+
+
+def test_sdk_test_file_not_found_exits_1():
+    args = SimpleNamespace(path="/nonexistent/connector.rb")
+    exited, code, _, err = _capture_stdout_stderr_exit(
+        lambda: wa.cmd_sdk_test(None, args)
+    )
+    assert exited and code == 1
+    assert "not found" in err
+
+
+def test_sdk_test_path_is_directory_exits_1():
+    with tempfile.TemporaryDirectory() as d:
+        args = SimpleNamespace(path=d)
+        exited, code, _, err = _capture_stdout_stderr_exit(
+            lambda: wa.cmd_sdk_test(None, args)
+        )
+        assert exited and code == 1
+        assert "not a file" in err
+
+
+def test_sdk_test_happy_path_exits_0_with_structure():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "connector.rb"
+        # Multi-line connector — the conventional Workato format.
+        path.write_text(
+            "{\n"
+            "  title: 'X',\n"
+            "  connection: { fields: [] },\n"
+            "  actions: {},\n"
+            "}\n"
+        )
+        restore = _patch_ruby_check(rc=0)
+        try:
+            args = SimpleNamespace(path=str(path))
+            exited, code, out, _ = _capture_stdout_stderr_exit(
+                lambda: wa.cmd_sdk_test(None, args)
+            )
+            # Success means either returns cleanly (exited=False) OR exits 0.
+            assert (not exited) or code == 0
+            parsed = json.loads(out)
+            assert parsed["syntax_ok"] is True
+            assert parsed["ruby_exit_code"] == 0
+            assert "title" in parsed["structure"]["found"]
+            assert "connection" in parsed["structure"]["found"]
+            assert "warnings" not in parsed
+        finally:
+            restore()
+
+
+def test_sdk_test_syntax_error_exits_1_and_includes_stderr():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "connector.rb"
+        path.write_text("{ title: 'X', invalid ruby syntax here\n")
+        restore = _patch_ruby_check(rc=1, stderr="parse error: unexpected ...\n")
+        try:
+            args = SimpleNamespace(path=str(path))
+            exited, code, out, _ = _capture_stdout_stderr_exit(
+                lambda: wa.cmd_sdk_test(None, args)
+            )
+            assert exited and code == 1
+            parsed = json.loads(out)
+            assert parsed["syntax_ok"] is False
+            assert "parse error" in parsed["ruby_stderr"]
+        finally:
+            restore()
+
+
+def test_sdk_test_warns_when_title_missing():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "connector.rb"
+        path.write_text("{ actions: {} }\n")
+        restore = _patch_ruby_check(rc=0)
+        try:
+            args = SimpleNamespace(path=str(path))
+            exited, code, out, _ = _capture_stdout_stderr_exit(
+                lambda: wa.cmd_sdk_test(None, args)
+            )
+            # Warning, not failure — success-style exit.
+            assert (not exited) or code == 0
+            parsed = json.loads(out)
+            assert "warnings" in parsed
+            assert any("title" in w or "connection" in w for w in parsed["warnings"])
+        finally:
+            restore()
+
+
+def test_sdk_test_exits_127_when_ruby_missing():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "connector.rb"
+        path.write_text("{ title: 'X', connection: {} }\n")
+        restore = _patch_ruby_check(rc=127, stderr="ruby not found\n")
+        try:
+            args = SimpleNamespace(path=str(path))
+            exited, code, out, _ = _capture_stdout_stderr_exit(
+                lambda: wa.cmd_sdk_test(None, args)
+            )
+            assert exited and code == 127
+            parsed = json.loads(out)
+            assert parsed["ruby_exit_code"] == 127
+        finally:
+            restore()
+
+
+def main() -> int:
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ok  {name}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  FAIL {name}")
+
+    print(f"\n{len(tests) - len(failures)}/{len(tests)} passed")
+    for name, tb in failures:
+        print(f"\n--- {name} ---\n{tb}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workato-api.py
+++ b/scripts/workato-api.py
@@ -33,6 +33,8 @@ Usage:
     (wraps `workato pull` in the project directory)
   python3 scripts/workato-api.py sdk diff-project [--project-dir <path>]
     (pulls to a temp dir and diffs against the project directory)
+  python3 scripts/workato-api.py sdk test <connector.rb>
+    (local lint: `ruby -c` syntax check + top-level structure report)
   python3 scripts/workato-api.py sdk edit <file> [--key <master.key>]
   python3 scripts/workato-api.py sdk decrypt <file> [--key <master.key>]
   python3 scripts/workato-api.py deploy preview --to <test|prod>
@@ -1489,6 +1491,116 @@ def _connector_slug(record: dict, fallback: str | None = None) -> str:
     return slug or (str(record.get("id")) if isinstance(record, dict) else "connector")
 
 
+CONNECTOR_TOP_LEVEL_KEYS = (
+    "title", "connection", "actions", "triggers", "methods",
+    "object_definitions", "pick_lists", "test", "custom_action_help",
+)
+
+
+def _ruby_syntax_check(path: Path, _runner=None) -> tuple[int, str, str]:
+    """Run `ruby -c <path>` to parse-check a connector file.
+
+    Returns (returncode, stdout, stderr). Never raises — if the `ruby`
+    binary itself is missing we return rc 127 with a clear message so
+    the caller can surface a controlled error.
+    """
+    argv = ["ruby", "-c", str(path)]
+    if _runner is not None:
+        return _runner(argv, None)
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError:
+        return 127, "", (
+            "Error: `ruby` not found on PATH. Install Ruby to run "
+            "`sdk test`.\n"
+        )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _inspect_connector_structure(source: str) -> dict:
+    """Identify which CONNECTOR_TOP_LEVEL_KEYS appear as top-level entries.
+
+    A connector file is a Ruby hash literal: `{ title: 'X', connection:
+    {...}, actions: {...} }`. We are not parsing Ruby; instead we look
+    for `<key>:` appearing on a line at 0 or 2 spaces of indent (the
+    conventional formatting in every Workato connector example).
+    `# comment` content is stripped first.
+
+    Informational only — the caller does not fail if a key is missing.
+    """
+    import re
+    found: dict[str, bool] = {k: False for k in CONNECTOR_TOP_LEVEL_KEYS}
+    for raw_line in source.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line:
+            continue
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if indent > 2:
+            continue
+        m = re.match(r"['\"]?([a-z_]+)['\"]?\s*:", stripped)
+        if not m:
+            continue
+        key = m.group(1)
+        if key in found:
+            found[key] = True
+    return {
+        "found": [k for k, present in found.items() if present],
+        "missing": [k for k, present in found.items() if not present],
+    }
+
+
+def cmd_sdk_test(_api: WorkatoAPI | None, args: argparse.Namespace):
+    """Locally lint a connector source file.
+
+    Combines two checks:
+      1. `ruby -c <path>` — parses the file as Ruby; non-zero rc means
+         the syntax is broken and the connector cannot be pushed.
+      2. Structural inspection — informational report of which
+         top-level keys (title, connection, actions, triggers, ...)
+         appear in the source. Missing `title` or `connection` adds a
+         warning but does not fail the command.
+
+    Exit codes:
+      0 — syntax OK (structure report may still note missing keys)
+      1 — file not found OR ruby -c reported a syntax error
+      127 — ruby binary not found on PATH
+    """
+    path = Path(args.path)
+    if not path.exists():
+        print(f"Error: connector file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    if not path.is_file():
+        print(f"Error: not a file: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    rc, _stdout, stderr = _ruby_syntax_check(path)
+    source = path.read_text()
+    structure = _inspect_connector_structure(source)
+
+    syntax_ok = (rc == 0)
+    output: dict = {
+        "path": str(path),
+        "syntax_ok": syntax_ok,
+        "ruby_exit_code": rc,
+        "structure": structure,
+    }
+    if not syntax_ok:
+        output["ruby_stderr"] = stderr.strip()
+    if "title" not in structure["found"] or "connection" not in structure["found"]:
+        output.setdefault("warnings", []).append(
+            "Connector is missing a top-level `title:` or `connection:`. "
+            "Workato may reject the push or surface an unhelpful error."
+        )
+
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+    if rc == 127:
+        sys.exit(127)
+    if not syntax_ok:
+        sys.exit(1)
+
+
 def _invoke_workato_pull(
     profile_name: str, cwd: Path,
     _runner=None,
@@ -2444,6 +2556,29 @@ def main():
         help="Project directory to pull into (default: cwd). Must contain .workatoenv.",
     )
 
+    sdk_test_p = sdk_sub.add_parser(
+        "test",
+        help="Lint a connector file locally (no Workato API call)",
+        description=(
+            "Lint a Workato connector source file locally. Runs "
+            "`ruby -c` to parse-check the file and a structural "
+            "inspection that reports which top-level keys (title, "
+            "connection, actions, triggers, methods, ...) are present. "
+            "No API call to Workato. Exit code: 0 = syntax OK, "
+            "1 = syntax error or file missing, 127 = ruby not on PATH."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  # Lint a connector before push\n"
+            "  python3 scripts/workato-api.py sdk test connectors/foo/connector.rb\n\n"
+            "  # Common pre-push pipeline (test then push)\n"
+            "  python3 scripts/workato-api.py sdk test connectors/foo/connector.rb \\\n"
+            "    && python3 scripts/workato-api.py sdk push --connector connectors/foo/connector.rb\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sdk_test_p.add_argument("path", help="Path to the connector Ruby file")
+
     sdk_diff_project_p = sdk_sub.add_parser(
         "diff-project",
         help="Diff local project against dev workspace",
@@ -2662,6 +2797,7 @@ def main():
         "edit": cmd_sdk_edit,
         "pull-project": cmd_sdk_pull_project,
         "diff-project": cmd_sdk_diff_project,
+        "test": cmd_sdk_test,
     }
     if args.command == "sdk" and getattr(args, "sdk_command", None) in _sdk_pre_api:
         _sdk_pre_api[args.sdk_command](None, args)


### PR DESCRIPTION
## Summary

Closes the last group of Issue #160. `sdk test <path>` runs purely local checks on a connector Ruby file with no Workato API call.

### New command

```bash
sdk test <path-to-connector.rb>
```

| Check | Behavior |
|---|---|
| `ruby -c <path>` | Parses the file. Non-zero rc = syntax error and the connector cannot be pushed. **Fatal.** |
| Structural inspection | Reports which CONNECTOR_TOP_LEVEL_KEYS (title, connection, actions, triggers, methods, object_definitions, pick_lists, test, custom_action_help) appear in the source. Missing `title` or `connection` adds a **warning** but does not fail. |

### Exit codes

Mirrors the pattern established in PR #173:

| Code | Meaning |
|---|---|
| 0 | Syntax OK (structure report may still note missing keys) |
| 1 | File missing OR syntax error |
| 127 | `ruby` not on PATH |

### Implementation notes

- `_ruby_syntax_check(path, _runner=None)` wraps `ruby -c` with the FileNotFoundError → rc 127 pattern from PR #173.
- `_inspect_connector_structure(source)` is a deliberately small regex-based scan: drops `# comment` content, ignores keys nested more than 2 spaces deep, recognises both `key:` and `'key':` / `"key":` forms. We are NOT parsing Ruby — `ruby -c` is the authoritative pass; the structural check is informational.
- `cmd_sdk_test` is dispatched in `main()`'s **pre-API group** alongside `decrypt`, `edit`, `pull-project`, `diff-project`. `sdk test` does not touch the Workato API so it should not block on a keyring/WorkatoAPI bootstrap.

### Smoke check against real Ruby

```bash
$ python3 scripts/workato-api.py sdk test /tmp/good_connector.rb
{ "syntax_ok": true, "structure": { "found": ["title","connection","actions"], ... } }
$ echo $?
0

$ python3 scripts/workato-api.py sdk test /tmp/broken_connector.rb
{ "syntax_ok": false, "ruby_stderr": "ruby: ...syntax errors found (SyntaxError)..." }
$ echo $?
1
```

## Test plan

13 new tests in `scripts/tests/test_sdk_test.py` (now 232 across the suite):

- [x] `_ruby_syntax_check`: argv shape, 127 on missing binary
- [x] `_inspect_connector_structure`: detects keys in multi-line format, ignores `# comment` lines, ignores deeply-indented keys (no false positive on nested `actions:`), recognises quoted keys, empty source reports all missing
- [x] `cmd_sdk_test`: missing file → 1, directory path → 1, happy path → 0, syntax error → 1 with `ruby_stderr`, missing title/connection adds warning (still 0), missing ruby → 127
- [x] All 232 existing tests pass
- [x] Pre-push Codex review on clean worktree: no defects flagged
- [x] Real-`ruby` smoke check: valid connector exits 0, broken one exits 1 with actual Ruby parse error in `ruby_stderr`

Refs #160 (group E — **this completes Issue #160**).