### PR TITLE
fix(kit): stop the credential guard from blocking legitimate Workato workflows

### DIFF
--- a/docs/platform/cli-profiles.md
+++ b/docs/platform/cli-profiles.md
@@ -76,9 +76,9 @@ workato profiles list
 |---|---|
 | `~/.workato/profiles` | Profile metadata (workspace_id, region, current_profile) — **not** the API tokens |
 | OS keyring (macOS Keychain / Linux Secret Service) | API token per profile, managed by `workato init` |
-| `.workatoenv` (per project) | `workspace_id` + `folder_id`; no credentials. Auto-generated; gitignored |
+| `.workatoenv` (per project) | `workspace_id` + `folder_id`; no credentials. Auto-generated; **git-managed** (commit it, pointing at dev) |
 
-Never commit `.workatoenv` or anything from `~/.workato/`.
+Never commit anything from `~/.workato/` (it holds the credential index). `.workatoenv` itself contains no secrets and **is** committed — keep it pointing at dev.
 
 ## Common mistakes
 

--- a/docs/platform/environments.md
+++ b/docs/platform/environments.md
@@ -97,7 +97,7 @@ If the target service itself has a sandbox (e.g. Salesforce Sandbox vs. Producti
 
 ### Folder / project IDs
 
-`folder_id` and `project_id` are workspace-specific. The `.workatoenv` file therefore differs per environment. **Do not commit a `.workatoenv` that points at prod** — each developer's local checkout should point at dev. See `@.claude/rules/workato-deployment-flow.md` for the safety rule.
+`folder_id` and `project_id` are workspace-specific. The `.workatoenv` file therefore differs per environment. `.workatoenv` is git-managed (it holds only IDs, no credentials) and **must point at dev** — that is the binding the whole team shares. Prod-push protection does not depend on hiding this file: it comes from the deployment-flow profile check (the resolved profile must end in `-dev`). See `@.claude/rules/workato-deployment-flow.md` for the safety rule.
 
 ## Mapping environments to CLI profiles
 
@@ -118,7 +118,7 @@ See `@docs/platform/cli-profiles.md` for the full profile selection rules and th
 | `workato push` against the prod profile | Bypasses Deploy approvals; overwrites prod | Set `<org>-dev` as the default profile in `.workatoenv`; use `<org>-test`/`<org>-prod` only for pull |
 | Renaming a connection per environment | Deploy treats it as a new connection | Keep the same display name across environments |
 | Hardcoding `folder_id` from dev into a doc / script | Targets the wrong workspace when the doc is reused | Always read `folder_id` from `.workatoenv` at runtime |
-| Committing `.workatoenv` for prod | Other developers accidentally push to prod | `.workatoenv` is gitignored by default; keep it that way |
+| Committing a `.workatoenv` that points at prod | Other developers resolve a prod profile | Commit only a dev-pointing `.workatoenv`; the deployment-flow check refuses any push whose profile is not `-dev` |
 | Auto-approving prod deploy via script | Skips release-manager review | Manual approval only; never script `POST /api/deployments/{id}/approve` |
 
 ## Related

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -99,7 +99,8 @@ The three inviolable principles:
 - Connector details: pre-built → `@docs/connectors/` (+ `@org/docs/connectors/`); custom → `@connectors/docs/`. For missing entries, WebFetch.
 - Record new findings in `org/docs/<relative-path>` (do not edit the kit's `docs/` directly).
 - `*.connection.json` never contains credentials.
-- Do not commit `.workatoenv` or `master.key`.
+- `.workatoenv` holds only project/folder/workspace IDs (no credentials) and **is** committed so the project↔Workato binding is shared. Keep it pointing at dev; prod-push safety comes from the deployment-flow profile check, not from hiding the file.
+- Do not commit `master.key` or other connector secrets (`settings.yaml`, `settings.yaml.enc`).
 
 ## Skills
 

--- a/framework/claude/CLAUDE.md
+++ b/framework/claude/CLAUDE.md
@@ -96,7 +96,8 @@ The three inviolable principles:
 - Connector details: pre-built → `@docs/connectors/` (+ `@org/docs/connectors/`); custom → `@connectors/docs/`. For missing entries, WebFetch.
 - Record new findings in `org/docs/<relative-path>` (do not edit the kit's `docs/` directly).
 - `*.connection.json` never contains credentials.
-- Do not commit `.workatoenv` or `master.key`.
+- `.workatoenv` holds only project/folder/workspace IDs (no credentials) and **is** committed so the project↔Workato binding is shared. Keep it pointing at dev; prod-push safety comes from the deployment-flow profile check, not from hiding the file.
+- Do not commit `master.key` or other connector secrets (`settings.yaml`, `settings.yaml.enc`).
 
 ## Skills
 

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -90,15 +90,21 @@ SAFE_GIT_SUBCMDS = {"add", "rm", "mv", "status", "commit", "stash",
 def git_segment_safe(rest):
     """rest = tokens after git. Safe only when the first token is a non-reading
     subcommand, there are no global options before it (a global option like
-    -c alias or --no-pager can turn git into an arbitrary reader), and no
-    -p / --patch flag follows (those print hunks of file contents)."""
+    -c alias or --no-pager can turn git into an arbitrary reader), and no flag
+    that prints file contents to stdout follows: -p/--patch (hunks) and
+    -v/--verbose (e.g. `git status -v` emits the staged diff). Bundled short
+    flags such as -vp are caught too."""
     if not rest or rest[0].startswith("-"):
         return False
     if rest[0] not in SAFE_GIT_SUBCMDS:
         return False
     for t in rest[1:]:
-        if t in ("-p", "--patch") or t.startswith("--patch"):
-            return False
+        if t.startswith("--"):
+            if t.startswith("--patch") or t.startswith("--verbose"):
+                return False
+        elif t.startswith("-") and len(t) > 1:
+            if "p" in t[1:] or "v" in t[1:]:  # patch / verbose short flag
+                return False
     return True
 
 def segment_safe(seg):

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -56,10 +56,46 @@ def pat_to_bash_re(p):
     body = re.escape(p).replace(r"\*", r"\S*")
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
+# Tools that legitimately operate ON credential files without dumping their
+# contents to the agent (the workato CLI encrypts/edits/runs; git stages and
+# commits). These must never be blocked, or the hook would break normal
+# workflows. The kit helper script is matched by substring (its program is
+# `python3`, which we cannot allowlist wholesale).
+SAFE_PROGS = {"workato", "git"}
+SAFE_MARKERS = ("workato-api.py",)
+
+def _segment_program(seg):
+    """Program invoked in a command segment, skipping leading VAR=value env
+    assignments (so `FOO=1 workato ...` still resolves to `workato`)."""
+    toks = seg.split()
+    i = 0
+    while i < len(toks) and re.match(r"^\w+=", toks[i]):
+        i += 1
+    return os.path.basename(toks[i]) if i < len(toks) else ""
+
 def bash_hit(cmd):
-    for pat in patterns:
-        if pat_to_bash_re(pat).search(cmd):
-            return pat
+    """Block only when a credential file's CONTENTS would be dumped into the
+    agent's tool output. We split on shell separators and deny a segment that
+    references a credential pattern UNLESS its program is a known-safe tool
+    (workato CLI / git / kit helper). `cat master.key`, `grep token
+    settings.yaml`, etc. are still blocked; `workato edit settings.yaml.enc`,
+    `git add settings.yaml.enc`, `python3 scripts/workato-api.py …` are not."""
+    sep = re.compile("|".join([r"\|\|", r"&&", r"[|;&\n]", r"\$\(", r"\)", re.escape(chr(96))]))
+    for seg in sep.split(cmd):
+        if not seg.strip():
+            continue
+        hit = None
+        for pat in patterns:
+            if pat_to_bash_re(pat).search(seg):
+                hit = pat
+                break
+        if not hit:
+            continue
+        if any(m in seg for m in SAFE_MARKERS):
+            continue
+        if _segment_program(seg) in SAFE_PROGS:
+            continue
+        return hit
     return None
 
 tool = data.get("tool_name", "")

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -9,6 +9,12 @@
 # Defense-in-depth: the .claude/settings.json permissions.deny list also
 # blocks these tools, but that list has known enforcement bugs in some Claude
 # Code versions. This hook is the reliable enforcement layer.
+#
+# The embedded Python decides AND emits the user-facing message itself, then
+# exits 2 (block) or 0 (allow). The wrapper deliberately does NOT capture the
+# output via $(...): a quoted heredoc inside command substitution makes bash
+# scan the body for quote/paren balance, so a stray ' " or ( in a comment
+# breaks the whole script. Running the heredoc directly avoids that entirely.
 
 INPUT=$(cat)
 
@@ -22,15 +28,21 @@ if [ ! -f "$PATTERNS_FILE" ]; then
   exit 0
 fi
 
-DECISION="$(INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
+INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
 import fnmatch, json, os, re, sys
+
+def deny(reason):
+    sys.stderr.write(f"Blocked by workato-dev-kit credential guard: {reason}\n")
+    sys.stderr.write("  Credential files (see kit/framework/credential-patterns.txt) must not be\n")
+    sys.stderr.write("  read by the agent. If this is intentional, edit that file or temporarily\n")
+    sys.stderr.write("  remove this hook from .claude/settings.json.\n")
+    sys.exit(2)
 
 raw = os.environ.get("INPUT", "")
 try:
     data = json.loads(raw)
 except Exception:
-    print("OK")
-    sys.exit(0)
+    sys.exit(0)  # fail open on malformed input
 
 patterns = []
 with open(os.environ["PATTERNS_FILE"]) as f:
@@ -51,44 +63,47 @@ def path_hit(p):
     return None
 
 def pat_to_bash_re(p):
-    """Glob → regex that matches the pattern as a whole token inside a shell
+    """Glob to regex that matches the pattern as a whole token inside a shell
     command (preceded and followed by non-word characters or boundaries)."""
     body = re.escape(p).replace(r"\*", r"\S*")
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
-# Tools that legitimately operate ON credential files without dumping their
-# contents to the agent: the workato CLI (encrypt/edit/run — it has no "print
-# file" mode), git for staging only (add/rm/mv/commit/…), and the kit helper
-# script. These must never be blocked, or the hook would break normal
-# workflows.
+# The only tools allowlisted to appear alongside a credential filename are the
+# workato CLI (encrypt/edit/run; it has no print-file mode) and git used for
+# staging only (add/rm/mv/commit/...). Everything else that names a credential
+# is blocked. That is safe because the kit helper script's normal commands
+# (profile/pull/diff/deploy) never name a credential file; only its sdk-decrypt
+# (which prints plaintext to stdout) and sdk-edit subcommands do, and decrypt is
+# exactly what we want blocked. The workato gem covers the edit case.
 #
 # NOTE: this is an accident-guard, not a sandbox against a deliberately hostile
-# command. A determined caller can still exfiltrate by redefining a shell
-# function (`git(){ cat "$1"; }; git add master.key`) or by authoring connector
-# code that prints a secret; those are out of scope. We do close the cheap
-# holes: the safe program is the REAL program (the script behind `python`, not
-# a `-c` payload), and `git` is safe only for non-reading subcommands with no
-# global options (so `git -c …`, `git show`, `git diff`, `git cat-file` — all of
-# which can print file contents — are NOT allowlisted).
-SAFE_PROGS = {"workato", "workato-api.py"}
-# git subcommands that never print file contents to stdout.
+# command. Out of scope: redefining a shell function, connector code that
+# prints a secret, and commands that dump contents WITHOUT naming the file
+# (a git patch view of a stash) -- the hook only fires when a credential
+# pattern literally appears in the command.
+SAFE_PROGS = {"workato"}
+# git subcommands that never print file contents to stdout in their plain form.
+# The -p / --patch variants DO print hunks, so they are rejected below.
 SAFE_GIT_SUBCMDS = {"add", "rm", "mv", "status", "commit", "stash",
                     "restore", "checkout", "switch", "reset"}
 
-def _git_segment_safe(rest):
-    """rest = tokens after `git`. Safe only when the first token is a
-    non-reading subcommand and there are no global options before it (a global
-    option such as `-c alias…=!cat` or `-C` / `--no-pager` can turn git into an
-    arbitrary file reader, so any leading `-…` disqualifies the segment)."""
-    for t in rest:
-        if t.startswith("-"):
+def git_segment_safe(rest):
+    """rest = tokens after git. Safe only when the first token is a non-reading
+    subcommand, there are no global options before it (a global option like
+    -c alias or --no-pager can turn git into an arbitrary reader), and no
+    -p / --patch flag follows (those print hunks of file contents)."""
+    if not rest or rest[0].startswith("-"):
+        return False
+    if rest[0] not in SAFE_GIT_SUBCMDS:
+        return False
+    for t in rest[1:]:
+        if t in ("-p", "--patch") or t.startswith("--patch"):
             return False
-        return t in SAFE_GIT_SUBCMDS
-    return False  # bare `git` with no subcommand
+    return True
 
-def _segment_safe(seg):
+def segment_safe(seg):
     """True if this segment's program is a known-safe tool. Skips leading
-    VAR=value env assignments and resolves `python[3] <script>` to <script>."""
+    VAR=value env assignments so an env prefix still resolves to the program."""
     toks = seg.split()
     i = 0
     while i < len(toks) and re.match(r"^\w+=", toks[i]):
@@ -96,22 +111,14 @@ def _segment_safe(seg):
     if i >= len(toks):
         return False
     prog = os.path.basename(toks[i])
-    rest = toks[i + 1:]
-    if re.match(r"^python[0-9.]*$", prog) and rest:
-        prog = os.path.basename(rest[0])   # the interpreted script is the real program
-        rest = rest[1:]
     if prog == "git":
-        return _git_segment_safe(rest)
+        return git_segment_safe(toks[i + 1:])
     return prog in SAFE_PROGS
 
 def bash_hit(cmd):
-    """Block only when a credential file's CONTENTS would be dumped into the
-    agent's tool output. We split on shell separators and deny a segment that
-    references a credential pattern UNLESS its program is a known-safe tool.
-    `cat master.key`, `grep token settings.yaml`, `git show …:settings.yaml`,
-    `python3 -c "open('master.key')"` are still blocked; `workato edit
-    settings.yaml.enc`, `git add settings.yaml.enc`, and
-    `python3 scripts/workato-api.py …` are not."""
+    """Block only when credential file contents would be dumped into the agent
+    tool output. Split on shell separators and deny a segment that references a
+    credential pattern unless its program is a known-safe tool."""
     sep = re.compile("|".join([r"\|\|", r"&&", r"[|;&\n]", r"\$\(", r"\)", re.escape(chr(96))]))
     for seg in sep.split(cmd):
         if not seg.strip():
@@ -123,7 +130,7 @@ def bash_hit(cmd):
                 break
         if not hit:
             continue
-        if _segment_safe(seg):
+        if segment_safe(seg):
             continue
         return hit
     return None
@@ -141,16 +148,15 @@ elif tool == "NotebookEdit":
     if np:
         paths.append(np)
 elif tool in ("Grep", "Glob"):
-    # Direct path match (e.g. Grep(path="master.key")) — block immediately.
+    # Direct path match (e.g. Grep on master.key) — block immediately.
     pp = ti.get("path") or "."
     direct = path_hit(pp)
     if direct:
-        print(f"DENY:{direct}:{pp}")
-        sys.exit(0)
-    # Reachability check: if Grep/Glob points at a directory that contains
-    # any credential file, its results would expose it. Walk the tree and
-    # deny if a credential basename is found. Bounded by skipping known
-    # heavy dirs (.git, node_modules, …) so the hook stays interactive.
+        deny(f"{direct}: {pp}")
+    # Reachability check: if Grep/Glob points at a directory that contains any
+    # credential file, its results would expose it. Walk the tree and deny if a
+    # credential basename is found. Bounded by skipping known heavy dirs so the
+    # hook stays interactive.
     try:
         target = pp if os.path.isabs(pp) else os.path.abspath(pp)
         if os.path.isdir(target):
@@ -162,40 +168,27 @@ elif tool in ("Grep", "Glob"):
                     for pat in patterns:
                         if fnmatch.fnmatchcase(f, pat):
                             rel = os.path.join(root, f)
-                            print(f"DENY:{pat}:{tool} on '{pp}' would expose {rel}")
-                            sys.exit(0)
+                            deny(f"{pat}: {tool} on {pp} would expose {rel}")
+    except SystemExit:
+        raise
     except Exception:
         pass  # fail open on traversal errors; Read/Bash hook layers still apply
-    print("OK")
     sys.exit(0)
 elif tool == "Bash":
     hit = bash_hit(ti.get("command", "") or "")
     if hit:
-        print(f"DENY:{hit}:bash command references credential file")
-        sys.exit(0)
-    print("OK")
+        deny(f"{hit}: bash command references credential file")
     sys.exit(0)
 
 for p in paths:
     hit = path_hit(p)
     if hit:
-        print(f"DENY:{hit}:{p}")
-        sys.exit(0)
+        deny(f"{hit}: {p}")
 
-print("OK")
+sys.exit(0)
 PY
-)"
-
-case "$DECISION" in
-  DENY:*)
-    REASON="${DECISION#DENY:}"
-    echo "Blocked by workato-dev-kit credential guard: $REASON" >&2
-    echo "  Credential files (see kit/framework/credential-patterns.txt) must not be" >&2
-    echo "  read by the agent. If this is intentional, edit that file or temporarily" >&2
-    echo "  remove this hook from .claude/settings.json." >&2
-    exit 2
-    ;;
-  *)
-    exit 0
-    ;;
-esac
+rc=$?
+# Only an explicit deny (exit 2) blocks. Any other status — including an
+# unexpected Python error — falls through to allow (fail open).
+[ "$rc" -eq 2 ] && exit 2
+exit 0

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -57,29 +57,61 @@ def pat_to_bash_re(p):
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
 # Tools that legitimately operate ON credential files without dumping their
-# contents to the agent (the workato CLI encrypts/edits/runs; git stages and
-# commits). These must never be blocked, or the hook would break normal
-# workflows. The kit helper script is matched by substring (its program is
-# `python3`, which we cannot allowlist wholesale).
-SAFE_PROGS = {"workato", "git"}
-SAFE_MARKERS = ("workato-api.py",)
+# contents to the agent: the workato CLI (encrypt/edit/run — it has no "print
+# file" mode), git for staging only (add/rm/mv/commit/…), and the kit helper
+# script. These must never be blocked, or the hook would break normal
+# workflows.
+#
+# NOTE: this is an accident-guard, not a sandbox against a deliberately hostile
+# command. A determined caller can still exfiltrate by redefining a shell
+# function (`git(){ cat "$1"; }; git add master.key`) or by authoring connector
+# code that prints a secret; those are out of scope. We do close the cheap
+# holes: the safe program is the REAL program (the script behind `python`, not
+# a `-c` payload), and `git` is safe only for non-reading subcommands with no
+# global options (so `git -c …`, `git show`, `git diff`, `git cat-file` — all of
+# which can print file contents — are NOT allowlisted).
+SAFE_PROGS = {"workato", "workato-api.py"}
+# git subcommands that never print file contents to stdout.
+SAFE_GIT_SUBCMDS = {"add", "rm", "mv", "status", "commit", "stash",
+                    "restore", "checkout", "switch", "reset"}
 
-def _segment_program(seg):
-    """Program invoked in a command segment, skipping leading VAR=value env
-    assignments (so `FOO=1 workato ...` still resolves to `workato`)."""
+def _git_segment_safe(rest):
+    """rest = tokens after `git`. Safe only when the first token is a
+    non-reading subcommand and there are no global options before it (a global
+    option such as `-c alias…=!cat` or `-C` / `--no-pager` can turn git into an
+    arbitrary file reader, so any leading `-…` disqualifies the segment)."""
+    for t in rest:
+        if t.startswith("-"):
+            return False
+        return t in SAFE_GIT_SUBCMDS
+    return False  # bare `git` with no subcommand
+
+def _segment_safe(seg):
+    """True if this segment's program is a known-safe tool. Skips leading
+    VAR=value env assignments and resolves `python[3] <script>` to <script>."""
     toks = seg.split()
     i = 0
     while i < len(toks) and re.match(r"^\w+=", toks[i]):
         i += 1
-    return os.path.basename(toks[i]) if i < len(toks) else ""
+    if i >= len(toks):
+        return False
+    prog = os.path.basename(toks[i])
+    rest = toks[i + 1:]
+    if re.match(r"^python[0-9.]*$", prog) and rest:
+        prog = os.path.basename(rest[0])   # the interpreted script is the real program
+        rest = rest[1:]
+    if prog == "git":
+        return _git_segment_safe(rest)
+    return prog in SAFE_PROGS
 
 def bash_hit(cmd):
     """Block only when a credential file's CONTENTS would be dumped into the
     agent's tool output. We split on shell separators and deny a segment that
-    references a credential pattern UNLESS its program is a known-safe tool
-    (workato CLI / git / kit helper). `cat master.key`, `grep token
-    settings.yaml`, etc. are still blocked; `workato edit settings.yaml.enc`,
-    `git add settings.yaml.enc`, `python3 scripts/workato-api.py …` are not."""
+    references a credential pattern UNLESS its program is a known-safe tool.
+    `cat master.key`, `grep token settings.yaml`, `git show …:settings.yaml`,
+    `python3 -c "open('master.key')"` are still blocked; `workato edit
+    settings.yaml.enc`, `git add settings.yaml.enc`, and
+    `python3 scripts/workato-api.py …` are not."""
     sep = re.compile("|".join([r"\|\|", r"&&", r"[|;&\n]", r"\$\(", r"\)", re.escape(chr(96))]))
     for seg in sep.split(cmd):
         if not seg.strip():
@@ -91,9 +123,7 @@ def bash_hit(cmd):
                 break
         if not hit:
             continue
-        if any(m in seg for m in SAFE_MARKERS):
-            continue
-        if _segment_program(seg) in SAFE_PROGS:
+        if _segment_safe(seg):
             continue
         return hit
     return None

--- a/framework/claude/hooks/block-credential-read.sh
+++ b/framework/claude/hooks/block-credential-read.sh
@@ -99,11 +99,17 @@ def git_segment_safe(rest):
     if rest[0] not in SAFE_GIT_SUBCMDS:
         return False
     for t in rest[1:]:
+        if t == "--":
+            continue  # pathspec separator, not an option
         if t.startswith("--"):
-            if t.startswith("--patch") or t.startswith("--verbose"):
+            # git accepts any unambiguous prefix, so reject every abbreviation
+            # of --patch / --verbose (--ver, --patc, …), both of which print
+            # file contents to stdout.
+            stem = t[2:].split("=", 1)[0]
+            if stem and ("verbose".startswith(stem) or "patch".startswith(stem)):
                 return False
         elif t.startswith("-") and len(t) > 1:
-            if "p" in t[1:] or "v" in t[1:]:  # patch / verbose short flag
+            if "p" in t[1:] or "v" in t[1:]:  # patch / verbose short flag (incl. -vp)
                 return False
     return True
 

--- a/framework/claude/settings.json
+++ b/framework/claude/settings.json
@@ -44,7 +44,6 @@
     "deny": [
       "Bash(rm -rf:*)",
       "Bash(sudo:*)",
-      "Read(./**/.workatoenv)",
       "Read(./**/master.key)",
       "Read(./**/settings.yaml)",
       "Read(./**/settings.yaml.enc)",

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -79,8 +79,13 @@ def git_segment_safe(rest):
     if rest[0] not in SAFE_GIT_SUBCMDS:
         return False
     for t in rest[1:]:
+        if t == "--":
+            continue  # pathspec separator, not an option
         if t.startswith("--"):
-            if t.startswith("--patch") or t.startswith("--verbose"):
+            # git accepts any unambiguous prefix, so reject every abbreviation
+            # of --patch / --verbose (--ver, --patc, …).
+            stem = t[2:].split("=", 1)[0]
+            if stem and ("verbose".startswith(stem) or "patch".startswith(stem)):
                 return False
         elif t.startswith("-") and len(t) > 1:
             if "p" in t[1:] or "v" in t[1:]:

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -4,7 +4,7 @@
 # Codex CLI's PreToolUse hook only fires for the Bash tool — Read / Write /
 # Edit / web fetch / MCP tool calls do not trigger it (documented limitation).
 # So this hook can only block credential reads that happen through the shell
-# (e.g. `cat .workatoenv`, `grep token master.key`).
+# (e.g. `cat master.key`, `grep token settings.yaml`).
 #
 # The kit also ships `.codexignore` with the same patterns, but Codex
 # currently ignores that file (openai/codex#6530); this hook is the best

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -44,22 +44,42 @@ with open(os.environ["PATTERNS_FILE"]) as f:
             patterns.append(line)
 
 # Tools that legitimately operate ON credential files without dumping their
-# contents (workato CLI encrypts/edits/runs; git stages/commits). Never block
-# these. The kit helper script is matched by substring (its program is
-# `python3`, which we cannot allowlist wholesale).
-SAFE_PROGS = {"workato", "git"}
-SAFE_MARKERS = ("workato-api.py",)
+# contents: the workato CLI (no print-file mode), git for staging only, and the
+# kit helper script. This is an accident-guard, not a sandbox against a
+# deliberately hostile command. We close the cheap holes: the safe program is
+# the REAL program (the script behind python, not a -c payload), and git is
+# safe only for non-reading subcommands with no global options (so git -c,
+# git show, git diff, git cat-file are NOT allowlisted).
+SAFE_PROGS = {"workato", "workato-api.py"}
+SAFE_GIT_SUBCMDS = {"add", "rm", "mv", "status", "commit", "stash",
+                    "restore", "checkout", "switch", "reset"}
 
 def pat_re(p):
     body = re.escape(p).replace(r"\*", r"\S*")
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
-def segment_program(seg):
+def git_segment_safe(rest):
+    for t in rest:
+        if t.startswith("-"):
+            return False
+        return t in SAFE_GIT_SUBCMDS
+    return False
+
+def segment_safe(seg):
     toks = seg.split()
     i = 0
     while i < len(toks) and re.match(r"^\w+=", toks[i]):
         i += 1
-    return os.path.basename(toks[i]) if i < len(toks) else ""
+    if i >= len(toks):
+        return False
+    prog = os.path.basename(toks[i])
+    rest = toks[i + 1:]
+    if re.match(r"^python[0-9.]*$", prog) and rest:
+        prog = os.path.basename(rest[0])
+        rest = rest[1:]
+    if prog == "git":
+        return git_segment_safe(rest)
+    return prog in SAFE_PROGS
 
 # Block only when credential file contents would be dumped to the agent.
 sep = re.compile("|".join([r"\|\|", r"&&", r"[|;&\n]", r"\$\(", r"\)", re.escape(chr(96))]))
@@ -73,9 +93,7 @@ for seg in sep.split(cmd):
             break
     if not hit:
         continue
-    if any(m in seg for m in SAFE_MARKERS):
-        continue
-    if segment_program(seg) in SAFE_PROGS:
+    if segment_safe(seg):
         continue
     print(f"DENY:{hit}")
     sys.exit(0)

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -9,6 +9,12 @@
 # The kit also ships `.codexignore` with the same patterns, but Codex
 # currently ignores that file (openai/codex#6530); this hook is the best
 # enforcement available today.
+#
+# The embedded Python decides AND emits the message itself, then exits 2
+# (block) or 0 (allow). We deliberately do NOT capture via $(...): a quoted
+# heredoc inside command substitution makes bash scan the body for quote/paren
+# balance, so a stray ' " or ( in a comment breaks the script. Running the
+# heredoc directly avoids that.
 
 INPUT=$(cat)
 
@@ -19,19 +25,24 @@ if [ ! -f "$PATTERNS_FILE" ]; then
   exit 0   # fail open — without patterns we cannot decide.
 fi
 
-DECISION="$(INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
+INPUT="$INPUT" PATTERNS_FILE="$PATTERNS_FILE" python3 <<'PY'
 import json, os, re, sys
+
+def deny(pat):
+    sys.stderr.write(f"Blocked by workato-dev-kit credential guard: bash command references {pat}\n")
+    sys.stderr.write("  Credential files (see kit/framework/credential-patterns.txt) must not be\n")
+    sys.stderr.write("  read through the shell. Edit that file or temporarily remove this hook\n")
+    sys.stderr.write("  from .codex/hooks.json if this is intentional.\n")
+    sys.exit(2)
 
 raw = os.environ.get("INPUT", "")
 try:
     data = json.loads(raw)
 except Exception:
-    print("OK")
     sys.exit(0)
 
 # Codex PreToolUse fires only for Bash, but be defensive.
 if data.get("tool_name") != "Bash":
-    print("OK")
     sys.exit(0)
 
 cmd = (data.get("tool_input") or {}).get("command", "") or ""
@@ -43,14 +54,15 @@ with open(os.environ["PATTERNS_FILE"]) as f:
         if line and not line.startswith("#"):
             patterns.append(line)
 
-# Tools that legitimately operate ON credential files without dumping their
-# contents: the workato CLI (no print-file mode), git for staging only, and the
-# kit helper script. This is an accident-guard, not a sandbox against a
-# deliberately hostile command. We close the cheap holes: the safe program is
-# the REAL program (the script behind python, not a -c payload), and git is
-# safe only for non-reading subcommands with no global options (so git -c,
-# git show, git diff, git cat-file are NOT allowlisted).
-SAFE_PROGS = {"workato", "workato-api.py"}
+# Only the workato CLI (no print-file mode) and git used for staging are
+# allowlisted alongside a credential filename. The kit helper script is NOT
+# allowlisted: its normal commands never name a credential file, while its
+# sdk-decrypt subcommand prints plaintext to stdout and must stay blocked.
+# This is an accident-guard, not a sandbox: shell-function redefinition,
+# connector code that prints secrets, and dumps that do not name the file
+# are out of scope. git is safe only for non-reading subcommands with no
+# global options and no -p / --patch flag.
+SAFE_PROGS = {"workato"}
 SAFE_GIT_SUBCMDS = {"add", "rm", "mv", "status", "commit", "stash",
                     "restore", "checkout", "switch", "reset"}
 
@@ -59,11 +71,14 @@ def pat_re(p):
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
 def git_segment_safe(rest):
-    for t in rest:
-        if t.startswith("-"):
+    if not rest or rest[0].startswith("-"):
+        return False
+    if rest[0] not in SAFE_GIT_SUBCMDS:
+        return False
+    for t in rest[1:]:
+        if t in ("-p", "--patch") or t.startswith("--patch"):
             return False
-        return t in SAFE_GIT_SUBCMDS
-    return False
+    return True
 
 def segment_safe(seg):
     toks = seg.split()
@@ -73,12 +88,8 @@ def segment_safe(seg):
     if i >= len(toks):
         return False
     prog = os.path.basename(toks[i])
-    rest = toks[i + 1:]
-    if re.match(r"^python[0-9.]*$", prog) and rest:
-        prog = os.path.basename(rest[0])
-        rest = rest[1:]
     if prog == "git":
-        return git_segment_safe(rest)
+        return git_segment_safe(toks[i + 1:])
     return prog in SAFE_PROGS
 
 # Block only when credential file contents would be dumped to the agent.
@@ -95,23 +106,11 @@ for seg in sep.split(cmd):
         continue
     if segment_safe(seg):
         continue
-    print(f"DENY:{hit}")
-    sys.exit(0)
+    deny(hit)
 
-print("OK")
+sys.exit(0)
 PY
-)"
-
-case "$DECISION" in
-  DENY:*)
-    PAT="${DECISION#DENY:}"
-    echo "Blocked by workato-dev-kit credential guard: bash command references $PAT" >&2
-    echo "  Credential files (see kit/framework/credential-patterns.txt) must not be" >&2
-    echo "  read through the shell. Edit that file or temporarily remove this hook" >&2
-    echo "  from .codex/hooks.json if this is intentional." >&2
-    exit 2
-    ;;
-  *)
-    exit 0
-    ;;
-esac
+rc=$?
+# Only an explicit deny (exit 2) blocks; anything else falls through to allow.
+[ "$rc" -eq 2 ] && exit 2
+exit 0

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -43,11 +43,42 @@ with open(os.environ["PATTERNS_FILE"]) as f:
         if line and not line.startswith("#"):
             patterns.append(line)
 
-for pat in patterns:
-    body = re.escape(pat).replace(r"\*", r"\S*")
-    if re.search(rf"(?<!\w){body}(?!\w)", cmd):
-        print(f"DENY:{pat}")
-        sys.exit(0)
+# Tools that legitimately operate ON credential files without dumping their
+# contents (workato CLI encrypts/edits/runs; git stages/commits). Never block
+# these. The kit helper script is matched by substring (its program is
+# `python3`, which we cannot allowlist wholesale).
+SAFE_PROGS = {"workato", "git"}
+SAFE_MARKERS = ("workato-api.py",)
+
+def pat_re(p):
+    body = re.escape(p).replace(r"\*", r"\S*")
+    return re.compile(rf"(?<!\w){body}(?!\w)")
+
+def segment_program(seg):
+    toks = seg.split()
+    i = 0
+    while i < len(toks) and re.match(r"^\w+=", toks[i]):
+        i += 1
+    return os.path.basename(toks[i]) if i < len(toks) else ""
+
+# Block only when credential file contents would be dumped to the agent.
+sep = re.compile("|".join([r"\|\|", r"&&", r"[|;&\n]", r"\$\(", r"\)", re.escape(chr(96))]))
+for seg in sep.split(cmd):
+    if not seg.strip():
+        continue
+    hit = None
+    for pat in patterns:
+        if pat_re(pat).search(seg):
+            hit = pat
+            break
+    if not hit:
+        continue
+    if any(m in seg for m in SAFE_MARKERS):
+        continue
+    if segment_program(seg) in SAFE_PROGS:
+        continue
+    print(f"DENY:{hit}")
+    sys.exit(0)
 
 print("OK")
 PY

--- a/framework/codex/hooks/block-credential-read.sh
+++ b/framework/codex/hooks/block-credential-read.sh
@@ -71,13 +71,20 @@ def pat_re(p):
     return re.compile(rf"(?<!\w){body}(?!\w)")
 
 def git_segment_safe(rest):
+    # Safe only for a non-reading subcommand with no leading global option and
+    # no content-printing flag: -p/--patch (hunks) or -v/--verbose (e.g.
+    # `git status -v` emits the staged diff). Bundled short flags (-vp) caught.
     if not rest or rest[0].startswith("-"):
         return False
     if rest[0] not in SAFE_GIT_SUBCMDS:
         return False
     for t in rest[1:]:
-        if t in ("-p", "--patch") or t.startswith("--patch"):
-            return False
+        if t.startswith("--"):
+            if t.startswith("--patch") or t.startswith("--verbose"):
+                return False
+        elif t.startswith("-") and len(t) > 1:
+            if "p" in t[1:] or "v" in t[1:]:
+                return False
     return True
 
 def segment_safe(seg):

--- a/framework/credential-patterns.txt
+++ b/framework/credential-patterns.txt
@@ -12,8 +12,12 @@
 # Gitignore-style globs, one pattern per line. Blank lines and lines starting
 # with `#` are ignored.
 
-# Workato Platform CLI — contains API tokens
-.workatoenv
+# NOTE: .workatoenv is intentionally NOT listed here. It holds only project /
+# folder / workspace IDs (project_id, folder_id, workspace_id, project_name) —
+# no API tokens — and is git-managed so the project↔Workato binding is shared.
+# Skills and scripts/workato-api.py must be able to read it. Prod-push safety
+# comes from the deployment-flow profile check (profile must end in `-dev`), not
+# from hiding this file. Do not add .workatoenv here.
 
 # Connector SDK secrets
 master.key

--- a/framework/cursor/rules/workato-project.mdc
+++ b/framework/cursor/rules/workato-project.mdc
@@ -106,7 +106,8 @@ workato init --non-interactive --profile default --project-id <id> --folder-name
 - Platform features: `docs/platform/` (+ `org/docs/platform/`).
 - Record new findings under `org/docs/<relative-path>` (do not edit the kit's `docs/` directly).
 - `*.connection.json` never contains credentials.
-- Do not commit `.workatoenv` or `master.key`.
+- `.workatoenv` holds only project/folder/workspace IDs (no credentials) and **is** committed so the project↔Workato binding is shared. Keep it pointing at dev; prod-push safety comes from the deployment-flow profile check, not from hiding the file.
+- Do not commit `master.key` or other connector secrets (`settings.yaml`, `settings.yaml.enc`).
 
 ## Toolkit development rules
 

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -35,11 +35,11 @@ def run(hook: Path, payload: dict | str) -> subprocess.CompletedProcess:
 # Claude hook — paths
 # ---------------------------------------------------------------------------
 
-def test_claude_blocks_read_workatoenv():
+def test_claude_allows_read_workatoenv():
+    # .workatoenv is git-managed metadata (no credentials); skills must read it.
     r = run(CLAUDE_HOOK, {"tool_name": "Read",
                           "tool_input": {"file_path": "projects/foo/.workatoenv"}})
-    assert r.returncode == 2, r.stderr
-    assert ".workatoenv" in r.stderr
+    assert r.returncode == 0, r.stderr
 
 
 def test_claude_blocks_read_master_key():
@@ -128,10 +128,11 @@ def test_claude_allows_grep_on_clean_dir():
 # Claude hook — Bash
 # ---------------------------------------------------------------------------
 
-def test_claude_blocks_bash_cat_workatoenv():
+def test_claude_allows_bash_cat_workatoenv():
+    # .workatoenv is git-managed metadata (no credentials); reading it is fine.
     r = run(CLAUDE_HOOK, {"tool_name": "Bash",
                           "tool_input": {"command": "cat projects/foo/.workatoenv | head"}})
-    assert r.returncode == 2
+    assert r.returncode == 0, r.stderr
 
 
 def test_claude_blocks_bash_glob_token():
@@ -171,10 +172,11 @@ def test_codex_blocks_bash_grep_master_key():
     assert r.returncode == 2
 
 
-def test_codex_blocks_bash_cat_workatoenv():
+def test_codex_allows_bash_cat_workatoenv():
+    # .workatoenv is git-managed metadata (no credentials); reading it is fine.
     r = run(CODEX_HOOK, {"tool_name": "Bash",
                          "tool_input": {"command": "cat .workatoenv"}})
-    assert r.returncode == 2
+    assert r.returncode == 0, r.stderr
 
 
 def test_codex_allows_non_bash_read():

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -169,10 +169,31 @@ def test_claude_allows_git_add_enc():
     assert r.returncode == 0, r.stderr
 
 
-def test_claude_allows_helper_script_with_settings_arg():
+def test_claude_allows_helper_script_normal_command():
+    # The helper's normal commands name no credential file, so they pass.
     r = run(CLAUDE_HOOK, {"tool_name": "Bash",
-                          "tool_input": {"command": "python3 scripts/workato-api.py pull --settings settings.yaml.enc"}})
+                          "tool_input": {"command": "python3 scripts/workato-api.py profile show"}})
     assert r.returncode == 0, r.stderr
+
+
+def test_claude_blocks_helper_sdk_decrypt():
+    # `sdk decrypt` prints plaintext to stdout — the helper is NOT allowlisted.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "python3 scripts/workato-api.py sdk decrypt settings.yaml.enc --key master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_add_patch():
+    # `git add -p <file>` prints hunks of file contents.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git add -p connectors/x/settings.yaml"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_stash_show_patch_named():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git stash show -p connectors/x/master.key"}})
+    assert r.returncode == 2
 
 
 def test_claude_allows_output_dot_key_false_positive():
@@ -278,6 +299,18 @@ def test_codex_allows_git_add_enc():
     r = run(CODEX_HOOK, {"tool_name": "Bash",
                          "tool_input": {"command": "git add connectors/foo/settings.yaml.enc"}})
     assert r.returncode == 0, r.stderr
+
+
+def test_codex_blocks_helper_sdk_decrypt():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "python3 scripts/workato-api.py sdk decrypt settings.yaml.enc --key master.key"}})
+    assert r.returncode == 2
+
+
+def test_codex_blocks_git_add_patch():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "git add -p connectors/x/settings.yaml"}})
+    assert r.returncode == 2
 
 
 def test_codex_allows_malformed_json():

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -209,6 +209,26 @@ def test_claude_blocks_git_status_bundled_verbose_short_flag():
     assert r.returncode == 2
 
 
+def test_claude_blocks_git_verbose_abbreviation():
+    # git accepts `--ver` as an abbreviation of --verbose.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git status --ver -- connectors/x/master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_patch_abbreviation():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git add --patc connectors/x/settings.yaml"}})
+    assert r.returncode == 2
+
+
+def test_claude_allows_git_add_with_pathspec_separator():
+    # `--` is the pathspec separator, not a content-printing option.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git add -- connectors/x/settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
+
+
 def test_claude_allows_output_dot_key_false_positive():
     # `*.key` must not block a non-credential output file passed to a safe tool.
     r = run(CLAUDE_HOOK, {"tool_name": "Bash",

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -195,6 +195,39 @@ def test_claude_blocks_dump_in_chained_command():
     assert r.returncode == 2
 
 
+# The allowlist must not be defeatable by cheap tricks (Codex review).
+
+def test_claude_blocks_comment_spoof_helper_marker():
+    # A trailing comment naming the helper script must not allowlist a dump.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "cat master.key # workato-api.py"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_diff_no_index():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git --no-pager diff --no-index /dev/null master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_dash_c_alias():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git -c alias.x='!cat master.key' x"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_show_secret():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git show HEAD:connectors/x/settings.yaml"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_python_dash_c_dump():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "python3 -c \"print(open('master.key').read())\""}})
+    assert r.returncode == 2
+
+
 # ---------------------------------------------------------------------------
 # Claude hook — fail-open on malformed input
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -196,6 +196,19 @@ def test_claude_blocks_git_stash_show_patch_named():
     assert r.returncode == 2
 
 
+def test_claude_blocks_git_status_verbose():
+    # `git status -v` prints the staged diff (content) to stdout.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git status -v -- connectors/x/settings.yaml"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_git_status_bundled_verbose_short_flag():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git status -vv connectors/x/master.key"}})
+    assert r.returncode == 2
+
+
 def test_claude_allows_output_dot_key_false_positive():
     # `*.key` must not block a non-credential output file passed to a safe tool.
     r = run(CLAUDE_HOOK, {"tool_name": "Bash",

--- a/scripts/tests/test_block_credential_read.py
+++ b/scripts/tests/test_block_credential_read.py
@@ -153,6 +153,48 @@ def test_claude_allows_bash_no_creds():
     assert r.returncode == 0, r.stderr
 
 
+# Legitimate tools (workato CLI / git / kit helper) operate ON credential
+# files without dumping their contents, so they must not be blocked even when
+# a credential filename appears as an argument.
+
+def test_claude_allows_workato_edit_enc():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "workato edit settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_allows_git_add_enc():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git add connectors/foo/settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_allows_helper_script_with_settings_arg():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "python3 scripts/workato-api.py pull --settings settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_allows_output_dot_key_false_positive():
+    # `*.key` must not block a non-credential output file passed to a safe tool.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "workato generate schema --output=out.key"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_claude_blocks_bash_cat_master_key():
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "cat connectors/x/master.key"}})
+    assert r.returncode == 2
+
+
+def test_claude_blocks_dump_in_chained_command():
+    # A safe leading segment must not shield a later dump segment.
+    r = run(CLAUDE_HOOK, {"tool_name": "Bash",
+                          "tool_input": {"command": "git status && cat master.key"}})
+    assert r.returncode == 2
+
+
 # ---------------------------------------------------------------------------
 # Claude hook — fail-open on malformed input
 # ---------------------------------------------------------------------------
@@ -191,6 +233,18 @@ def test_codex_allows_bash_no_creds():
     r = run(CODEX_HOOK, {"tool_name": "Bash",
                          "tool_input": {"command": "git status"}})
     assert r.returncode == 0
+
+
+def test_codex_allows_workato_edit_enc():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "workato edit settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
+
+
+def test_codex_allows_git_add_enc():
+    r = run(CODEX_HOOK, {"tool_name": "Bash",
+                         "tool_input": {"command": "git add connectors/foo/settings.yaml.enc"}})
+    assert r.returncode == 0, r.stderr
 
 
 def test_codex_allows_malformed_json():

--- a/setup.sh
+++ b/setup.sh
@@ -307,7 +307,15 @@ if patterns_file and os.path.isfile(patterns_file):
                 deny.append(rule)
                 added_deny += 1
 
-if migrated or added_hook or added_deny:
+# Migrate: .workatoenv is no longer a credential. Older kit versions added a
+# deny rule for it; remove the stale entry so existing installs can read it.
+removed_deny = 0
+stale = 'Read(./**/.workatoenv)'
+while stale in deny:
+    deny.remove(stale)
+    removed_deny += 1
+
+if migrated or added_hook or added_deny or removed_deny:
     with open(user_settings, 'w') as f:
         json.dump(s, f, indent=2, ensure_ascii=False)
         f.write('\n')
@@ -318,6 +326,8 @@ if migrated or added_hook or added_deny:
         msgs.append('added block-credential-read PreToolUse hook')
     if added_deny:
         msgs.append(f'added {added_deny} credential deny rule(s)')
+    if removed_deny:
+        msgs.append('removed stale .workatoenv deny rule')
     print('  ✓ Updated .claude/settings.json (' + '; '.join(msgs) + ')')
 else:
     print('  EXISTS .claude/settings.json (kit entries already present)')
@@ -444,10 +454,18 @@ strip_workatoenv_ignore() {
   [ -f "$target" ] || return 0
   if grep -qxF ".workatoenv" "$target" 2>/dev/null; then
     # Portable in-place delete of lines that are exactly `.workatoenv`.
-    local tmp
+    # grep exits 1 when it selects no lines (i.e. the file was only
+    # `.workatoenv`); that is success here, so accept rc 0 and 1 and only
+    # bail on a real error (rc > 1), leaving the original untouched.
+    local tmp rc
     tmp="$(mktemp)"
-    grep -vxF ".workatoenv" "$target" > "$tmp" && mv "$tmp" "$target"
-    echo "  ✓ Removed stale .workatoenv entry from $(basename "$target") (now git-managed)"
+    grep -vxF ".workatoenv" "$target" > "$tmp"; rc=$?
+    if [ "$rc" -le 1 ]; then
+      mv "$tmp" "$target"
+      echo "  ✓ Removed stale .workatoenv entry from $(basename "$target") (now git-managed)"
+    else
+      rm -f "$tmp"
+    fi
   fi
 }
 strip_workatoenv_ignore "$GITIGNORE"

--- a/setup.sh
+++ b/setup.sh
@@ -358,7 +358,9 @@ touch "$GITIGNORE"
 
 ENTRIES=(
   "# Workato Dev Kit (managed by kit/setup.sh)"
-  ".workatoenv"
+  # NOTE: .workatoenv is intentionally NOT ignored — it holds only project /
+  # folder / workspace IDs (no credentials) and is committed so the
+  # project↔Workato binding is shared across the team.
   "master.key"
   "settings.yaml"
   "settings.yaml.enc"
@@ -431,6 +433,27 @@ if [ -f "$CRED_PATTERNS_FILE" ]; then
   add_credential_patterns "$WORKSPACE_ROOT/.geminiignore"  "$HEADER"
   add_credential_patterns "$WORKSPACE_ROOT/.codexignore"   "$HEADER"
 fi
+
+# ── 7c. Migrate: drop stale `.workatoenv` ignore entries ─────
+# Older kit versions treated .workatoenv as a credential and added it to the
+# gitignore / per-editor ignore files. It is now git-managed (no secrets), so
+# strip the exact `.workatoenv` line from each kit-managed ignore file on
+# re-run. Only the standalone entry is removed; user content is untouched.
+strip_workatoenv_ignore() {
+  local target="$1"
+  [ -f "$target" ] || return 0
+  if grep -qxF ".workatoenv" "$target" 2>/dev/null; then
+    # Portable in-place delete of lines that are exactly `.workatoenv`.
+    local tmp
+    tmp="$(mktemp)"
+    grep -vxF ".workatoenv" "$target" > "$tmp" && mv "$tmp" "$target"
+    echo "  ✓ Removed stale .workatoenv entry from $(basename "$target") (now git-managed)"
+  fi
+}
+strip_workatoenv_ignore "$GITIGNORE"
+strip_workatoenv_ignore "$WORKSPACE_ROOT/.cursorignore"
+strip_workatoenv_ignore "$WORKSPACE_ROOT/.geminiignore"
+strip_workatoenv_ignore "$WORKSPACE_ROOT/.codexignore"
 
 # ── 8. Cursor distribution (copy mode) ───────────────────────
 # framework/cursor/ is pre-generated on the kit side via

--- a/setup.sh
+++ b/setup.sh
@@ -308,12 +308,13 @@ if patterns_file and os.path.isfile(patterns_file):
                 added_deny += 1
 
 # Migrate: .workatoenv is no longer a credential. Older kit versions added a
-# deny rule for it; remove the stale entry so existing installs can read it.
-removed_deny = 0
-stale = 'Read(./**/.workatoenv)'
-while stale in deny:
-    deny.remove(stale)
-    removed_deny += 1
+# Read(...) deny rule for it; remove any such entry (covering legacy spellings
+# like Read(.workatoenv) / Read(./.workatoenv)) so existing installs can read
+# it. .workatoenv is not a credential, so dropping any deny rule naming it is
+# safe.
+before = len(deny)
+deny[:] = [r for r in deny if '.workatoenv' not in r]
+removed_deny = before - len(deny)
 
 if migrated or added_hook or added_deny or removed_deny:
     with open(user_settings, 'w') as f:

--- a/setup.sh
+++ b/setup.sh
@@ -252,6 +252,7 @@ else
     python3 <<'PY'
 import json
 import os
+import re
 
 user_settings = os.environ['USER_SETTINGS']
 kit_rel = os.environ['KIT_REL']
@@ -308,12 +309,12 @@ if patterns_file and os.path.isfile(patterns_file):
                 added_deny += 1
 
 # Migrate: .workatoenv is no longer a credential. Older kit versions added a
-# Read(...) deny rule for it; remove any such entry (covering legacy spellings
-# like Read(.workatoenv) / Read(./.workatoenv)) so existing installs can read
-# it. .workatoenv is not a credential, so dropping any deny rule naming it is
-# safe.
+# Read(...) deny rule for it; remove only the kit-generated spellings
+# (Read(.workatoenv), Read(./.workatoenv), Read(./**/.workatoenv)) so a
+# user-authored rule like Read(./**/.workatoenv.local) is preserved.
+stale_deny_re = re.compile(r'^Read\((?:\./)?(?:\*\*/)?\.workatoenv\)$')
 before = len(deny)
-deny[:] = [r for r in deny if '.workatoenv' not in r]
+deny[:] = [r for r in deny if not stale_deny_re.match(r)]
 removed_deny = before - len(deny)
 
 if migrated or added_hook or added_deny or removed_deny:


### PR DESCRIPTION
The credential guard was too aggressive and broke normal Workato development. This PR fixes that, and a 4-round Codex security review then hardened the relaxed allowlist against content-exfiltration.

## 1. `.workatoenv` was misclassified as a credential

`.workatoenv` contains **no secrets** — only `project_id` / `folder_id` / `workspace_id` / `project_name`. But it was treated as a credential everywhere, so the read hook **blocked the agent from reading it** (even though skills and `scripts/workato-api.py` are documented to read `folder_id`/`workspace_id` from it), and it was **gitignored**, so the project↔Workato binding couldn't be shared.

Prod-push safety actually comes from the **deployment-flow profile check** (resolved profile must end in `-dev`), not from hiding the file.

**Change:** drop `.workatoenv` from `credential-patterns.txt`, remove its `settings.json` deny rule, stop adding it to the user `.gitignore`, and add `setup.sh` migrations that strip the stale ignore entries and the stale `Read(./**/.workatoenv)` deny rule from existing installs (preserving user-authored rules like `Read(./**/.workatoenv.local)`). Docs/rules updated: it is committed and points at dev. `master.key`, `settings.yaml(.enc)` etc. remain blocked.

## 2. The bash scan blocked legitimate tools — then was hardened

Originally the hook blocked any command whose string contained a credential filename, breaking `workato edit settings.yaml.enc`, `git add …settings.yaml.enc`, and `workato generate --output=out.key` (a `*.key` false positive).

New model: split the command on shell separators; deny a segment that names a credential pattern **unless** its program is a known-safe tool. Codex review then closed every exfil path the relaxed allowlist opened:

| Command | Result |
|---|---|
| `workato edit settings.yaml.enc`, `git add …enc`, `git commit`, `git add -- …enc` | ✅ allowed |
| `python3 scripts/workato-api.py profile show` (helper, no secret named) | ✅ allowed |
| `cat master.key`, `grep token settings.yaml`, `head .env` | ❌ blocked |
| `cat master.key # workato-api.py` (comment spoof) | ❌ blocked |
| `git diff --no-index … master.key`, `git show …:secret`, `git -c alias='!cat …'` | ❌ blocked |
| `python3 -c "open('master.key')"`, `python3 …workato-api.py sdk decrypt …` | ❌ blocked |
| `git add -p`, `git status -v`, `git status --ver`, `git add --patc` (patch/verbose, incl. abbreviations & bundled short flags) | ❌ blocked |

`SAFE_PROGS = {"workato"}`; git is safe only for non-reading subcommands with no leading global option and no `-p`/`--patch`/`-v`/`--verbose` (incl. abbreviations). Path-based `Read`/`Edit`/`Write` blocking and `permissions.deny` are unchanged.

Both hooks were also refactored so the embedded Python is no longer wrapped in `$(… <<'PY' …)` — it emits the block message to stderr and exits 2/0 directly. This removes a fragility where a stray apostrophe/quote/paren in a comment broke bash's command-substitution parser.

**Out of scope** (documented in-code): shell-function redefinition, connector code that prints secrets, and dumps that never name the file. This is an accident-guard, not a sandbox.

## Verification

- **45/45** tests in `test_block_credential_read.py` pass (allowlist + every closed exfil path).
- 4 rounds of Codex security review; final verdict: *"The guard is good enough to ship."*
- `setup.sh` temp-workspace: strips stale `.workatoenv` ignore/deny entries (preserving user rules), keeps `master.key`, idempotent.
- `sync_agents.py` idempotent (CI sync-check passes).

## Migration for existing repos

Re-run `bash kit/setup.sh` (auto-removes the stale ignore/deny entries), then `git add .workatoenv` to start tracking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)